### PR TITLE
Refactor `get_address_logs` output

### DIFF
--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -293,8 +293,7 @@ async def get_address_logs(
 ) -> str:
     """
     Get comprehensive logs emitted by a specific address with decoded event data.
-    Returns enriched log entries including decoded event parameters with types and values, detailed contract information (ENS names, verification status, public tags, proxy details, token metadata), block context, transaction hashes, and event signatures.
-    Each log entry includes raw data, decoded event names, parameter extraction with indexed/non-indexed classification, and contract classifications.
+    Returns a lean JSON response containing only essential log data: block number, transaction hash, log index, topics, and decoded event parameters.
     Essential for analyzing smart contract events emitted by specific addresses, monitoring token contract activities, tracking DeFi protocol state changes, debugging contract event emissions, and understanding address-specific event history flows.
     """
     api_path = f"/api/v2/addresses/{address}/logs"
@@ -325,30 +324,47 @@ async def get_address_logs(
     )
     
     response_data = await make_blockscout_request(base_url=base_url, api_path=api_path, params=params)
-    
+
     # Report completion
     await report_and_log_progress(
         ctx, progress=2.0, total=2.0,
         message="Successfully fetched address logs."
     )
-    
-    logs_json_str = json.dumps(response_data)  # Compact JSON
+
+    original_items = response_data.get("items", [])
+
+    transformed_items = [
+        {
+            "block_number": item.get("block_number"),
+            "data": item.get("data"),
+            "decoded": item.get("decoded"),
+            "index": item.get("index"),
+            "topics": item.get("topics"),
+            "transaction_hash": item.get("transaction_hash"),
+        }
+        for item in original_items
+    ]
+
+    # Create a dictionary containing ONLY the transformed items.
+    transformed_response = {
+        "items": transformed_items,
+    }
+
+    logs_json_str = json.dumps(transformed_response)  # Compact JSON
     
     prefix = """**Items Structure:**
-- `address`: The queried address that emitted these logs (constant across all items)
-- `smart_contract`: The actual contract that generated the specific log event (varies per item)
-- `block_hash/block_number`: Block where the event was emitted
-- `transaction_hash`: Transaction that triggered the event
-- `index`: Log position within the block
-- `topics`: Raw indexed event parameters (first topic is event signature hash)
-- `data`: Raw non-indexed event parameters (hex encoded)
+    - `block_number`: Block where the event was emitted
+    - `transaction_hash`: Transaction that triggered the event
+    - `index`: Log position within the block
+    - `topics`: Raw indexed event parameters (first topic is event signature hash)
+    - `data`: Raw non-indexed event parameters (hex encoded)
 
-**Event Decoding (misleadingly named fields):**
+**Event Decoding (in `decoded` field):**
 - `method_call`: **Actually the event signature** (e.g., "Transfer(address indexed from, address indexed to, uint256 value)")
 - `method_id`: **Actually the event signature hash** (first 4 bytes of keccak256 hash)
 - `parameters`: Decoded event parameters with names, types, values, and indexing status
 
-**Address logs JSON:**
+**Address logs JSON (from queried address):**
 """
     
     output = f"{prefix}{logs_json_str}"

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -292,8 +292,8 @@ async def get_address_logs(
     ] = None,
 ) -> str:
     """
-    Get comprehensive logs emitted by a specific address with decoded event data.
-    Returns a lean JSON response containing only essential log data: block number, transaction hash, log index, topics, and decoded event parameters.
+    Get comprehensive logs emitted by a specific address.
+    Returns enriched logs, primarily focusing on decoded event parameters with their types and values (if event decoding is applicable).
     Essential for analyzing smart contract events emitted by specific addresses, monitoring token contract activities, tracking DeFi protocol state changes, debugging contract event emissions, and understanding address-specific event history flows.
     """
     api_path = f"/api/v2/addresses/{address}/logs"
@@ -359,12 +359,12 @@ async def get_address_logs(
     - `topics`: Raw indexed event parameters (first topic is event signature hash)
     - `data`: Raw non-indexed event parameters (hex encoded)
 
-**Event Decoding (in `decoded` field):**
+**Event Decoding in `decoded` field:**
 - `method_call`: **Actually the event signature** (e.g., "Transfer(address indexed from, address indexed to, uint256 value)")
 - `method_id`: **Actually the event signature hash** (first 4 bytes of keccak256 hash)
 - `parameters`: Decoded event parameters with names, types, values, and indexing status
 
-**Address logs JSON (from queried address):**
+**Address logs JSON:**
 """
     
     output = f"{prefix}{logs_json_str}"

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -266,7 +266,6 @@ async def get_transaction_logs(
             "data": item.get("data"),
             "decoded": item.get("decoded"),
             "index": item.get("index"),
-            "smart_contract": item.get("smart_contract"),
             "topics": item.get("topics"),
         }
         for item in original_items

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -46,8 +46,30 @@ async def test_get_address_logs_integration(mock_ctx):
     assert isinstance(result, str)
     assert "To get the next page call" in result
     assert 'cursor="' in result
-    assert "**Items Structure:**" in result
-    assert "\"items\": [" in result
+    assert "**Address logs JSON (from queried address):**" in result
+
+    json_part = result.split("----")[0]
+    data = json.loads(json_part.split("**Address logs JSON (from queried address):**\n")[-1])
+
+    assert "items" in data
+    assert isinstance(data["items"], list)
+    assert len(data["items"]) > 0
+
+    first_log = data["items"][0]
+    expected_keys = {
+        "block_number",
+        "data",
+        "decoded",
+        "index",
+        "topics",
+        "transaction_hash",
+    }
+    assert set(first_log.keys()) == expected_keys
+    assert isinstance(first_log["transaction_hash"], str)
+    assert first_log["transaction_hash"].startswith("0x")
+    assert isinstance(first_log["block_number"], int)
+    assert isinstance(first_log["index"], int)
+    assert isinstance(first_log["topics"], list)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -46,10 +46,10 @@ async def test_get_address_logs_integration(mock_ctx):
     assert isinstance(result, str)
     assert "To get the next page call" in result
     assert 'cursor="' in result
-    assert "**Address logs JSON (from queried address):**" in result
+    assert "**Address logs JSON:**" in result
 
     json_part = result.split("----")[0]
-    data = json.loads(json_part.split("**Address logs JSON (from queried address):**\n")[-1])
+    data = json.loads(json_part.split("**Address logs JSON:**\n")[-1])
 
     assert "items" in data
     assert isinstance(data["items"], list)

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -50,7 +50,7 @@ async def test_get_transaction_logs_integration(mock_ctx):
 
     # 3. Validate the schema of the first transformed log item.
     first_log = data["items"][0]
-    expected_keys = {"address", "block_number", "data", "decoded", "index", "smart_contract", "topics"}
+    expected_keys = {"address", "block_number", "data", "decoded", "index", "topics"}
     assert set(first_log.keys()) == expected_keys
 
     # 4. Validate the data types of key fields.

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -158,7 +158,6 @@ async def test_get_transaction_logs_success(mock_ctx):
                 "block_number": 19000000,
                 "block_hash": "0xblockhash1...",
                 "decoded": {"name": "EventA"},
-                "smart_contract": None,
                 "index": 0,
             },
             {
@@ -170,7 +169,6 @@ async def test_get_transaction_logs_success(mock_ctx):
                 "block_number": 19000000,
                 "block_hash": "0xblockhash2...",
                 "decoded": {"name": "EventB"},
-                "smart_contract": None,
                 "index": 1,
             }
         ],
@@ -184,7 +182,6 @@ async def test_get_transaction_logs_success(mock_ctx):
                 "data": "0xdata123...",
                 "decoded": {"name": "EventA"},
                 "index": 0,
-                "smart_contract": None,
                 "topics": ["0xtopic1...", "0xtopic2..."],
             },
             {
@@ -193,7 +190,6 @@ async def test_get_transaction_logs_success(mock_ctx):
                 "data": "0xdata456...",
                 "decoded": {"name": "EventB"},
                 "index": 1,
-                "smart_contract": None,
                 "topics": ["0xtopic3..."],
             },
         ],
@@ -410,7 +406,6 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
                 "transaction_index": 10,
                 "removed": False,
                 "decoded": {"name": "Transfer"},
-                "smart_contract": None,
                 "index": 42,
             }
         ],
@@ -424,7 +419,6 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
                 "data": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
                 "decoded": {"name": "Transfer"},
                 "index": 42,
-                "smart_contract": None,
                 "topics": [
                     "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
                     "0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
@@ -483,7 +477,6 @@ async def test_get_transaction_logs_with_pagination(mock_ctx):
                 "transaction_hash": hash,
                 "block_number": 1,
                 "decoded": None,
-                "smart_contract": None,
                 "index": 0,
             }
         ],
@@ -498,7 +491,6 @@ async def test_get_transaction_logs_with_pagination(mock_ctx):
                 "data": "0x",
                 "decoded": None,
                 "index": 0,
-                "smart_contract": None,
                 "topics": [],
             }
         ],


### PR DESCRIPTION
## Summary
- simplify transaction logs by removing `smart_contract`
- transform address logs to a leaner schema and document new format
- update corresponding unit and integration tests
- drop contract address from each address log item for clarity
- validate data types in address logs integration test

Closes #41

------
https://chatgpt.com/codex/tasks/task_b_684cadd10650832396ac1d251365143c