### PR TITLE
Refactor pagination to opaque cursor

### DIFF
--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -230,10 +230,13 @@ output_parts.append("]")  # End JSON array
 # Add pagination hints if available
 next_page_params = response_data.get("next_page_params")
 if next_page_params:
+    # Use the centralized helper to create an opaque cursor
+    from .common import encode_cursor
+    next_cursor = encode_cursor(next_page_params)
     pagination_hint = f"""
 
 ----
-To get the next page call tool_name({chain_id}, <args>, "{next_page_params.get("param")}")"""
+To get the next page call tool_name(chain_id="{chain_id}", <other_args>, cursor="{next_cursor}")"""
     output_parts.append(pagination_hint)
 
 return "".join(output_parts)
@@ -251,6 +254,61 @@ prefix = """
 This is some explanatory text that helps the user understand the data.
 """
 return f"{prefix}\n{content}"
+```
+
+### 6. Handling Pagination with Opaque Cursors (`return_type: str` or `list[dict]`)
+
+For tools that return paginated data, do not expose individual pagination parameters (like `page`, `offset`, `items_count`) in the tool's signature. Instead, use a single, opaque `cursor` string. This improves robustness and saves LLM context. The implementation involves both handling an incoming cursor and generating the next one.
+
+**A. Handling the Incoming Cursor:**
+Your tool should accept an optional `cursor` argument. If it's provided, use the `decode_cursor` helper to parse it and apply the parameters to your API call.
+
+**B. Generating the Outgoing Cursor:**
+In your response, check for `next_page_params` from the API. If they exist, use the `encode_cursor` helper to create the next cursor and include it in a user-friendly hint.
+
+**Complete Example Pattern:**
+
+```python
+from typing import Annotated, Optional
+from pydantic import Field
+from blockscout_mcp_server.tools.common import make_blockscout_request, get_blockscout_base_url, encode_cursor, decode_cursor, InvalidCursorError
+
+async def paginated_tool_name(
+    chain_id: Annotated[str, Field(description="The ID of the blockchain")],
+    address: Annotated[str, Field(description="The address to query")],
+    cursor: Annotated[Optional[str], Field(description="The pagination cursor from a previous response to get the next page of results.")] = None,
+    ctx: Context = None
+) -> str:
+    """
+    A tool that demonstrates the correct way to handle pagination.
+    """
+    api_path = f"/api/v2/some_paginated_endpoint/{address}"
+    query_params = {}
+
+    # 1. Handle incoming cursor
+    if cursor:
+        try:
+            decoded_params = decode_cursor(cursor)
+            query_params.update(decoded_params)
+        except InvalidCursorError:
+            return "Error: Invalid or expired pagination cursor. Please make a new request without the cursor to start over."
+
+    base_url = await get_blockscout_base_url(chain_id)
+    response_data = await make_blockscout_request(base_url=base_url, api_path=api_path, params=query_params)
+
+    output_string = process_items(response_data.get("items", []))
+
+    # 2. Generate outgoing cursor
+    next_page_params = response_data.get("next_page_params")
+    if next_page_params:
+        next_cursor = encode_cursor(next_page_params)
+        pagination_hint = f"""
+
+----
+To get the next page call paginated_tool_name(chain_id="{chain_id}", address="{address}", cursor="{next_cursor}")"""
+        output_string += pagination_hint
+
+    return output_string
 ```
 
 ## Registering the Tool

--- a/.cursor/rules/140-development-testing-workflow.mdc
+++ b/.cursor/rules/140-development-testing-workflow.mdc
@@ -55,33 +55,79 @@ async def test_some_tool_success(mock_ctx):  # Request the fixture as an argumen
 
 #### B. Asserting on JSON within Formatted Strings
 
-For tools that return a formatted string containing a JSON object (e.g., `get_address_logs`, `get_transaction_logs`), **DO NOT** parse the JSON from the final string result in your test. This is brittle.
+For tools that return a formatted string containing a JSON object (e.g., `get_address_logs`), **DO NOT** parse the JSON from the final string result in your test. This is brittle. Instead, **mock the serialization function (`json.dumps`)** to verify that the correct Python dictionary was passed to it *before* it was serialized.
 
-Instead, **mock `json.dumps`** to verify that the correct Python dictionary was passed to it *before* it was serialized into a string.
+However, the approach depends on the complexity of the tool.
+
+##### The Simple Case: One Serialization Call
+
+If the tool under test is the only function calling `json.dumps`, the approach is straightforward.
 
 **Correct Usage:**
+```python
+# In a test for a tool like get_transaction_logs
+from unittest.mock import patch, AsyncMock
+
+@pytest.mark.asyncio
+async def test_get_transaction_logs_correctly_prepares_json(mock_ctx):
+    # ... (Arrange mocks for API calls)
+    mock_api_response = {"items": [...]} 
+
+    # Patch json.dumps where it is used in the tool's module
+    with patch('blockscout_mcp_server.tools.transaction_tools.json.dumps') as mock_json_dumps:
+        mock_json_dumps.return_value = '{"fake_json": true}'  # Return value doesn't matter
+
+        # ACT
+        result = await get_transaction_logs(..., ctx=mock_ctx)
+
+        # ASSERT
+        # Verify that json.dumps was called with the raw, unprocessed API response
+        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+```
+
+##### The Complex Case: Multiple Serialization Calls
+
+A more complex situation arises when the tool under test (e.g., `get_address_logs`) calls `json.dumps` for its main body, but it *also* calls a helper function (e.g., `encode_cursor`) which has its own internal call to `json.dumps`. A simple patch on `json.dumps` would incorrectly capture both calls, causing the test to fail.
+
+The solution is to **mock both the low-level primitive (`json.dumps`) and the higher-level helper (`encode_cursor`)**. This isolates the test's focus, allowing you to verify each responsibility of the tool independently.
+
+**Correct Usage (Advanced):**
 ```python
 # In a test for a tool like get_address_logs
 from unittest.mock import patch, AsyncMock
 
 @pytest.mark.asyncio
-async def test_get_address_logs_correctly_prepares_json(mock_ctx):
-    # ... (Arrange mocks for API calls)
-    mock_api_response = {"items": [...]}
+async def test_get_address_logs_with_pagination(mock_ctx):
+    # ARRANGE
+    mock_api_response = {
+        "items": [...],
+        "next_page_params": {"block_number": 123, ...}
+    }
+    fake_cursor = "ENCODED_CURSOR_FROM_TEST"
+    fake_json_body = '{"fake_json_body": true}'
 
-    # Patch json.dumps where it is used in the tool's module
-    with patch('blockscout_mcp_server.tools.address_tools.json.dumps') as mock_json_dumps:
-        mock_json_dumps.return_value = '{"fake_json": true}' # Return value doesn't matter
+    # THE FIX: Patch both `json.dumps` AND the helper `encode_cursor`
+    with patch('blockscout_mcp_server.tools.address_tools.json.dumps') as mock_json_dumps, \
+         patch('blockscout_mcp_server.tools.address_tools.encode_cursor') as mock_encode_cursor:
+
+        # Configure both mocks
+        mock_json_dumps.return_value = fake_json_body
+        mock_encode_cursor.return_value = fake_cursor
 
         # ACT
         result = await get_address_logs(..., ctx=mock_ctx)
 
         # ASSERT
-        # Verify that json.dumps was called with the raw, unprocessed API response
+        # 1. Verify the call to `json.dumps` for the main body.
+        #    This works because the call from `encode_cursor` is prevented by its mock.
         mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
 
-        # You can still assert on other parts of the string result, like pagination hints
-        assert "To get the next page" in result
+        # 2. Verify the call to the helper function for the pagination part.
+        mock_encode_cursor.assert_called_once_with(mock_api_response["next_page_params"])
+
+        # 3. Verify the final string was assembled correctly from the outputs of both mocks.
+        assert fake_json_body in result
+        assert f'cursor="{fake_cursor}"' in result
 ```
 
 #### C. Handling Repetitive Data in Assertions (DAMP vs. DRY)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ mcp-server/
 │       ├── ens_tools.py        # Implements ENS-related tools
 │       ├── search_tools.py     # Implements search-related tools (e.g., lookup_token_by_symbol)
 │       ├── contract_tools.py   # Implements contract-related tools (e.g., get_contract_abi)
-│       ├── address_tools.py    # Implements address-related tools (e.g., get_address_info, get_tokens_by_address)
+│       ├── address_tools.py    # Implements address-related tools (e.g., get_address_info, get_tokens_by_address, get_address_logs)
 │       ├── block_tools.py      # Implements block-related tools (e.g., get_latest_block, get_block_info)
 │       ├── transaction_tools.py# Implements transaction-related tools (e.g., get_transactions_by_address, transaction_summary)
 │       └── chains_tools.py     # Implements chain-related tools (e.g., get_chains_list)
@@ -26,6 +26,7 @@ mcp-server/
 │   │   ├── __init__.py         # Marks integration as a sub-package
 │   │   └── test_common_helpers.py # Integration tests for API helper functions
 │   └── tools/                  # Unit test modules for each tool implementation
+│       ├── test_common.py            # Tests for shared utility functions
 │       ├── test_address_tools.py     # Tests for address-related tools (get_address_info, get_tokens_by_address)
 │       ├── test_address_tools_2.py   # Extended tests for complex address tools (nft_tokens_by_address, get_address_logs)
 │       ├── test_block_tools.py       # Tests for block-related tools (get_latest_block, get_block_info)
@@ -97,7 +98,7 @@ mcp-server/
 
 2. **`tests/` (Test Suite)**
     * This directory contains the complete test suite for the project, divided into two categories:
-    * **`tests/tools/`**: Contains the comprehensive **unit test** suite. All external API calls are mocked, allowing these tests to run quickly and offline.
+    * **`tests/tools/`**: Contains the comprehensive **unit test** suite. All external API calls are mocked, allowing these tests to run quickly and offline. It includes tests for each tool module and for shared utilities in `test_common.py`.
         * Each test file corresponds to a tool module and provides comprehensive test coverage:
             * **Success scenarios**: Testing normal operation with valid inputs and API responses.
             * **Error handling**: Testing API errors, chain lookup failures, timeout errors, and invalid responses.
@@ -145,6 +146,7 @@ mcp-server/
         * **`common.py`**:
             * Contains shared utility functions for all tool modules.
             * Implements chain resolution and caching mechanism with `get_blockscout_base_url` function.
+            * Implements helper functions (`encode_cursor`, `decode_cursor`) and a custom exception (`InvalidCursorError`) for handling opaque pagination cursors.
             * Contains asynchronous HTTP client functions for different API endpoints:
                 * `make_blockscout_request`: Takes base_url (resolved from chain_id), API path, and parameters for Blockscout API calls.
                 * `make_bens_request`: For BENS API calls.
@@ -177,6 +179,6 @@ mcp-server/
                 * `ens_tools.py`: Implements `get_address_by_ens_name` (fixed BENS endpoint, no chain_id).
                 * `search_tools.py`: Implements `lookup_token_by_symbol(chain_id, symbol)`.
                 * `contract_tools.py`: Implements `get_contract_abi(chain_id, address)`.
-                * `address_tools.py`: Implements `get_address_info(chain_id, address)`, `get_tokens_by_address(chain_id, address, ...)` with pagination.
+                * `address_tools.py`: Implements `get_address_info(chain_id, address)`, `get_tokens_by_address(chain_id, address, cursor=None)`, `get_address_logs(chain_id, address, cursor=None)` with robust, cursor-based pagination.
                 * `block_tools.py`: Implements `get_block_info(chain_id, number_or_hash)`, `get_latest_block(chain_id)`.
                 * `transaction_tools.py`: Implements `get_transactions_by_address(chain_id, address, ...)`, `transaction_summary(chain_id, hash)`, etc.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 4. `lookup_token_by_symbol(chain_id, symbol)` - Searches for token addresses by symbol or name, returning multiple potential matches.
 5. `get_contract_abi(chain_id, address)` - Retrieves the ABI (Application Binary Interface) for a smart contract.
 6. `get_address_info(chain_id, address)` - Gets comprehensive information about an address including balance, ENS association, contract status, and token details.
-7. `get_tokens_by_address(chain_id, address, ...)` - Returns detailed ERC20 token holdings for an address with enriched metadata and market data.
+7. `get_tokens_by_address(chain_id, address, cursor=None)` - Returns detailed ERC20 token holdings for an address with enriched metadata and market data.
 8. `get_latest_block(chain_id)` - Returns the latest indexed block number and timestamp.
 9. `get_transactions_by_address(chain_id, address, age_from, age_to, methods)` - Gets transactions for an address within a specific time range with optional method filtering.
 10. `get_token_transfers_by_address(chain_id, address, age_from, age_to, token)` - Returns ERC-20 token transfers for an address within a specific time range.
@@ -47,7 +47,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 13. `get_block_info(chain_id, number_or_hash)` - Returns block information including timestamp, gas used, burnt fees, and transaction count.
 14. `get_transaction_info(chain_id, hash)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
 15. `get_transaction_logs(chain_id, hash)` - Returns transaction logs with decoded event data.
-16. `get_address_logs(chain_id, address, ...)` - Gets logs emitted by a specific address with decoded event data.
+16. `get_address_logs(chain_id, address, cursor=None)` - Gets logs emitted by a specific address with decoded event data.
 
 ## Example Prompts for AI Agents (to be added)
 

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.1.0" 
+__version__ = "0.3.0"

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -3,7 +3,7 @@ Constants used throughout the Blockscout MCP Server.
 """
 
 SERVER_INSTRUCTIONS = """
-Blockscout MCP server version: 0.1.0
+Blockscout MCP server version: 0.3.0
 
 If you receive an error "500 Internal Server Error" for any tool, retry calling this tool up to 3 times until successful.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.1.0"
+version = "0.3.0"
 description = "MCP server for Blockscout"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.9.2",  # Or the latest version of the SDK
     "httpx>=0.27.0",

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -1,0 +1,34 @@
+import pytest
+from blockscout_mcp_server.tools.common import encode_cursor, decode_cursor, InvalidCursorError
+
+
+def test_encode_decode_roundtrip():
+    """Verify that encoding and then decoding returns the original data."""
+    params = {"block_number": 123, "index": 456, "items_count": 50}
+    encoded = encode_cursor(params)
+    decoded = decode_cursor(encoded)
+    assert decoded == params
+
+
+def test_encode_empty_dict():
+    """Verify encoding an empty dict returns an empty string."""
+    assert encode_cursor({}) == ""
+
+
+def test_decode_invalid_cursor():
+    """Verify decoding a malformed string raises the correct error."""
+    with pytest.raises(InvalidCursorError, match="Invalid or expired cursor provided."):
+        decode_cursor("this-is-not-valid-base64")
+
+
+def test_decode_empty_cursor():
+    """Verify decoding an empty string raises an error."""
+    with pytest.raises(InvalidCursorError, match="Cursor cannot be empty."):
+        decode_cursor("")
+
+
+def test_decode_valid_base64_invalid_json():
+    """Verify decoding valid base64 that isn't JSON raises an error."""
+    invalid_json_cursor = "bm90IGpzb24="  # base64 for 'not json'
+    with pytest.raises(InvalidCursorError, match="Invalid or expired cursor provided."):
+        decode_cursor(invalid_json_cursor)


### PR DESCRIPTION
## Summary
- add encode/decode cursor helpers
- refactor `get_tokens_by_address` and `get_address_logs` to use `cursor`
- update unit tests for new cursor behaviour and add invalid cursor tests
- bump server version to 0.3.0
- update developer guidelines and docs with new pagination pattern
- expand pagination guidelines and project overview
- fix pagination logs test mocking
- adjust pagination test to patch `encode_cursor` instead of `json.dumps`
- **clarify how to mock JSON serialization in complex cases**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68484f8fdeb8832890bf78f81be80f43