### PR TITLE
Remove redundant mock_ctx import

### DIFF
--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -6,7 +6,6 @@ from blockscout_mcp_server.tools.address_tools import (
     get_tokens_by_address,
     get_address_logs,
 )
-from tests.conftest import mock_ctx
 
 
 @pytest.mark.integration

--- a/tests/integration/test_block_tools_integration.py
+++ b/tests/integration/test_block_tools_integration.py
@@ -1,7 +1,6 @@
 import pytest
 
 from blockscout_mcp_server.tools.block_tools import get_latest_block
-from tests.conftest import mock_ctx
 
 
 @pytest.mark.integration

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -1,7 +1,6 @@
 import pytest
 
 from blockscout_mcp_server.tools.chains_tools import get_chains_list
-from tests.conftest import mock_ctx
 
 
 @pytest.mark.integration

--- a/tests/integration/test_contract_tools_integration.py
+++ b/tests/integration/test_contract_tools_integration.py
@@ -1,7 +1,6 @@
 import pytest
 
 from blockscout_mcp_server.tools.contract_tools import get_contract_abi
-from tests.conftest import mock_ctx
 
 
 @pytest.mark.integration

--- a/tests/integration/test_ens_tools_integration.py
+++ b/tests/integration/test_ens_tools_integration.py
@@ -1,7 +1,6 @@
 import pytest
 
 from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
-from tests.conftest import mock_ctx
 
 
 @pytest.mark.integration

--- a/tests/integration/test_search_tools_integration.py
+++ b/tests/integration/test_search_tools_integration.py
@@ -1,7 +1,6 @@
 import pytest
 
 from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
-from tests.conftest import mock_ctx
 
 
 @pytest.mark.integration

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -1,7 +1,6 @@
 import pytest
 
 from blockscout_mcp_server.tools.transaction_tools import transaction_summary
-from tests.conftest import mock_ctx
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #20 

## Summary
- remove unused `mock_ctx` imports from integration tests

## Testing
- `pytest -m integration -q`

------
https://chatgpt.com/codex/tasks/task_b_684a074af15883238560147b88368155