### PR TITLE
Make ctx parameter required in tool functions

### DIFF
--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -46,13 +46,13 @@ async def get_address_info(
 async def get_tokens_by_address(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     address: Annotated[str, Field(description="Wallet address")],
+    ctx: Context,
     cursor: Annotated[
         Optional[str],
         Field(
             description="The pagination cursor from a previous response to get the next page of results."
         ),
     ] = None,
-    ctx: Context = None,
 ) -> str:
     """
     Get comprehensive ERC20 token holdings for an address with enriched metadata and market data.
@@ -199,13 +199,13 @@ async def nft_tokens_by_address(
 async def get_address_logs(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     address: Annotated[str, Field(description="Account address")],
+    ctx: Context,
     cursor: Annotated[
         Optional[str],
         Field(
             description="The pagination cursor from a previous response to get the next page of results."
         ),
     ] = None,
-    ctx: Context = None,
 ) -> str:
     """
     Get comprehensive logs emitted by a specific address with decoded event data.

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -13,10 +13,10 @@ from mcp.server.fastmcp import Context
 async def get_transactions_by_address(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     address: Annotated[str, Field(description="Address which either sender or receiver of the transaction")],
+    ctx: Context,
     age_from: Annotated[Optional[str], Field(description="Start date and time (e.g 2025-05-22T23:00:00.00Z).")] = None,
     age_to: Annotated[Optional[str], Field(description="End date and time (e.g 2025-05-22T22:30:00.00Z).")] = None,
     methods: Annotated[Optional[str], Field(description="A method signature to filter transactions by (e.g 0x304e6ade)")] = None,
-    ctx: Context = None
 ) -> Dict:
     """
     Get transactions for an address within a specific time range.
@@ -81,10 +81,10 @@ async def get_transactions_by_address(
 async def get_token_transfers_by_address(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     address: Annotated[str, Field(description="Address which either transfer initiator or transfer receiver")],
+    ctx: Context,
     age_from: Annotated[Optional[str], Field(description="Start date and time (e.g 2025-05-22T23:00:00.00Z). This parameter should be provided in most cases to limit transfers and avoid heavy database queries. Omit only if you absolutely need the full history.")] = None,
     age_to: Annotated[Optional[str], Field(description="End date and time (e.g 2025-05-22T22:30:00.00Z). Can be omitted to get all transfers up to the current time.")] = None,
     token: Annotated[Optional[str], Field(description="An ERC-20 token contract address to filter transfers by a specific token. If omitted, returns transfers of all tokens.")] = None,
-    ctx: Context = None
 ) -> Dict:
     """
     Get ERC-20 token transfers for an address within a specific time range.


### PR DESCRIPTION
Closes #18 

## Summary
- make context arg mandatory for tools using ctx
- keep the argument order consistent

## Testing
- `pytest -q`
- `pytest -m integration -q`

------
https://chatgpt.com/codex/tasks/task_b_684a01069830832387b6ce9fb0875e17