### PR TITLE
Add integration test scaffolding

### DIFF
--- a/.cursor/rules/140-development-testing-workflow.mdc
+++ b/.cursor/rules/140-development-testing-workflow.mdc
@@ -213,20 +213,34 @@ The test suite is designed to run in CI environments with:
 ---
 ## Guidelines for Writing Integration Tests
 
-While the unit test guidelines focus on mocking, integration tests require a different approach focused on stability and precision.
+While unit tests focus on logic with mocked data, integration tests verify our interaction with live external APIs. We have two distinct categories of integration tests, each with a specific purpose.
 
-#### 1. Test the Boundary, Not the Tool Logic
--   Integration tests should primarily target the helper functions in `tools/common.py` that make the actual network calls (`make_blockscout_request`, etc.).
--   Avoid re-testing the complex formatting logic of a full tool. If the helper function returns the correct data from the live API, we can trust the unit-tested tool to format it correctly.
+### Category 1: Helper-Level Integration Tests (Connectivity & Basic Contract)
 
-#### 2. Use Stable and Non-Volatile Targets
--   To ensure tests are reliable and deterministic, always test against stable data points that are unlikely to change.
--   **Good examples:** A famous historical block (`19000000` on Ethereum), a well-known ENS name (`vitalik.eth`), or a genesis block.
--   **Bad examples:** The *latest* block, a recent transaction, or a token with a fluctuating market cap.
+These tests target the low-level helper functions in `tools/common.py` (e.g., `make_blockscout_request`, `get_blockscout_base_url`).
 
-#### 3. Assert on Structure and Stable Values
--   When checking a response from a live API, prioritize asserting the *structure* of the data (e.g., `assert "timestamp" in response_data`) and the *type* of the data (`assert isinstance(response_data["height"], int)`).
--   Only assert on specific *values* when they are guaranteed to be stable, like the block number you requested or the known address for an ENS name.
+*   **Purpose:** To verify basic network connectivity and ensure the fundamental HTTP request/response cycle with each external service is working.
+*   **Location:** `tests/integration/test_common_helpers.py`.
+*   **What to Assert:**
+    *   The request was successful (no HTTP errors).
+    *   The top-level structure of the response is as expected (e.g., `isinstance(response, list)`).
+    *   Presence of a few key, stable fields to confirm we're hitting the right endpoint.
 
-#### 4. Always Use the `integration` Marker
--   Every integration test function **must** be decorated with `@pytest.mark.integration`. This is critical for separating the test suites and ensuring the default `pytest` run remains fast and offline.
+### Category 2: Tool-Level Integration Tests (Data Extraction & Schema Validation)
+
+These tests target the high-level MCP tool functions themselves (e.g., `get_latest_block`, `get_tokens_by_address`).
+
+*   **Purpose:** To validate the "contract" between our tool's data processing logic and the live API's response schema. They ensure that the fields our tools *extract and transform* are still present and correctly structured in the live data. This protects against breaking changes in the API schema.
+*   **Location:** `tests/integration/test_*_integration.py` (e.g., `test_block_tools_integration.py`).
+*   **What to Call:** The actual MCP tool function (e.g., `await get_latest_block(chain_id="1", ctx=mock_ctx)`).
+*   **What to Assert:**
+    *   Focus on the **final, processed result** returned by the tool.
+    *   Verify that the extracted data has the correct type and format (e.g., `assert isinstance(result["block_number"], int)`).
+    *   For lists, check that items in the list contain the expected processed fields (e.g., `assert "address" in item`).
+    *   For tools with string formatting (like pagination hints), assert that the key substrings are present in the final output.
+*   **What to Avoid:** Do not re-test complex formatting logic already covered by unit tests. The focus is on verifying the *data extraction* was successful.
+
+### General Rules for All Integration Tests
+
+*   **Use Stable Targets:** Always test against non-volatile data points (e.g., a famous historical block, a well-known ENS name).
+*   **Use the `integration` Marker:** Every integration test function **must** be decorated with `@pytest.mark.integration`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,14 @@ mcp-server/
 ├── tests/                      # Test suite for all MCP tools
 │   ├── integration/            # Integration tests that make real network calls
 │   │   ├── __init__.py         # Marks integration as a sub-package
-│   │   └── test_common_helpers.py # Integration tests for API helper functions
+│   │   ├── test_address_tools_integration.py   # Tool-level integration tests for address tools
+│   │   ├── test_block_tools_integration.py     # Tool-level integration tests for block tools
+│   │   ├── test_chains_tools_integration.py    # Tool-level integration tests for chains tools
+│   │   ├── test_common_helpers.py              # Helper-level integration tests for API helpers
+│   │   ├── test_contract_tools_integration.py  # Tool-level integration tests for contract tools
+│   │   ├── test_ens_tools_integration.py       # Tool-level integration tests for ENS tools
+│   │   ├── test_search_tools_integration.py    # Tool-level integration tests for search tools
+│   │   └── test_transaction_tools_integration.py # Tool-level integration tests for transaction tools
 │   └── tools/                  # Unit test modules for each tool implementation
 │       ├── test_common.py            # Tests for shared utility functions
 │       ├── test_address_tools.py     # Tests for address-related tools (get_address_info, get_tokens_by_address)
@@ -109,7 +116,10 @@ mcp-server/
         * All tests maintain full isolation using `unittest.mock.patch` to mock external API calls.
         * Test execution completes in under 1 second with 67 total test cases across 10 test modules.
         * Provides 100% coverage of all 16 MCP tool functions with multiple test scenarios each.
-    * **`tests/integration/`**: Contains the **integration test** suite. These tests make real network calls to live APIs to verify connectivity and API contracts. They are marked with `@pytest.mark.integration` and are excluded from the default test run.
+    * **`tests/integration/`**: Contains the **integration test** suite. These tests make real network calls and are divided into two categories:
+        * **Helper-level tests** in `test_common_helpers.py` verify basic connectivity and API availability.
+        * **Tool-level tests** in `test_*_integration.py` validate that our tools extract and structure data correctly from live responses.
+      All integration tests are marked with `@pytest.mark.integration` and are excluded from the default test run.
 
 3. **`blockscout_mcp_server/` (Main Python Package)**
     * **`__init__.py`**: Standard file to mark the directory as a Python package.

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -1,0 +1,51 @@
+import json
+import pytest
+
+from blockscout_mcp_server.tools.address_tools import (
+    nft_tokens_by_address,
+    get_tokens_by_address,
+    get_address_logs,
+)
+from tests.conftest import mock_ctx
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_nft_tokens_by_address_integration(mock_ctx):
+    address = "0xBd3531dA5CF5857e7CfAA92426877b022e612cf8"  # Pudgy Penguins contract
+    result = await nft_tokens_by_address(chain_id="1", address=address, ctx=mock_ctx)
+
+    assert isinstance(result, list) and len(result) > 0
+    first_collection = result[0]
+    assert "collection" in first_collection and "token_instances" in first_collection
+    assert "name" in first_collection["collection"]
+    assert "address" in first_collection["collection"]
+    if first_collection["token_instances"]:
+        assert "id" in first_collection["token_instances"][0]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_tokens_by_address_integration(mock_ctx):
+    address = "0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503"  # Binance wallet
+    result = await get_tokens_by_address(chain_id="1", address=address, ctx=mock_ctx)
+
+    assert isinstance(result, str)
+    assert "To get the next page call" in result
+    assert 'cursor="' in result
+
+    main_json = json.loads(result.split("----")[0])
+    assert isinstance(main_json, list) and len(main_json) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_address_logs_integration(mock_ctx):
+    address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"  # USDC contract
+    result = await get_address_logs(chain_id="1", address=address, ctx=mock_ctx)
+
+    assert isinstance(result, str)
+    assert "To get the next page call" in result
+    assert 'cursor="' in result
+    assert "**Items Structure:**" in result
+    assert "\"items\": [" in result

--- a/tests/integration/test_block_tools_integration.py
+++ b/tests/integration/test_block_tools_integration.py
@@ -1,0 +1,14 @@
+import pytest
+
+from blockscout_mcp_server.tools.block_tools import get_latest_block
+from tests.conftest import mock_ctx
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_latest_block_integration(mock_ctx):
+    result = await get_latest_block(chain_id="1", ctx=mock_ctx)
+
+    assert isinstance(result, dict)
+    assert "block_number" in result and isinstance(result["block_number"], int)
+    assert "timestamp" in result and isinstance(result["timestamp"], str)

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -1,0 +1,20 @@
+import pytest
+
+from blockscout_mcp_server.tools.chains_tools import get_chains_list
+from tests.conftest import mock_ctx
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_chains_list_integration(mock_ctx):
+    """Tests that get_chains_list returns a formatted string and contains known, stable chains."""
+    result = await get_chains_list(ctx=mock_ctx)
+
+    # Assert that the result is a string and not empty
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+    # Assert that the output contains a well-known, stable chain entry.
+    # This verifies that the name and chainid fields were correctly extracted and formatted.
+    assert "Ethereum: 1" in result
+    assert "Polygon PoS: 137" in result

--- a/tests/integration/test_common_helpers.py
+++ b/tests/integration/test_common_helpers.py
@@ -84,7 +84,7 @@ async def test_get_blockscout_base_url_for_known_chains(chain_id, expected_url):
     resolved_url = await get_blockscout_base_url(chain_id=chain_id)
 
     # ASSERT
-    assert resolved_url == expected_url
+    assert resolved_url.rstrip('/') == expected_url.rstrip('/')
 
 
 @pytest.mark.integration

--- a/tests/integration/test_contract_tools_integration.py
+++ b/tests/integration/test_contract_tools_integration.py
@@ -1,0 +1,16 @@
+import pytest
+
+from blockscout_mcp_server.tools.contract_tools import get_contract_abi
+from tests.conftest import mock_ctx
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_contract_abi_integration(mock_ctx):
+    # Use the WETH contract to ensure a rich, stable ABI is returned
+    address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    result = await get_contract_abi(chain_id="1", address=address, ctx=mock_ctx)
+
+    assert isinstance(result, dict)
+    assert "abi" in result and isinstance(result["abi"], list)
+    assert len(result["abi"]) > 0

--- a/tests/integration/test_ens_tools_integration.py
+++ b/tests/integration/test_ens_tools_integration.py
@@ -1,0 +1,14 @@
+import pytest
+
+from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
+from tests.conftest import mock_ctx
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_address_by_ens_name_integration(mock_ctx):
+    result = await get_address_by_ens_name(name="vitalik.eth", ctx=mock_ctx)
+
+    assert isinstance(result, dict)
+    assert "resolved_address" in result
+    assert result["resolved_address"].lower() == "0xd8da6bf26964af9d7eed9e03e53415d37aa96045".lower()

--- a/tests/integration/test_search_tools_integration.py
+++ b/tests/integration/test_search_tools_integration.py
@@ -1,0 +1,16 @@
+import pytest
+
+from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
+from tests.conftest import mock_ctx
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lookup_token_by_symbol_integration(mock_ctx):
+    result = await lookup_token_by_symbol(chain_id="1", symbol="USDC", ctx=mock_ctx)
+
+    assert isinstance(result, list) and len(result) > 0
+    first_item = result[0]
+    assert "address" in first_item and first_item["address"].startswith("0x")
+    assert "name" in first_item and isinstance(first_item["name"], str)
+    assert "symbol" in first_item and isinstance(first_item["symbol"], str)

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -1,0 +1,23 @@
+import pytest
+
+from blockscout_mcp_server.tools.transaction_tools import transaction_summary
+from tests.conftest import mock_ctx
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_transaction_summary_integration(mock_ctx):
+    """Tests transaction_summary against a stable, historical transaction to ensure
+    the 'summaries' field is correctly extracted from the 'data' object."""
+    # A stable, historical transaction (e.g., an early Uniswap V2 router transaction)
+    tx_hash = "0x5c7f2f244d91ec281c738393da0be6a38bc9045e29c0566da8c11e7a2f7cbc64"
+    result = await transaction_summary(chain_id="1", hash=tx_hash, ctx=mock_ctx)
+
+    # Assert that the result is a non-empty string
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+    # Assert that the tool's formatting prefix is present. This confirms
+    # that the tool successfully extracted the summary data and proceeded
+    # with formatting, rather than returning "No summary available."
+    assert "# Transaction Summary from Blockscout Transaction Interpreter" in result


### PR DESCRIPTION
## Summary
- document new tool-level integration tests in `AGENTS.md`
- clarify integration test categories in workflow docs
- expand helper integration tests to handle trailing slashes
- add empty integration test modules and first tool-level tests
- finish integration tests for chains and transactions

## Testing
- `pytest -m integration -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6848bb9235688323a3cc7b2d70ec0f9f