### PR TITLE
Implement log data truncation

### DIFF
--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -455,3 +455,40 @@ return "\n".join(output_parts)
 
 **Key Points:**
 - Always use `return_exceptions=True`
+
+#### 8. Truncating Large Data Fields to Save Context (`return_type: str`)
+
+**Rationale:** Some API fields, like the `data` field in transaction logs, can be extremely large and consume excessive LLM context. To handle this, we truncate the data and explicitly flag the truncation to the agent, guiding it on how to retrieve the full data if needed.
+
+**Implementation Pattern:**
+This pattern uses a shared helper to centralize the truncation logic and conditionally adds an instructional note to the output.
+
+```python
+from .common import _process_and_truncate_log_items # Fictional helper for this example
+
+async def tool_with_large_data_fields(chain_id: str, hash: str, ctx: Context) -> str:
+    # 1. Get raw response from API
+    base_url = await get_blockscout_base_url(chain_id)
+    raw_response = await make_blockscout_request(...)
+
+    # 2. Use the helper to process items and check for truncation
+    processed_items, was_truncated = _process_and_truncate_log_items(
+        raw_response.get("items", [])
+    )
+
+    # 3. Prepare the main JSON body
+    output_json = json.dumps({"items": processed_items})
+    output_string = f"**Some Data:**\n{output_json}"
+
+    # 4. Conditionally add the instructional note
+    if was_truncated:
+        note = f"""
+----
+**Note on Truncated Data:**
+Some data was truncated. To get the full data, use:
+`curl "{base_url}/api/v2/some_endpoint/{hash}"`
+"""
+        output_string += note
+
+    return output_string
+```

--- a/.cursor/rules/220-integration-testing-guidelines.mdc
+++ b/.cursor/rules/220-integration-testing-guidelines.mdc
@@ -153,6 +153,35 @@ async def test_with_retry_logic():
     assert result is not None
 ```
 
+### Avoid Hardcoding Environment-Specific URLs
+
+When asserting on output that contains a URL resolved by the server, **DO NOT** hardcode the URL in your test. The server dynamically resolves URLs (e.g., using `get_blockscout_base_url`), and these resolved values can change.
+
+Instead, the test itself should call the same helper to get the expected URL and use that variable in the assertion. This makes the test resilient to changes in the underlying service infrastructure.
+
+**Incorrect (Brittle):**
+```python
+@pytest.mark.integration
+async def test_tool_with_hardcoded_url(mock_ctx):
+    result = await some_tool_that_generates_a_url(chain_id="1", ...)
+    
+    # This will break if the resolved URL for chain 1 changes.
+    assert "https://eth.blockscout.com/some/path" in result
+```
+
+**Correct (Robust):**
+```python
+from blockscout_mcp_server.tools.common import get_blockscout_base_url
+
+@pytest.mark.integration
+async def test_tool_with_dynamic_url(mock_ctx):
+    base_url = await get_blockscout_base_url("1")
+    result = await some_tool_that_generates_a_url(chain_id="1", ...)
+    
+    # This test is resilient to changes in the resolved URL.
+    assert f"{base_url}/some/path" in result
+```
+
 ## File Size Limitations
 
 **Integration test files must not exceed 500 LOC.** If a file approaches this limit, split tests into multiple focused files (e.g., `test_block_tools_integration_1.py`, `test_block_tools_integration_2.py`) to maintain readability and logical organization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ mcp-server/
 │   ├── constants.py            # Centralized constants used throughout the application
 │   └── tools/                  # Sub-package for tool implementations
 │       ├── __init__.py         # Initializes the tools sub-package
-│       ├── common.py           # Shared utilities for tools (e.g., HTTP client, chain resolution, progress reporting)
+│       ├── common.py           # Shared utilities for tools (e.g., HTTP client, chain resolution, progress reporting, data processing helpers)
 │       ├── get_instructions.py # Implements the __get_instructions__ tool
 │       ├── ens_tools.py        # Implements ENS-related tools
 │       ├── search_tools.py     # Implements search-related tools (e.g., lookup_token_by_symbol)

--- a/SPEC.md
+++ b/SPEC.md
@@ -148,6 +148,16 @@ sequenceDiagram
        To get the next page call get_address_logs(..., cursor="eyJibG9ja19udW1iZXIiOjE4OTk5OTk5LCJpbmRleCI6NDIsIml0ZW1zX2NvdW50Ijo1MH0")
        ```
 
+    c) Log Data Field Truncation
+
+    To prevent LLM context overflow from excessively large `data` fields in transaction logs, the server implements a smart truncation strategy.
+
+    - **Mechanism**: If a log's `data` field exceeds a predefined limit (512 bytes), it is truncated.
+    - **Flagging**: A new boolean field, `data_truncated: true`, is added to the log item to explicitly signal that the data has been shortened.
+    - **Guidance**: When truncation occurs, a note is added to the tool's output. This note explains the flag and provides a `curl` command template, guiding the agent on how to programmatically fetch the complete, untruncated data if required for deeper analysis.
+
+    This approach maintains a small context footprint by default while providing a reliable "escape hatch" for high-fidelity data retrieval when necessary.
+
 3. **Instructions Delivery Workaround**:
    - Although the MCP specification defines an `instructions` field in the initialization response (per [MCP lifecycle](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#initialization)), current MCP Host implementations (e.g., Claude Desktop) do not reliably use these instructions
    - The `__get_instructions__` tool serves as a workaround for this limitation

--- a/SPEC.md
+++ b/SPEC.md
@@ -152,7 +152,7 @@ sequenceDiagram
 
     To prevent LLM context overflow from excessively large `data` fields in transaction logs, the server implements a smart truncation strategy.
 
-    - **Mechanism**: If a log's `data` field exceeds a predefined limit (512 bytes), it is truncated.
+    - **Mechanism**: If a log's `data` field (a hex string) exceeds a predefined limit of 1026 characters (representing 512 bytes of data plus the '0x' prefix), it is truncated.
     - **Flagging**: A new boolean field, `data_truncated: true`, is added to the log item to explicitly signal that the data has been shortened.
     - **Guidance**: When truncation occurs, a note is added to the tool's output. This note explains the flag and provides a `curl` command template, guiding the agent on how to programmatically fetch the complete, untruncated data if required for deeper analysis.
 

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -24,3 +24,7 @@ All Blockscout API tools require a chain_id parameter:
 """
 
 SERVER_NAME = "blockscout-mcp-server"
+
+# The maximum length for a log's `data` field before it's truncated.
+# 1026 = '0x' prefix + 1024 hex characters (512 bytes).
+LOG_DATA_TRUNCATION_LIMIT = 1026

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -337,8 +337,9 @@ async def get_address_logs(
         response_data.get("items", [])
     )
 
-    transformed_items = [
-        {
+    transformed_items = []
+    for item in original_items:
+        new_item = {
             "block_number": item.get("block_number"),
             "data": item.get("data"),
             "decoded": item.get("decoded"),
@@ -346,8 +347,9 @@ async def get_address_logs(
             "topics": item.get("topics"),
             "transaction_hash": item.get("transaction_hash"),
         }
-        for item in original_items
-    ]
+        if item.get("data_truncated"):
+            new_item["data_truncated"] = True
+        transformed_items.append(new_item)
 
     # Create a dictionary containing ONLY the transformed items.
     transformed_response = {

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -297,7 +297,7 @@ async def get_address_logs(
     """
     Get comprehensive logs emitted by a specific address.
     Returns enriched logs, primarily focusing on decoded event parameters with their types and values (if event decoding is applicable).
-    Essential for analyzing smart contract events emitted by specific addresses, monitoring token contract activities, tracking DeFi protocol state changes, debugging contract event emissions, and understanding address-specific event history flows. The `data` field may be truncated if it is excessively large.
+    Essential for analyzing smart contract events emitted by specific addresses, monitoring token contract activities, tracking DeFi protocol state changes, debugging contract event emissions, and understanding address-specific event history flows.
     """
     api_path = f"/api/v2/addresses/{address}/logs"
     params = {}

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -390,8 +390,8 @@ To get the next page call get_address_logs(chain_id="{chain_id}", address="{addr
 ----
 **Note on Truncated Data:**
 One or more log items in this response had a `data` field that was too large and has been truncated (indicated by `"data_truncated": true`).
-If the full log data is crucial for your analysis, you can retrieve the complete, untruncated logs for this address programmatically. For example, using curl:
-`curl "{base_url}/api/v2/addresses/{address}/logs"`
+If the full log data is crucial for your analysis, you must first get the `transaction_hash` from the specific log item in the JSON response above. Then, you can retrieve all logs for that single transaction programmatically. For example, using curl:
+`curl "{base_url}/api/v2/transactions/{{THE_TRANSACTION_HASH}}/logs"`
 You would then need to parse the JSON response and find the specific log by its index.
 """
         output += note_on_truncation

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -310,6 +310,24 @@ def decode_cursor(cursor: str) -> dict:
         raise InvalidCursorError("Invalid or expired cursor provided.") from e
 
 
+from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
+
+
+def _process_and_truncate_log_items(items: list) -> tuple[list, bool]:
+    """Processes log items, truncating the 'data' field if it exceeds a limit."""
+    processed_items = []
+    was_truncated = False
+    for item in items:
+        item_copy = item.copy()
+        data = item_copy.get("data")
+        if data and len(data) > LOG_DATA_TRUNCATION_LIMIT:
+            item_copy["data"] = data[:LOG_DATA_TRUNCATION_LIMIT]
+            item_copy["data_truncated"] = True
+            was_truncated = True
+        processed_items.append(item_copy)
+    return processed_items, was_truncated
+
+
 async def report_and_log_progress(
     ctx: Context,
     progress: float,

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -5,6 +5,7 @@ import base64
 import anyio
 from typing import Optional, Callable, Awaitable, Any, Dict
 from blockscout_mcp_server.config import config
+from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
 from mcp.server.fastmcp import Context
 
 class ChainNotFoundError(ValueError):
@@ -308,9 +309,6 @@ def decode_cursor(cursor: str) -> dict:
         return json.loads(json_string)
     except (TypeError, ValueError, json.JSONDecodeError, base64.binascii.Error) as e:
         raise InvalidCursorError("Invalid or expired cursor provided.") from e
-
-
-from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
 
 
 def _process_and_truncate_log_items(items: list) -> tuple[list, bool]:

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -318,7 +318,7 @@ def _process_and_truncate_log_items(items: list) -> tuple[list, bool]:
     for item in items:
         item_copy = item.copy()
         data = item_copy.get("data")
-        if data and len(data) > LOG_DATA_TRUNCATION_LIMIT:
+        if isinstance(data, str) and len(data) > LOG_DATA_TRUNCATION_LIMIT:
             item_copy["data"] = data[:LOG_DATA_TRUNCATION_LIMIT]
             item_copy["data_truncated"] = True
             was_truncated = True

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -194,7 +194,7 @@ async def get_token_transfers_by_address(
 
 async def transaction_summary(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
-    hash: Annotated[str, Field(description="Transaction hash")],
+    transaction_hash: Annotated[str, Field(description="Transaction hash")],
     ctx: Context
 ) -> str:
     """
@@ -203,10 +203,10 @@ async def transaction_summary(
     Essential for rapid transaction comprehension, dashboard displays, and initial analysis.
     Note: Not all transactions can be summarized and accuracy is not guaranteed for complex patterns.
     """
-    api_path = f"/api/v2/transactions/{hash}/summary"
+    api_path = f"/api/v2/transactions/{transaction_hash}/summary"
 
     # Report start of operation
-    await report_and_log_progress(ctx, progress=0.0, total=2.0, message=f"Starting to fetch transaction summary for {hash} on chain {chain_id}...")
+    await report_and_log_progress(ctx, progress=0.0, total=2.0, message=f"Starting to fetch transaction summary for {transaction_hash} on chain {chain_id}...")
 
     base_url = await get_blockscout_base_url(chain_id)
     
@@ -226,7 +226,7 @@ async def transaction_summary(
 
 async def get_transaction_info(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
-    hash: Annotated[str, Field(description="Transaction hash")],
+    transaction_hash: Annotated[str, Field(description="Transaction hash")],
     ctx: Context,
     include_raw_input: Annotated[Optional[bool], Field(description="If true, includes the raw transaction input data.")] = False
 ) -> Dict:
@@ -236,10 +236,10 @@ async def get_transaction_info(
     By default, the raw transaction input is omitted if a decoded version is available to save context; request it with `include_raw_input=True` only when you truly need the raw hex data.
     Essential for transaction analysis, debugging smart contract interactions, tracking DeFi operations.
     """
-    api_path = f"/api/v2/transactions/{hash}"
+    api_path = f"/api/v2/transactions/{transaction_hash}"
     
     # Report start of operation
-    await report_and_log_progress(ctx, progress=0.0, total=2.0, message=f"Starting to fetch transaction info for {hash} on chain {chain_id}...")
+    await report_and_log_progress(ctx, progress=0.0, total=2.0, message=f"Starting to fetch transaction info for {transaction_hash} on chain {chain_id}...")
     
     base_url = await get_blockscout_base_url(chain_id)
     
@@ -262,7 +262,7 @@ async def get_transaction_info(
 
 async def get_transaction_logs(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
-    hash: Annotated[str, Field(description="Transaction hash")],
+    transaction_hash: Annotated[str, Field(description="Transaction hash")],
     ctx: Context,
     cursor: Annotated[
         Optional[str],
@@ -276,7 +276,7 @@ async def get_transaction_logs(
     Unlike standard eth_getLogs, this tool returns enriched logs, primarily focusing on decoded event parameters with their types and values (if event decoding is applicable).
     Essential for analyzing smart contract events, tracking token transfers, monitoring DeFi protocol interactions, debugging event emissions, and understanding complex multi-contract transaction flows. The `data` field may be truncated if it is excessively large.
     """
-    api_path = f"/api/v2/transactions/{hash}/logs"
+    api_path = f"/api/v2/transactions/{transaction_hash}/logs"
     params = {}
 
     if cursor:
@@ -289,7 +289,7 @@ async def get_transaction_logs(
             )
     
     # Report start of operation
-    await report_and_log_progress(ctx, progress=0.0, total=2.0, message=f"Starting to fetch transaction logs for {hash} on chain {chain_id}...")
+    await report_and_log_progress(ctx, progress=0.0, total=2.0, message=f"Starting to fetch transaction logs for {transaction_hash} on chain {chain_id}...")
     
     base_url = await get_blockscout_base_url(chain_id)
     
@@ -352,7 +352,7 @@ async def get_transaction_logs(
         pagination_hint = f"""
 
 ----
-To get the next page call get_transaction_logs(chain_id=\"{chain_id}\", hash=\"{hash}\", cursor=\"{next_cursor}\")"""
+To get the next page call get_transaction_logs(chain_id=\"{chain_id}\", transaction_hash=\"{transaction_hash}\", cursor=\"{next_cursor}\")"""
         output += pagination_hint
 
     # Add a note about truncated data if it happened
@@ -362,7 +362,7 @@ To get the next page call get_transaction_logs(chain_id=\"{chain_id}\", hash=\"{
 **Note on Truncated Data:**
 One or more log items in this response had a `data` field that was too large and has been truncated (indicated by `"data_truncated": true`).
 If the full log data is crucial for your analysis, you can retrieve the complete, untruncated logs for this transaction programmatically. For example, using curl:
-`curl "{base_url}/api/v2/transactions/{hash}/logs"`
+`curl "{base_url}/api/v2/transactions/{transaction_hash}/logs"`
 You would then need to parse the JSON response and find the specific log by its index.
 """
         output += note_on_truncation

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -310,7 +310,7 @@ async def get_transaction_logs(
     """
     Get comprehensive transaction logs.
     Unlike standard eth_getLogs, this tool returns enriched logs, primarily focusing on decoded event parameters with their types and values (if event decoding is applicable).
-    Essential for analyzing smart contract events, tracking token transfers, monitoring DeFi protocol interactions, debugging event emissions, and understanding complex multi-contract transaction flows. The `data` field may be truncated if it is excessively large.
+    Essential for analyzing smart contract events, tracking token transfers, monitoring DeFi protocol interactions, debugging event emissions, and understanding complex multi-contract transaction flows.
     """
     api_path = f"/api/v2/transactions/{transaction_hash}/logs"
     params = {}

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -304,8 +304,9 @@ async def get_transaction_logs(
         response_data.get("items", [])
     )
 
-    transformed_items = [
-        {
+    transformed_items = []
+    for item in original_items:
+        new_item = {
             "address": item.get("address", {}).get("hash"),
             "block_number": item.get("block_number"),
             "data": item.get("data"),
@@ -313,8 +314,9 @@ async def get_transaction_logs(
             "index": item.get("index"),
             "topics": item.get("topics"),
         }
-        for item in original_items
-    ]
+        if item.get("data_truncated"):
+            new_item["data_truncated"] = True
+        transformed_items.append(new_item)
 
     transformed_response = {
         "items": transformed_items,

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -75,6 +75,8 @@ async def test_get_address_logs_integration(mock_ctx):
     assert isinstance(first_log["topics"], list)
 
 
+from blockscout_mcp_server.tools.common import get_blockscout_base_url
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_get_address_logs_with_truncation_integration(mock_ctx):
@@ -82,11 +84,16 @@ async def test_get_address_logs_with_truncation_integration(mock_ctx):
     Tests that get_address_logs correctly truncates oversized `data` fields
     from a live API response and includes the instructional note.
     """
+    # This address is known to emit logs with very large data fields.
     address = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7"
-    result_str = await get_address_logs(chain_id="1", address=address, ctx=mock_ctx)
+    chain_id = "1"
+
+    # Resolve the base URL the same way the tool does
+    base_url = await get_blockscout_base_url(chain_id)
+    result_str = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
 
     assert "**Note on Truncated Data:**" in result_str
-    assert f"`curl \"https://eth.blockscout.com/api/v2/addresses/{address}/logs\"`" in result_str
+    assert f"`curl \"{base_url}/api/v2/addresses/{address}/logs\"`" in result_str
 
     json_part = result_str.split("**Address logs JSON:**\n")[1].split("----")[0]
     data = json.loads(json_part)

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -1,6 +1,5 @@
 import json
 import pytest
-from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
 
 from blockscout_mcp_server.tools.address_tools import (
     get_address_info,
@@ -75,35 +74,6 @@ async def test_get_address_logs_integration(mock_ctx):
     assert isinstance(first_log["topics"], list)
 
 
-from blockscout_mcp_server.tools.common import get_blockscout_base_url
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_get_address_logs_with_truncation_integration(mock_ctx):
-    """
-    Tests that get_address_logs correctly truncates oversized `data` fields
-    from a live API response and includes the instructional note.
-    """
-    # This address is known to emit logs with very large data fields.
-    address = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7"
-    chain_id = "1"
-
-    # Resolve the base URL the same way the tool does
-    base_url = await get_blockscout_base_url(chain_id)
-    result_str = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
-
-    assert "**Note on Truncated Data:**" in result_str
-    assert f"`curl \"{base_url}/api/v2/addresses/{address}/logs\"`" in result_str
-
-    json_part = result_str.split("**Address logs JSON:**\n")[1].split("----")[0]
-    data = json.loads(json_part)
-    assert "items" in data and isinstance(data["items"], list) and len(data["items"]) > 0
-
-    truncated_item = next((item for item in data["items"] if item.get("data_truncated")), None)
-    assert truncated_item is not None
-    assert truncated_item["data_truncated"] is True
-    assert "data" in truncated_item
-    assert len(truncated_item["data"]) == LOG_DATA_TRUNCATION_LIMIT
 
 
 @pytest.mark.integration

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
 
 from blockscout_mcp_server.tools.address_tools import (
     get_address_info,
@@ -72,6 +73,30 @@ async def test_get_address_logs_integration(mock_ctx):
     assert isinstance(first_log["block_number"], int)
     assert isinstance(first_log["index"], int)
     assert isinstance(first_log["topics"], list)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_address_logs_with_truncation_integration(mock_ctx):
+    """
+    Tests that get_address_logs correctly truncates oversized `data` fields
+    from a live API response and includes the instructional note.
+    """
+    address = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7"
+    result_str = await get_address_logs(chain_id="1", address=address, ctx=mock_ctx)
+
+    assert "**Note on Truncated Data:**" in result_str
+    assert f"`curl \"https://eth.blockscout.com/api/v2/addresses/{address}/logs\"`" in result_str
+
+    json_part = result_str.split("**Address logs JSON:**\n")[1].split("----")[0]
+    data = json.loads(json_part)
+    assert "items" in data and isinstance(data["items"], list) and len(data["items"]) > 0
+
+    truncated_item = next((item for item in data["items"] if item.get("data_truncated")), None)
+    assert truncated_item is not None
+    assert truncated_item["data_truncated"] is True
+    assert "data" in truncated_item
+    assert len(truncated_item["data"]) == LOG_DATA_TRUNCATION_LIMIT
 
 
 @pytest.mark.integration

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -64,7 +64,9 @@ async def test_get_address_logs_integration(mock_ctx):
         "topics",
         "transaction_hash",
     }
-    assert set(first_log.keys()) == expected_keys
+    assert expected_keys.issubset(first_log.keys())
+    if "data_truncated" in first_log:
+        assert isinstance(first_log["data_truncated"], bool)
     assert isinstance(first_log["transaction_hash"], str)
     assert first_log["transaction_hash"].startswith("0x")
     assert isinstance(first_log["block_number"], int)

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -13,7 +13,7 @@ async def test_transaction_summary_integration(mock_ctx):
     the 'summaries' field is correctly extracted from the 'data' object."""
     # A stable, historical transaction (e.g., an early Uniswap V2 router transaction)
     tx_hash = "0x5c7f2f244d91ec281c738393da0be6a38bc9045e29c0566da8c11e7a2f7cbc64"
-    result = await transaction_summary(chain_id="1", hash=tx_hash, ctx=mock_ctx)
+    result = await transaction_summary(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
 
     # Assert that the result is a non-empty string
     assert isinstance(result, str)
@@ -32,7 +32,7 @@ async def test_get_transaction_logs_integration(mock_ctx):
     # This transaction on Ethereum Mainnet is known to have many logs, ensuring a paginated response.
     tx_hash = "0x293b638403324a2244a8245e41b3b145e888a26e3a51353513030034a26a4e41"
     try:
-        result_str = await get_transaction_logs(chain_id="1", hash=tx_hash, ctx=mock_ctx)
+        result_str = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
     except httpx.HTTPStatusError as e:
         pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
 
@@ -80,7 +80,7 @@ async def test_get_transaction_logs_with_truncation_integration(mock_ctx):
     # Resolve the base URL the same way the tool does
     base_url = await get_blockscout_base_url(chain_id)
     try:
-        result_str = await get_transaction_logs(chain_id=chain_id, hash=tx_hash, ctx=mock_ctx)
+        result_str = await get_transaction_logs(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
     except httpx.HTTPStatusError as e:
         pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
 
@@ -104,7 +104,7 @@ async def test_get_transaction_info_integration(mock_ctx):
     """Tests that get_transaction_info returns full data and omits raw_input by default."""
     # This is a stable transaction with a known decoded input (a swap).
     tx_hash = "0xd4df84bf9e45af2aa8310f74a2577a28b420c59f2e3da02c52b6d39dc83ef10f"
-    result = await get_transaction_info(chain_id="1", hash=tx_hash, ctx=mock_ctx)
+    result = await get_transaction_info(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
 
     # Assert that the main data is present and transformed
     assert isinstance(result, dict)
@@ -133,7 +133,7 @@ async def test_get_transaction_info_integration_no_decoded_input(mock_ctx):
     """Tests that get_transaction_info keeps raw_input by default when decoded_input is null."""
     # This is a stable contract creation transaction, which has no decoded_input.
     tx_hash = "0x12341be874149efc8c714f4ef431db0ce29f64532e5c70d3882257705e2b1ad2"
-    result = await get_transaction_info(chain_id="1", hash=tx_hash, ctx=mock_ctx)
+    result = await get_transaction_info(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
 
     # Assert that the main data is present and transformed
     assert isinstance(result, dict)

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -51,7 +51,9 @@ async def test_get_transaction_logs_integration(mock_ctx):
     # 3. Validate the schema of the first transformed log item.
     first_log = data["items"][0]
     expected_keys = {"address", "block_number", "data", "decoded", "index", "topics"}
-    assert set(first_log.keys()) == expected_keys
+    assert expected_keys.issubset(first_log.keys())
+    if "data_truncated" in first_log:
+        assert isinstance(first_log["data_truncated"], bool)
 
     # 4. Validate the data types of key fields.
     assert isinstance(first_log["address"], str)

--- a/tests/tools/test_address_logs.py
+++ b/tests/tools/test_address_logs.py
@@ -49,10 +49,12 @@ async def test_get_address_logs_success(mock_ctx):
 
     with patch('blockscout_mcp_server.tools.address_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
          patch('blockscout_mcp_server.tools.address_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request, \
+         patch('blockscout_mcp_server.tools.address_tools._process_and_truncate_log_items') as mock_process_logs, \
          patch('blockscout_mcp_server.tools.address_tools.json.dumps') as mock_json_dumps:
 
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
+        mock_process_logs.return_value = (mock_api_response.get("items", []), False)
         mock_json_dumps.return_value = '{"fake_json": true}'
 
         # ACT
@@ -65,6 +67,7 @@ async def test_get_address_logs_success(mock_ctx):
             api_path=f"/api/v2/addresses/{address}/logs",
             params={}
         )
+        mock_process_logs.assert_called_once_with(mock_api_response.get("items", []))
 
         mock_json_dumps.assert_called_once_with(expected_transformed_response)
 
@@ -121,11 +124,13 @@ async def test_get_address_logs_with_pagination(mock_ctx):
 
     with patch('blockscout_mcp_server.tools.address_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
          patch('blockscout_mcp_server.tools.address_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request, \
+         patch('blockscout_mcp_server.tools.address_tools._process_and_truncate_log_items') as mock_process_logs, \
          patch('blockscout_mcp_server.tools.address_tools.json.dumps') as mock_json_dumps, \
          patch('blockscout_mcp_server.tools.address_tools.encode_cursor') as mock_encode_cursor:
 
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
+        mock_process_logs.return_value = (mock_api_response["items"], False)
         mock_json_dumps.return_value = fake_json_body
         mock_encode_cursor.return_value = fake_cursor
 
@@ -144,6 +149,7 @@ async def test_get_address_logs_with_pagination(mock_ctx):
             api_path=f"/api/v2/addresses/{address}/logs",
             params={}
         )
+        mock_process_logs.assert_called_once_with(mock_api_response["items"])
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
@@ -167,10 +173,12 @@ async def test_get_address_logs_with_optional_params(mock_ctx):
 
     with patch('blockscout_mcp_server.tools.address_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
          patch('blockscout_mcp_server.tools.address_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request, \
+         patch('blockscout_mcp_server.tools.address_tools._process_and_truncate_log_items') as mock_process_logs, \
          patch('blockscout_mcp_server.tools.address_tools.json.dumps') as mock_json_dumps:
 
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
+        mock_process_logs.return_value = (mock_api_response["items"], False)
         mock_json_dumps.return_value = '{"empty": true}'
 
         # ACT
@@ -192,6 +200,7 @@ async def test_get_address_logs_with_optional_params(mock_ctx):
                 "items_count": items_count,
             }
         )
+        mock_process_logs.assert_called_once_with(mock_api_response["items"])
 
         mock_json_dumps.assert_called_once_with(expected_transformed_response)
 
@@ -258,10 +267,12 @@ async def test_get_address_logs_empty_logs(mock_ctx):
     # Patch json.dumps directly since it's imported locally in the function
     with patch('blockscout_mcp_server.tools.address_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
          patch('blockscout_mcp_server.tools.address_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request, \
+         patch('blockscout_mcp_server.tools.address_tools._process_and_truncate_log_items') as mock_process_logs, \
          patch('blockscout_mcp_server.tools.address_tools.json.dumps') as mock_json_dumps:
 
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
+        mock_process_logs.return_value = (mock_api_response["items"], False)
         # We don't care what json.dumps returns, only that it's called correctly
         mock_json_dumps.return_value = "{...}"
 
@@ -278,6 +289,7 @@ async def test_get_address_logs_empty_logs(mock_ctx):
             api_path=f"/api/v2/addresses/{address}/logs",
             params={}
         )
+        mock_process_logs.assert_called_once_with(mock_api_response["items"])
         
         # Verify the result structure
         assert result.startswith("**Items Structure:**")
@@ -287,3 +299,30 @@ async def test_get_address_logs_empty_logs(mock_ctx):
         
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_address_logs_with_truncation_note(mock_ctx):
+    """Verify the truncation note is added when the helper indicates truncation."""
+    # ARRANGE
+    chain_id = "1"
+    address = "0x123abc"
+    mock_base_url = "https://eth.blockscout.com"
+    mock_api_response = {"items": [{"data": "0xlong..."}]}
+
+    with patch('blockscout_mcp_server.tools.address_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
+         patch('blockscout_mcp_server.tools.address_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request, \
+         patch('blockscout_mcp_server.tools.address_tools._process_and_truncate_log_items') as mock_process_logs:
+
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_api_response
+        # Simulate truncated data
+        mock_process_logs.return_value = (mock_api_response["items"], True)
+
+        # ACT
+        result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+        # ASSERT
+        mock_process_logs.assert_called_once_with(mock_api_response["items"])
+        assert "**Note on Truncated Data:**" in result
+        assert f"`curl \"{mock_base_url}/api/v2/addresses/{address}/logs\"`" in result

--- a/tests/tools/test_address_logs.py
+++ b/tests/tools/test_address_logs.py
@@ -343,4 +343,4 @@ async def test_get_address_logs_with_truncation_note(mock_ctx):
         mock_process_logs.assert_called_once_with(mock_api_response["items"])
         mock_json_dumps.assert_called_once_with(expected_transformed)
         assert "**Note on Truncated Data:**" in result
-        assert f"`curl \"{mock_base_url}/api/v2/addresses/{address}/logs\"`" in result
+        assert f"`curl \"{mock_base_url}/api/v2/transactions/{{THE_TRANSACTION_HASH}}/logs\"`" in result

--- a/tests/tools/test_transaction_tools.py
+++ b/tests/tools/test_transaction_tools.py
@@ -275,7 +275,7 @@ async def test_transaction_summary_without_wrapper(mock_ctx):
         mock_request.return_value = mock_api_response
 
         # ACT
-        result = await transaction_summary(chain_id=chain_id, hash=tx_hash, ctx=mock_ctx)
+        result = await transaction_summary(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
 
         # ASSERT
         assert result == expected_result
@@ -312,7 +312,7 @@ async def test_transaction_summary_no_summary_available(mock_ctx):
         mock_request.return_value = mock_api_response
 
         # ACT
-        result = await transaction_summary(chain_id=chain_id, hash=tx_hash, ctx=mock_ctx)
+        result = await transaction_summary(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
 
         # ASSERT
         assert result == expected_result

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -54,7 +54,7 @@ async def test_get_transaction_info_success(mock_ctx):
         mock_request.return_value = mock_api_response
 
         # ACT
-        result = await get_transaction_info(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
@@ -86,7 +86,7 @@ async def test_get_transaction_info_not_found(mock_ctx):
 
         # ACT & ASSERT
         with pytest.raises(httpx.HTTPStatusError):
-            await get_transaction_info(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+            await get_transaction_info(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
@@ -111,7 +111,7 @@ async def test_get_transaction_info_chain_not_found(mock_ctx):
 
         # ACT & ASSERT
         with pytest.raises(ChainNotFoundError):
-            await get_transaction_info(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+            await get_transaction_info(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         mock_get_url.assert_called_once_with(chain_id)
 
@@ -138,7 +138,7 @@ async def test_get_transaction_info_minimal_response(mock_ctx):
         mock_request.return_value = mock_api_response
 
         # ACT
-        result = await get_transaction_info(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
@@ -204,7 +204,7 @@ async def test_get_transaction_info_with_token_transfers_transformation(mock_ctx
         mock_request.return_value = mock_api_response
 
         # ACT
-        result = await get_transaction_info(chain_id=chain_id, hash=tx_hash, ctx=mock_ctx)
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
 
         # ASSERT
         assert result == expected_transformed_result
@@ -278,7 +278,7 @@ async def test_get_transaction_logs_success(mock_ctx):
         mock_json_dumps.return_value = "{...}"
 
         # ACT
-        result = await get_transaction_logs(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
         # Assert that json.dumps was called with the transformed data
@@ -318,7 +318,7 @@ async def test_get_transaction_info_removes_raw_input_by_default(mock_ctx):
         mock_request.return_value = mock_api_response.copy()
 
         # ACT
-        result = await get_transaction_info(chain_id=chain_id, hash=tx_hash, ctx=mock_ctx)
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
 
         # ASSERT
         assert "raw_input" not in result
@@ -344,7 +344,7 @@ async def test_get_transaction_info_keeps_raw_input_when_flagged(mock_ctx):
         mock_request.return_value = mock_api_response.copy()
 
         # ACT
-        result = await get_transaction_info(chain_id=chain_id, hash=tx_hash, ctx=mock_ctx, include_raw_input=True)
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx, include_raw_input=True)
 
         # ASSERT
         assert "raw_input" in result
@@ -370,7 +370,7 @@ async def test_get_transaction_info_keeps_raw_input_if_no_decoded(mock_ctx):
         mock_request.return_value = mock_api_response.copy()
 
         # ACT
-        result = await get_transaction_info(chain_id=chain_id, hash=tx_hash, ctx=mock_ctx)
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
 
         # ASSERT
         assert "raw_input" in result

--- a/tests/tools/test_transaction_tools_3.py
+++ b/tests/tools/test_transaction_tools_3.py
@@ -35,7 +35,7 @@ async def test_get_transaction_logs_empty_logs(mock_ctx):
         mock_json_dumps.return_value = "{...}"
 
         # ACT
-        result = await get_transaction_logs(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
         # Assert that json.dumps was called with the transformed data
@@ -75,7 +75,7 @@ async def test_get_transaction_logs_api_error(mock_ctx):
 
         # ACT & ASSERT
         with pytest.raises(httpx.HTTPStatusError):
-            await get_transaction_logs(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+            await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
@@ -144,7 +144,7 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
         mock_json_dumps.return_value = "{...}"
 
         # ACT
-        result = await get_transaction_logs(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
         # Assert that json.dumps was called with the transformed data
@@ -223,7 +223,7 @@ async def test_get_transaction_logs_with_pagination(mock_ctx):
         mock_json_dumps.return_value = fake_json_body
         mock_encode_cursor.return_value = fake_cursor
 
-        result = await get_transaction_logs(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         mock_json_dumps.assert_called_once_with(expected_transformed_response)
         mock_encode_cursor.assert_called_once_with(
@@ -273,7 +273,7 @@ async def test_get_transaction_logs_with_cursor(mock_ctx):
         mock_process_logs.return_value = (mock_api_response["items"], False)
         mock_json_dumps.return_value = "{...}"
 
-        await get_transaction_logs(chain_id=chain_id, hash=hash, cursor=cursor, ctx=mock_ctx)
+        await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, cursor=cursor, ctx=mock_ctx)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
@@ -299,7 +299,7 @@ async def test_get_transaction_logs_invalid_cursor(mock_ctx):
         new_callable=AsyncMock,
     ) as mock_request:
         result = await get_transaction_logs(
-            chain_id=chain_id, hash=hash, cursor=invalid_cursor, ctx=mock_ctx
+            chain_id=chain_id, transaction_hash=hash, cursor=invalid_cursor, ctx=mock_ctx
         )
 
         assert (
@@ -329,7 +329,7 @@ async def test_get_transaction_logs_with_truncation_note(mock_ctx):
         mock_json_dumps.return_value = '{"fake":true}'
 
         # ACT
-        result = await get_transaction_logs(chain_id=chain_id, hash=hash, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
         expected_transformed = {

--- a/tests/tools/test_transaction_tools_3.py
+++ b/tests/tools/test_transaction_tools_3.py
@@ -315,21 +315,39 @@ async def test_get_transaction_logs_with_truncation_note(mock_ctx):
     chain_id = "1"
     hash = "0xabc123"
     mock_base_url = "https://eth.blockscout.com"
-    mock_api_response = {"items": [{"data": "0xlong..."}]}
+    truncated_item = {"data": "0xlong...", "data_truncated": True}
+    mock_api_response = {"items": [truncated_item]}
 
     with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
          patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request, \
-         patch('blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items') as mock_process_logs:
+         patch('blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items') as mock_process_logs, \
+         patch('blockscout_mcp_server.tools.transaction_tools.json.dumps') as mock_json_dumps:
 
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
-        mock_process_logs.return_value = (mock_api_response["items"], True)
+        mock_process_logs.return_value = ([truncated_item], True)
+        mock_json_dumps.return_value = '{"fake":true}'
 
         # ACT
         result = await get_transaction_logs(chain_id=chain_id, hash=hash, ctx=mock_ctx)
 
         # ASSERT
+        expected_transformed = {
+            "items": [
+                {
+                    "address": None,
+                    "block_number": None,
+                    "data": truncated_item["data"],
+                    "decoded": None,
+                    "index": None,
+                    "topics": None,
+                    "data_truncated": True,
+                }
+            ]
+        }
+
         mock_process_logs.assert_called_once_with(mock_api_response["items"])
+        mock_json_dumps.assert_called_once_with(expected_transformed)
         assert "**Note on Truncated Data:**" in result
         assert f"`curl \"{mock_base_url}/api/v2/transactions/{hash}/logs\"`" in result
 


### PR DESCRIPTION
Closes #49 

## Summary
- add `LOG_DATA_TRUNCATION_LIMIT`
- provide `_process_and_truncate_log_items` helper
- apply truncation logic in address and transaction log tools
- show note when truncation happens
- document truncation strategy
- update tests for new behavior
- loosen integration test schema assertions for optional fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851e9eacb708323837c8f590ce09895