### PR TITLE
Optimize transaction tools output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ mcp-server/
 │       ├── test_get_instructions.py  # Tests for instruction tool (__get_instructions__)
 │       ├── test_search_tools.py      # Tests for search-related tools (lookup_token_by_symbol)
 │       ├── test_transaction_tools.py # Tests for transaction tools (get_transactions_by_address, transaction_summary)
-│       └── test_transaction_tools_2.py # Extended tests for transaction tools (get_transaction_info, get_transaction_logs)
+│       ├── test_transaction_tools_2.py # Extended tests for transaction tools (get_transaction_info, get_transaction_logs)
+│       └── test_transaction_tools_helpers.py # Tests for transaction helper functions
 ├── Dockerfile                  # For building the Docker image
 ├── pytest.ini                  # Pytest configuration (excludes integration tests by default)
 ├── README.md                   # Project overview, setup, and usage instructions

--- a/tests/tools/test_transaction_tools_helpers.py
+++ b/tests/tools/test_transaction_tools_helpers.py
@@ -1,6 +1,9 @@
 import pytest
 
-from blockscout_mcp_server.tools.transaction_tools import _transform_transaction_info
+from blockscout_mcp_server.tools.transaction_tools import (
+    _transform_transaction_info,
+    _transform_advanced_filter_item,
+)
 
 
 def test_transform_standard_response():
@@ -94,3 +97,62 @@ def test_transform_missing_hash_keys():
     }
 
     assert _transform_transaction_info(data) == expected
+
+
+def test_transform_transaction_item():
+    """Test transformation for a typical transaction item."""
+    raw_item = {
+        "from": {"hash": "0xfrom_hash"},
+        "to": {"hash": "0xto_hash"},
+        "token": "should be removed",
+        "total": "should be removed",
+        "value": "should be kept",
+    }
+    fields_to_remove = ["token", "total"]
+
+    expected = {
+        "from": "0xfrom_hash",
+        "to": "0xto_hash",
+        "value": "should be kept",
+    }
+
+    assert _transform_advanced_filter_item(raw_item, fields_to_remove) == expected
+
+
+def test_transform_token_transfer_item():
+    """Test transformation for a typical token transfer item."""
+    raw_item = {
+        "from": {"hash": "0xfrom_hash"},
+        "to": {"hash": "0xto_hash"},
+        "token": "should be kept",
+        "total": "should be kept",
+        "value": "should be removed",
+        "internal_transaction_index": "should be removed",
+    }
+    fields_to_remove = ["value", "internal_transaction_index"]
+
+    expected = {
+        "from": "0xfrom_hash",
+        "to": "0xto_hash",
+        "token": "should be kept",
+        "total": "should be kept",
+    }
+
+    assert _transform_advanced_filter_item(raw_item, fields_to_remove) == expected
+
+
+def test_transform_item_with_missing_keys():
+    """Test that the helper handles items with missing 'from' or 'to' objects."""
+    raw_item = {
+        "from": {"hash": "0xfrom_hash"},
+        "to": None,
+        "value": "should be removed",
+    }
+    fields_to_remove = ["value"]
+
+    expected = {
+        "from": "0xfrom_hash",
+        "to": None,
+    }
+
+    assert _transform_advanced_filter_item(raw_item, fields_to_remove) == expected


### PR DESCRIPTION
Closes #51 

## Summary
- add helper for address and field transformation
- test helper thoroughly
- integrate helper into transaction tools
- verify integration with unit and integration tests
- document new test file in `AGENTS.md`
- improve integration tests to check all items

## Testing
- `pytest -q`
- `pytest -m integration -q`


------
https://chatgpt.com/codex/tasks/task_b_6851f69bd1048323acb35c9afbc0686a