### PR TITLE
Add option to omit raw input in transaction info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ mcp-server/
 │       ├── contract_tools.py   # Implements contract-related tools (e.g., get_contract_abi)
 │       ├── address_tools.py    # Implements address-related tools (e.g., get_address_info, get_tokens_by_address, get_address_logs)
 │       ├── block_tools.py      # Implements block-related tools (e.g., get_latest_block, get_block_info)
-│       ├── transaction_tools.py# Implements transaction-related tools (e.g., get_transactions_by_address, transaction_summary)
+│       ├── transaction_tools.py# Implements transaction-related tools (e.g., get_transactions_by_address, get_transaction_info)
 │       └── chains_tools.py     # Implements chain-related tools (e.g., get_chains_list)
 ├── tests/                      # Test suite for all MCP tools
 │   ├── integration/            # Integration tests that make real network calls
@@ -188,4 +188,4 @@ mcp-server/
                 * `contract_tools.py`: Implements `get_contract_abi(chain_id, address)`.
                 * `address_tools.py`: Implements `get_address_info(chain_id, address)` (includes public tags), `get_tokens_by_address(chain_id, address, cursor=None)`, `nft_tokens_by_address(chain_id, address, cursor=None)`, `get_address_logs(chain_id, address, cursor=None)` with robust, cursor-based pagination.
                 * `block_tools.py`: Implements `get_block_info(chain_id, number_or_hash, include_transactions=False)`, `get_latest_block(chain_id)`.
-                * `transaction_tools.py`: Implements `get_transactions_by_address(chain_id, address, ...)`, `transaction_summary(chain_id, hash)`, etc.
+                * `transaction_tools.py`: Implements `get_transactions_by_address(chain_id, address, ...)`, `get_transaction_info(chain_id, hash, include_raw_input=False)`, etc.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 11. `transaction_summary(chain_id, hash)` - Provides human-readable transaction summaries using Blockscout Transaction Interpreter.
 12. `nft_tokens_by_address(chain_id, address, cursor=None)` - Retrieves NFT tokens owned by an address, grouped by collection.
 13. `get_block_info(chain_id, number_or_hash, include_transactions=False)` - Returns block information including timestamp, gas used, burnt fees, and transaction count. Can optionally include a list of transaction hashes.
-14. `get_transaction_info(chain_id, hash)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
+14. `get_transaction_info(chain_id, hash, include_raw_input=False)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
 15. `get_transaction_logs(chain_id, hash)` - Returns transaction logs with decoded event data.
 16. `get_address_logs(chain_id, address, cursor=None)` - Gets logs emitted by a specific address with decoded event data.
 

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -185,7 +185,7 @@ async def get_transaction_info(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     hash: Annotated[str, Field(description="Transaction hash")],
     ctx: Context,
-    include_raw_input: Annotated[Optional[bool], Field(description="If true, includes the raw transaction input data. Use only if you specifically need the raw hex data, as it can be very large.")] = False
+    include_raw_input: Annotated[Optional[bool], Field(description="If true, includes the raw transaction input data.")] = False
 ) -> Dict:
     """
     Get comprehensive transaction information. 

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -184,11 +184,13 @@ async def transaction_summary(
 async def get_transaction_info(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     hash: Annotated[str, Field(description="Transaction hash")],
-    ctx: Context
+    ctx: Context,
+    include_raw_input: Annotated[Optional[bool], Field(description="If true, includes the raw transaction input data. Use only if you specifically need the raw hex data, as it can be very large.")] = False
 ) -> Dict:
     """
     Get comprehensive transaction information. 
     Unlike standard eth_getTransactionByHash, this tool returns enriched data including decoded input parameters, detailed token transfers with token metadata, address information (ENS names, contract verification status, public tags, proxy details), transaction fee breakdown (priority fees, burnt fees) and categorized transaction types. 
+    By default, the raw transaction input is omitted if a decoded version is available to save context; request it with `include_raw_input=True` only when you truly need the raw hex data.
     Essential for transaction analysis, debugging smart contract interactions, tracking DeFi operations.
     """
     api_path = f"/api/v2/transactions/{hash}"
@@ -202,10 +204,14 @@ async def get_transaction_info(
     await report_and_log_progress(ctx, progress=1.0, total=2.0, message="Resolved Blockscout instance URL. Fetching transaction data...")
     
     response_data = await make_blockscout_request(base_url=base_url, api_path=api_path)
-    
+
     # Report completion
     await report_and_log_progress(ctx, progress=2.0, total=2.0, message="Successfully fetched transaction data.")
-    
+
+    # Conditionally remove raw_input to save context if decoded_input is present
+    if not include_raw_input and response_data.get("decoded_input"):
+        response_data.pop("raw_input", None)
+
     return response_data
 
 async def get_transaction_logs(

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -1,7 +1,7 @@
 import pytest
 
 import json
-from blockscout_mcp_server.tools.transaction_tools import transaction_summary, get_transaction_logs
+from blockscout_mcp_server.tools.transaction_tools import transaction_summary, get_transaction_logs, get_transaction_info
 
 
 @pytest.mark.integration
@@ -49,3 +49,37 @@ async def test_get_transaction_logs_integration(mock_ctx):
     assert "transaction_hash" not in first_log
     assert "block_hash" not in first_log
 
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_transaction_info_integration(mock_ctx):
+    """Tests that get_transaction_info returns full data and omits raw_input by default."""
+    # This is a stable transaction with a known decoded input (a swap).
+    tx_hash = "0xd4df84bf9e45af2aa8310f74a2577a28b420c59f2e3da02c52b6d39dc83ef10f"
+    result = await get_transaction_info(chain_id="1", hash=tx_hash, ctx=mock_ctx)
+
+    # Assert that the main data is present
+    assert isinstance(result, dict)
+    assert result["hash"].lower() == tx_hash.lower()
+    assert result["status"] == "ok"
+    assert "decoded_input" in result and result["decoded_input"] is not None
+
+    # Assert that the raw_input is NOT present by default
+    assert "raw_input" not in result
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_transaction_info_integration_no_decoded_input(mock_ctx):
+    """Tests that get_transaction_info keeps raw_input by default when decoded_input is null."""
+    # This is a stable contract creation transaction, which has no decoded_input.
+    tx_hash = "0x12341be874149efc8c714f4ef431db0ce29f64532e5c70d3882257705e2b1ad2"
+    result = await get_transaction_info(chain_id="1", hash=tx_hash, ctx=mock_ctx)
+
+    # Assert that the main data is present
+    assert isinstance(result, dict)
+    assert result["hash"].lower() == tx_hash.lower()
+    assert result["decoded_input"] is None
+
+    # Assert that the raw_input IS present because decoded_input was null
+    assert "raw_input" in result
+    assert isinstance(result["raw_input"], str) and len(result["raw_input"]) > 2


### PR DESCRIPTION
## Summary
- improve `get_transaction_info` to optionally drop raw transaction input
- test the new behaviour and document how to use it
- ensure integration test covers the new return contract
- verify raw input is retained when decoded data is missing

Closes #36

------
https://chatgpt.com/codex/tasks/task_b_684c73d693b08323a3ca2a1c3f49feee