### PR TITLE
Use compact JSON output

### DIFF
--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -217,11 +217,11 @@ Use for responses requiring significant text formatting, conditionals, or loops:
 items_data = response_data.get("items", [])
 output_parts = ["["]  # Start JSON array
 for i, item in enumerate(items_data):
-    item_str = f"""
-  {{
-    "field1": "{item.get("field1", "")}",
-    "field2": "{item.get("field2", "")}"
-  }}"""
+    item_dict = {
+        "field1": item.get("field1", ""),
+        "field2": item.get("field2", ""),
+    }
+    item_str = json.dumps(item_dict)
     output_parts.append(item_str)
     if i < len(items_data) - 1:
         output_parts.append(",")
@@ -248,13 +248,15 @@ Use when adding explanatory text to JSON output:
 
 ```python
 import json
-content = json.dumps(response_data, indent=2)  # Pretty-print JSON
+content = json.dumps(response_data)  # Compact JSON
 prefix = """
 # Explanatory Title
 This is some explanatory text that helps the user understand the data.
 """
 return f"{prefix}\n{content}"
 ```
+
+**Note:** We use compact JSON (without indentation) to minimize the data payload size. The output is consumed by machines, not humans, so readability of the raw JSON string is not a priority.
 
 ### 6. Handling Pagination with Opaque Cursors (`return_type: str` or `list[dict]`)
 

--- a/.cursor/rules/210-unit-testing-guidelines.mdc
+++ b/.cursor/rules/210-unit-testing-guidelines.mdc
@@ -61,7 +61,7 @@ async def test_get_transaction_logs_correctly_prepares_json(mock_ctx):
 
         # ASSERT
         # Verify that json.dumps was called with the raw, unprocessed API response
-        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+        mock_json_dumps.assert_called_once_with(mock_api_response)
 ```
 
 #### The Complex Case: Multiple Serialization Calls
@@ -99,7 +99,7 @@ async def test_get_address_logs_with_pagination(mock_ctx):
         # ASSERT
         # 1. Verify the call to `json.dumps` for the main body.
         #    This works because the call from `encode_cursor` is prevented by its mock.
-        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+        mock_json_dumps.assert_called_once_with(mock_api_response)
 
         # 2. Verify the call to the helper function for the pagination part.
         mock_encode_cursor.assert_called_once_with(mock_api_response["next_page_params"])

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -48,7 +48,7 @@ async def get_address_info(
         return f"Error fetching basic address info: {address_info_result}"
 
     output_parts.append("Basic address info:")
-    output_parts.append(json.dumps(address_info_result, indent=2))
+    output_parts.append(json.dumps(address_info_result))
     await ctx.report_progress(progress=2.0, total=3.0, message="Fetched basic address info.")
 
     if not isinstance(metadata_result, Exception) and metadata_result.get("addresses"):
@@ -62,7 +62,7 @@ async def get_address_info(
             address_metadata = metadata_result["addresses"][address_key]
             if address_metadata:
                 output_parts.append("\nMetadata associated with the address:")
-                output_parts.append(json.dumps(address_metadata, indent=2))
+                output_parts.append(json.dumps(address_metadata))
 
     await ctx.report_progress(progress=3.0, total=3.0, message="Successfully fetched all address data.")
 
@@ -233,7 +233,7 @@ async def nft_tokens_by_address(
             "token_instances": token_instances
         }
 
-        item_str = json.dumps(collection_data, indent=2)
+        item_str = json.dumps(collection_data)
         output_parts.append(item_str)
         if i < len(items_data) - 1:
             output_parts.append(",")
@@ -295,7 +295,7 @@ async def get_address_logs(
     # Report completion
     await ctx.report_progress(progress=2.0, total=2.0, message="Successfully fetched address logs.")
     
-    logs_json_str = json.dumps(response_data, indent=2)  # Pretty print JSON
+    logs_json_str = json.dumps(response_data)  # Compact JSON
     
     prefix = """**Items Structure:**
 - `address`: The queried address that emitted these logs (constant across all items)

--- a/blockscout_mcp_server/tools/block_tools.py
+++ b/blockscout_mcp_server/tools/block_tools.py
@@ -31,7 +31,7 @@ async def get_block_info(
             api_path=f"/api/v2/blocks/{number_or_hash}"
         )
         await ctx.report_progress(progress=2.0, total=total_steps, message="Successfully fetched block data.")
-        return f"Basic block info:\n{json.dumps(response_data, indent=2)}"
+        return f"Basic block info:\n{json.dumps(response_data)}"
 
     # If include_transactions is True
     block_api_path = f"/api/v2/blocks/{number_or_hash}"
@@ -54,7 +54,7 @@ async def get_block_info(
         return f"Error fetching basic block info: {block_info_result}"
 
     output_parts.append("Basic block info:")
-    output_parts.append(json.dumps(block_info_result, indent=2))
+    output_parts.append(json.dumps(block_info_result))
 
     # Second, handle the result of the transactions call.
     if isinstance(txs_result, Exception):
@@ -66,7 +66,7 @@ async def get_block_info(
             # We only need the 'hash' from each transaction object.
             tx_hashes = [tx.get("hash") for tx in tx_items if tx.get("hash")]
             output_parts.append("\n\nTransactions in the block:")
-            output_parts.append(json.dumps(tx_hashes, indent=2))
+            output_parts.append(json.dumps(tx_hashes))
         else:
             # Handle the case where the block has no transactions.
             output_parts.append("\n\nNo transactions in the block.")

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -233,7 +233,7 @@ async def get_transaction_logs(
     # Report completion
     await ctx.report_progress(progress=2.0, total=2.0, message="Successfully fetched transaction logs.")
     
-    logs_json_str = json.dumps(response_data, indent=2)  # Pretty print JSON
+    logs_json_str = json.dumps(response_data)  # Compact JSON
     
     prefix = """**Items Structure:**
 - `address`: The queried address that emitted these logs (constant across all items)

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -59,7 +59,10 @@ async def test_get_address_info_integration(mock_ctx):
 
     assert isinstance(result_str, str)
 
-    parts = result_str.split("\n\n")
+    metadata_prefix = "\nMetadata associated with the address:\n"
+    assert metadata_prefix in result_str
+
+    parts = result_str.split(metadata_prefix)
     assert len(parts) == 2, "Expected output to contain both a basic info and a metadata part"
 
     assert parts[0].startswith("Basic address info:")
@@ -68,8 +71,7 @@ async def test_get_address_info_integration(mock_ctx):
     assert basic_info["hash"].lower() == address.lower()
     assert basic_info["is_contract"] is True
 
-    assert parts[1].startswith("Metadata associated with the address:")
-    metadata_json_str = parts[1].replace("Metadata associated with the address:\n", "")
+    metadata_json_str = parts[1]
     metadata = json.loads(metadata_json_str)
     assert "tags" in metadata
     assert len(metadata["tags"]) > 0

--- a/tests/integration/test_block_tools_integration.py
+++ b/tests/integration/test_block_tools_integration.py
@@ -45,13 +45,15 @@ async def test_get_block_info_with_transactions_integration(mock_ctx):
     assert "Basic block info:" in result
     assert "Transactions in the block:" in result
 
-    parts = result.split("\n\n")
-    assert len(parts) >= 2
+    tx_prefix = "\n\nTransactions in the block:\n"
+    assert tx_prefix in result
+    parts = result.split(tx_prefix)
+    assert len(parts) == 2
 
     block_info_json_str = parts[0].replace("Basic block info:\n", "")
     block_info_json = json.loads(block_info_json_str)
 
-    tx_list_json_str = parts[1].replace("Transactions in the block:\n", "")
+    tx_list_json_str = parts[1]
     tx_list_json = json.loads(tx_list_json_str)
 
     assert block_info_json["height"] == 1000000
@@ -74,7 +76,9 @@ async def test_get_block_info_with_no_transactions_integration(mock_ctx):
     assert "No transactions in the block." in result
     assert "Transactions in the block:" not in result
 
-    block_info_json_str = result.split("\n\n")[0].replace("Basic block info:\n", "")
+    no_tx_prefix = "\n\nNo transactions in the block."
+    assert no_tx_prefix in result
+    block_info_json_str = result.split(no_tx_prefix)[0].replace("Basic block info:\n", "")
     block_info_json = json.loads(block_info_json_str)
 
     assert block_info_json["height"] == 100

--- a/tests/tools/test_address_tools.py
+++ b/tests/tools/test_address_tools.py
@@ -407,9 +407,9 @@ async def test_get_address_info_success_with_metadata(mock_ctx):
         )
 
         assert "Basic address info:" in result
-        assert json.dumps(mock_blockscout_response, indent=2) in result
+        assert json.dumps(mock_blockscout_response) in result
         assert "Metadata associated with the address:" in result
-        assert json.dumps(mock_metadata_response["addresses"][address], indent=2) in result
+        assert json.dumps(mock_metadata_response["addresses"][address]) in result
 
         assert mock_ctx.report_progress.call_count == 4
 
@@ -437,7 +437,7 @@ async def test_get_address_info_success_without_metadata(mock_ctx):
         result = await get_address_info(chain_id=chain_id, address=address, ctx=mock_ctx)
 
         assert "Basic address info:" in result
-        assert json.dumps(mock_blockscout_response, indent=2) in result
+        assert json.dumps(mock_blockscout_response) in result
         assert "Metadata associated with the address:" not in result
 
         assert mock_ctx.report_progress.call_count == 4

--- a/tests/tools/test_address_tools_2.py
+++ b/tests/tools/test_address_tools_2.py
@@ -475,7 +475,7 @@ async def test_get_address_logs_with_pagination(mock_ctx):
 
         result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
 
-        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+        mock_json_dumps.assert_called_once_with(mock_api_response)
         mock_encode_cursor.assert_called_once_with(mock_api_response["next_page_params"])
 
         assert result.startswith("**Items Structure:**")
@@ -605,7 +605,7 @@ async def test_get_address_logs_empty_logs(mock_ctx):
 
         # ASSERT
         # Assert that json.dumps was called with the exact API response data
-        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+        mock_json_dumps.assert_called_once_with(mock_api_response)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(

--- a/tests/tools/test_block_tools.py
+++ b/tests/tools/test_block_tools.py
@@ -156,7 +156,7 @@ async def test_get_block_info_success(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/blocks/{number_or_hash}")
-        expected_output = f"Basic block info:\n{json.dumps(mock_api_response, indent=2)}"
+        expected_output = f"Basic block info:\n{json.dumps(mock_api_response)}"
         assert result == expected_output
         assert mock_ctx.report_progress.call_count == 3
 
@@ -188,7 +188,7 @@ async def test_get_block_info_with_hash(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/blocks/{block_hash}")
-        expected_output = f"Basic block info:\n{json.dumps(mock_api_response, indent=2)}"
+        expected_output = f"Basic block info:\n{json.dumps(mock_api_response)}"
         assert result == expected_output
         assert mock_ctx.report_progress.call_count == 3
 
@@ -255,9 +255,9 @@ async def test_get_block_info_with_transactions_success(mock_ctx):
         assert mock_request.call_count == 2
 
         assert "Basic block info:" in result
-        assert json.dumps(mock_block_response, indent=2) in result
+        assert json.dumps(mock_block_response) in result
         assert "Transactions in the block:" in result
-        assert json.dumps(["0xtx1", "0xtx2"], indent=2) in result
+        assert json.dumps(["0xtx1", "0xtx2"]) in result
         assert "No transactions in the block." not in result
         assert mock_ctx.report_progress.call_count == 4
 
@@ -292,7 +292,7 @@ async def test_get_block_info_with_no_transactions(mock_ctx):
 
         # ASSERT
         assert "Basic block info:" in result
-        assert json.dumps(mock_block_response, indent=2) in result
+        assert json.dumps(mock_block_response) in result
         assert "No transactions in the block." in result
         assert "Transactions in the block:" not in result
         assert mock_ctx.report_progress.call_count == 4
@@ -327,6 +327,6 @@ async def test_get_block_info_with_transactions_api_error(mock_ctx):
 
         # ASSERT
         assert "Basic block info:" in result
-        assert json.dumps(mock_block_response, indent=2) in result
+        assert json.dumps(mock_block_response) in result
         assert "Error fetching transactions for the block:" in result
         assert str(tx_error) in result

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -180,7 +180,7 @@ async def test_get_transaction_logs_success(mock_ctx):
 
         # ASSERT
         # Assert that json.dumps was called with the exact API response data
-        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+        mock_json_dumps.assert_called_once_with(mock_api_response)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
@@ -221,7 +221,7 @@ async def test_get_transaction_logs_empty_logs(mock_ctx):
 
         # ASSERT
         # Assert that json.dumps was called with the exact API response data
-        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+        mock_json_dumps.assert_called_once_with(mock_api_response)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
@@ -308,7 +308,7 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
 
         # ASSERT
         # Assert that json.dumps was called with the exact API response data
-        mock_json_dumps.assert_called_once_with(mock_api_response, indent=2)
+        mock_json_dumps.assert_called_once_with(mock_api_response)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(


### PR DESCRIPTION
Closes #28 

## Summary
- return compact JSON in block tools, transaction tools, and address tools
- adjust tests for compact JSON
- revise integration test parsing
- update guidelines for compact JSON usage
- make block tools integration tests more robust

## Testing
- `pytest -q`
- `pytest -m integration tests/integration/test_block_tools_integration.py -q`
- `pytest -m integration -q`


------
https://chatgpt.com/codex/tasks/task_b_684b35b523508323be4013cc2173b612