### PR TITLE
Add pagination support for nft_tokens_by_address

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,6 @@ mcp-server/
                 * `ens_tools.py`: Implements `get_address_by_ens_name` (fixed BENS endpoint, no chain_id).
                 * `search_tools.py`: Implements `lookup_token_by_symbol(chain_id, symbol)`.
                 * `contract_tools.py`: Implements `get_contract_abi(chain_id, address)`.
-                * `address_tools.py`: Implements `get_address_info(chain_id, address)` (includes public tags), `get_tokens_by_address(chain_id, address, cursor=None)`, `get_address_logs(chain_id, address, cursor=None)` with robust, cursor-based pagination.
+                * `address_tools.py`: Implements `get_address_info(chain_id, address)` (includes public tags), `get_tokens_by_address(chain_id, address, cursor=None)`, `nft_tokens_by_address(chain_id, address, cursor=None)`, `get_address_logs(chain_id, address, cursor=None)` with robust, cursor-based pagination.
                 * `block_tools.py`: Implements `get_block_info(chain_id, number_or_hash)`, `get_latest_block(chain_id)`.
                 * `transaction_tools.py`: Implements `get_transactions_by_address(chain_id, address, ...)`, `transaction_summary(chain_id, hash)`, etc.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 9. `get_transactions_by_address(chain_id, address, age_from, age_to, methods)` - Gets transactions for an address within a specific time range with optional method filtering.
 10. `get_token_transfers_by_address(chain_id, address, age_from, age_to, token)` - Returns ERC-20 token transfers for an address within a specific time range.
 11. `transaction_summary(chain_id, hash)` - Provides human-readable transaction summaries using Blockscout Transaction Interpreter.
-12. `nft_tokens_by_address(chain_id, address)` - Retrieves NFT tokens owned by an address, grouped by collection.
+12. `nft_tokens_by_address(chain_id, address, cursor=None)` - Retrieves NFT tokens owned by an address, grouped by collection.
 13. `get_block_info(chain_id, number_or_hash)` - Returns block information including timestamp, gas used, burnt fees, and transaction count.
 14. `get_transaction_info(chain_id, hash)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
 15. `get_transaction_logs(chain_id, hash)` - Returns transaction logs with decoded event data.

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -12,16 +12,15 @@ from blockscout_mcp_server.tools.address_tools import (
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_nft_tokens_by_address_integration(mock_ctx):
-    address = "0xBd3531dA5CF5857e7CfAA92426877b022e612cf8"  # Pudgy Penguins contract
+    address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"  # Vitalik Buterin
     result = await nft_tokens_by_address(chain_id="1", address=address, ctx=mock_ctx)
 
-    assert isinstance(result, list) and len(result) > 0
-    first_collection = result[0]
-    assert "collection" in first_collection and "token_instances" in first_collection
-    assert "name" in first_collection["collection"]
-    assert "address" in first_collection["collection"]
-    if first_collection["token_instances"]:
-        assert "id" in first_collection["token_instances"][0]
+    assert isinstance(result, str)
+    assert "To get the next page call" in result
+    assert 'cursor="' in result
+
+    main_json = json.loads(result.split("----")[0])
+    assert isinstance(main_json, list) and len(main_json) > 0
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add cursor-based pagination to `nft_tokens_by_address`
- return JSON string with pagination hints
- extend unit tests with pagination and cursor checks
- update integration test to handle paginated output
- document new parameter in README and AGENTS

## Testing
- `pytest tests/tools/test_address_tools_2.py -v`
- `pytest -q`
- `pytest -m integration tests/integration/test_address_tools_integration.py -v`


------
https://chatgpt.com/codex/tasks/task_b_684b261164788323bd8e1faddd5a2711