### PR TITLE
Add smart truncation for transaction input data

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -11,7 +11,7 @@ This directory `.cursor/rules` contains rule files that govern the behavior and 
 
 ### MCP Tool Development (100-199)
 
-- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions including API endpoints, file modifications, and implementation patterns
+- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions and patterns, including data truncation techniques
 - **`120-mcp-tool-arguments.mdc`** - Rules for modifying existing MCP tool functions, emphasizing context conservation and purpose clarity
 - **`130-version-management.mdc`** - Version update procedures requiring synchronization across pyproject.toml, __init__.py, and constants.py
 - **`140-tool-description.mdc`** - Guidelines for writing effective tool descriptions with character limits and formatting rules

--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -492,3 +492,40 @@ Some data was truncated. To get the full data, use:
 
     return output_string
 ```
+
+#### 9. Recursively Truncating Nested Data Structures (`return_type: str` or `dict`)
+
+**Rationale:** Some API fields, like `decoded_input` in a transaction, can contain deeply nested lists and tuples with large data blobs. A simple check is not enough. To handle this, we use a recursive helper to traverse the structure and truncate any long strings found within, replacing them with a structured object to signal the truncation.
+
+**Implementation Pattern:**
+This pattern uses a shared recursive helper to centralize the logic and conditionally adds an instructional note to the output.
+
+```python
+from .common import _recursively_truncate_and_flag_long_strings # Fictional helper for this example
+
+async def tool_with_nested_data(chain_id: str, hash: str, ctx: Context) -> str | dict:
+    # 1. Get raw response from API
+    raw_response = await make_blockscout_request(...)
+
+    # 2. Use the recursive helper on the part of the response with nested data
+    processed_params, params_truncated = _recursively_truncate_and_flag_long_strings(
+        raw_response.get("decoded_input", {}).get("parameters", [])
+    )
+    if params_truncated:
+        raw_response["decoded_input"]["parameters"] = processed_params
+
+    # 3. Check if any truncation occurred and prepare final output
+    if params_truncated:
+        # Return as a string with a note
+        output_json = json.dumps(raw_response)
+        note = f"""
+----
+**Note on Truncated Data:**
+Some nested data was truncated. To get the full data, use:
+`curl "{base_url}/api/v2/some_endpoint/{hash}"`
+"""
+        return f"{output_json}{note}"
+    else:
+        # Return the dictionary directly
+        return raw_response
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ mcp-server/
 │   ├── __main__.py             # Entry point for `python -m blockscout_mcp_server`
 │   ├── server.py               # Core server logic: FastMCP instance, tool registration, CLI
 │   ├── config.py               # Configuration management (e.g., API keys, timeouts, cache settings)
-│   ├── constants.py            # Centralized constants used throughout the application
+│   ├── constants.py            # Centralized constants used throughout the application, including data truncation limits
 │   └── tools/                  # Sub-package for tool implementations
 │       ├── __init__.py         # Initializes the tools sub-package
-│       ├── common.py           # Shared utilities for tools (e.g., HTTP client, chain resolution, progress reporting, data processing helpers)
+│       ├── common.py           # Shared utilities for tools (e.g., HTTP client, chain resolution, progress reporting, data processing and truncation helpers)
 │       ├── get_instructions.py # Implements the __get_instructions__ tool
 │       ├── ens_tools.py        # Implements ENS-related tools
 │       ├── search_tools.py     # Implements search-related tools (e.g., lookup_token_by_symbol)
@@ -151,14 +151,14 @@ mcp-server/
         * Loads configuration values (e.g., API keys, timeouts, cache settings) from environment variables.
         * Provides a singleton configuration object that can be imported and used by other modules, especially by `tools/common.py` for API calls.
     * **`constants.py`**:
-        * Defines centralized constants used throughout the application.
+        * Defines centralized constants used throughout the application, including data truncation limits.
         * Contains server instructions and other configuration strings.
         * Ensures consistency between different parts of the application.
         * Used by both server.py and tools like get_instructions.py to maintain a single source of truth.
     * **`tools/` (Sub-package for Tool Implementations)**
         * **`__init__.py`**: Marks `tools` as a sub-package. May re-export tool functions for easier import into `server.py`.
         * **`common.py`**:
-            * Contains shared utility functions for all tool modules.
+            * Contains shared utility functions for all tool modules, including data processing and truncation helpers.
             * Implements chain resolution and caching mechanism with `get_blockscout_base_url` function.
             * Implements helper functions (`encode_cursor`, `decode_cursor`) and a custom exception (`InvalidCursorError`) for handling opaque pagination cursors.
             * Contains asynchronous HTTP client functions for different API endpoints:

--- a/SPEC.md
+++ b/SPEC.md
@@ -158,6 +158,14 @@ sequenceDiagram
 
     This approach maintains a small context footprint by default while providing a reliable "escape hatch" for high-fidelity data retrieval when necessary.
 
+    d) Transaction Input Data Truncation
+
+    To handle potentially massive transaction input data, the `get_transaction_info` tool employs a multi-faceted truncation strategy.
+
+    - **`raw_input` Truncation**: If the raw hexadecimal input string exceeds `INPUT_DATA_TRUNCATION_LIMIT`, it is shortened. A new flag, `raw_input_truncated: true`, is added to the response to signal this.
+    - **`decoded_input` Truncation**: The server recursively traverses the nested `parameters` of the decoded input. Any string value (e.g., a `bytes` or `string` parameter) exceeding the limit is replaced by a structured object: `{"value_sample": "...", "value_truncated": true}`. This preserves the overall structure of the decoded call while saving significant context.
+    - **Instructional Note**: If any field is truncated, a note is appended to the tool's output, providing a `curl` command to retrieve the complete, untruncated data, ensuring the agent has a path to the full information if needed.
+
 3. **Instructions Delivery Workaround**:
    - Although the MCP specification defines an `instructions` field in the initialization response (per [MCP lifecycle](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#initialization)), current MCP Host implementations (e.g., Claude Desktop) do not reliably use these instructions
    - The `__get_instructions__` tool serves as a workaround for this limitation

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -28,3 +28,7 @@ SERVER_NAME = "blockscout-mcp-server"
 # The maximum length for a log's `data` field before it's truncated.
 # 1026 = '0x' prefix + 1024 hex characters (512 bytes).
 LOG_DATA_TRUNCATION_LIMIT = 1026
+
+# The maximum length for a transaction's input data field before it's truncated.
+# 1026 = '0x' prefix + 1024 hex characters (512 bytes).
+INPUT_DATA_TRUNCATION_LIMIT = 1026

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -2,7 +2,7 @@ import pytest
 
 import json
 import httpx
-from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
+from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT, INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.tools.transaction_tools import (
     transaction_summary,
     get_transaction_logs,
@@ -141,22 +141,57 @@ async def test_get_transaction_info_integration_no_decoded_input(mock_ctx):
     tx_hash = "0x12341be874149efc8c714f4ef431db0ce29f64532e5c70d3882257705e2b1ad2"
     result = await get_transaction_info(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
 
-    # Assert that the main data is present and transformed
-    assert isinstance(result, dict)
-    assert "hash" not in result
-    assert result["decoded_input"] is None
-    assert isinstance(result.get("from"), str)
-    assert result.get("to") is None
+    assert isinstance(result, str)
+    assert "**Note on Truncated Data:**" in result
 
-    # raw_input should still be present
-    assert "raw_input" in result
-    assert isinstance(result["raw_input"], str) and len(result["raw_input"]) > 2
+    json_part = result.split("----")[0]
+    data = json.loads(json_part)
 
-    assert "token_transfers" in result and len(result["token_transfers"]) > 0
-    first_transfer = result["token_transfers"][0]
+    assert "hash" not in data
+    assert data["decoded_input"] is None
+    assert isinstance(data.get("from"), str)
+    assert data.get("to") is None
+
+    assert "raw_input" in data
+    assert data["raw_input_truncated"] is True
+
+    assert "token_transfers" in data and len(data["token_transfers"]) > 0
+    first_transfer = data["token_transfers"][0]
     assert isinstance(first_transfer.get("from"), str)
     assert isinstance(first_transfer.get("to"), str)
     assert first_transfer.get("type") == "token_minting"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_transaction_info_with_truncation_integration(mock_ctx):
+    """
+    Tests that get_transaction_info correctly truncates oversized `decoded_input` fields
+    from a live API response and includes the instructional note.
+    """
+    tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
+    chain_id = "1"
+
+    try:
+        result_str = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
+    except httpx.HTTPStatusError as e:
+        pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
+
+    assert isinstance(result_str, str)
+    assert "**Note on Truncated Data:**" in result_str
+    assert f"`curl \"https://eth.blockscout.com/api/v2/transactions/{tx_hash}\"`" in result_str
+
+    json_part = result_str.split("----")[0]
+    data = json.loads(json_part)
+
+    assert "decoded_input" in data
+    params = data["decoded_input"]["parameters"]
+    calldatas_param = next((p for p in params if p["name"] == "calldatas"), None)
+    assert calldatas_param is not None
+
+    truncated_value = calldatas_param["value"][0]
+    assert truncated_value["value_truncated"] is True
+    assert len(truncated_value["value_sample"]) == INPUT_DATA_TRUNCATION_LIMIT
 
 
 @pytest.mark.integration

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -5,8 +5,12 @@ from blockscout_mcp_server.tools.common import (
     decode_cursor,
     InvalidCursorError,
     _process_and_truncate_log_items,
+    _recursively_truncate_and_flag_long_strings,
 )
-from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
+from blockscout_mcp_server.constants import (
+    LOG_DATA_TRUNCATION_LIMIT,
+    INPUT_DATA_TRUNCATION_LIMIT,
+)
 
 
 def test_encode_decode_roundtrip():
@@ -95,3 +99,52 @@ def test_process_and_truncate_log_items_no_data_field():
     processed, truncated = _process_and_truncate_log_items(items)
     assert not truncated
     assert processed == items
+
+
+def test_recursively_truncate_handles_simple_string():
+    """Verify truncation of a simple long string."""
+    long_string = "a" * (INPUT_DATA_TRUNCATION_LIMIT + 1)
+    processed, truncated = _recursively_truncate_and_flag_long_strings(long_string)
+    assert truncated is True
+    assert processed == {
+        "value_sample": "a" * INPUT_DATA_TRUNCATION_LIMIT,
+        "value_truncated": True,
+    }
+
+
+def test_recursively_truncate_handles_short_string():
+    """Verify no change for a short string."""
+    short_string = "hello"
+    processed, truncated = _recursively_truncate_and_flag_long_strings(short_string)
+    assert truncated is False
+    assert processed == short_string
+
+
+def test_recursively_truncate_handles_nested_list():
+    """Verify truncation within a nested list."""
+    long_string = "a" * (INPUT_DATA_TRUNCATION_LIMIT + 1)
+    data = ["short", ["nested_short", long_string]]
+    processed, truncated = _recursively_truncate_and_flag_long_strings(data)
+    assert truncated is True
+    assert processed[0] == "short"
+    assert processed[1][0] == "nested_short"
+    assert processed[1][1]["value_truncated"] is True
+
+
+def test_recursively_truncate_handles_dict():
+    """Verify truncation within a dictionary's values."""
+    long_string = "a" * (INPUT_DATA_TRUNCATION_LIMIT + 1)
+    data = {"key1": "short", "key2": long_string}
+    processed, truncated = _recursively_truncate_and_flag_long_strings(data)
+    assert truncated is True
+    assert processed["key1"] == "short"
+    assert processed["key2"]["value_truncated"] is True
+
+
+def test_recursively_truncate_no_truncation_mixed_types():
+    """Verify no changes when no string is too long."""
+    data = ["string", 123, True, None, {"key": "value"}]
+    original_data = list(data)
+    processed, truncated = _recursively_truncate_and_flag_long_strings(data)
+    assert truncated is False
+    assert processed == original_data

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -5,6 +5,8 @@ import httpx
 
 from blockscout_mcp_server.tools.transaction_tools import get_transaction_info, get_transaction_logs
 from blockscout_mcp_server.tools.common import encode_cursor
+import json
+from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
 
 @pytest.mark.asyncio
 async def test_get_transaction_info_success(mock_ctx):
@@ -66,6 +68,122 @@ async def test_get_transaction_info_success(mock_ctx):
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
+
+@pytest.mark.asyncio
+async def test_get_transaction_info_no_truncation(mock_ctx):
+    """Verify behavior when no data is large enough to be truncated."""
+    chain_id = "1"
+    tx_hash = "0x123"
+    mock_base_url = "https://eth.blockscout.com"
+    mock_api_response = {
+        "hash": tx_hash,
+        "decoded_input": {"parameters": ["short_string"]},
+        "raw_input": "0xshort"
+    }
+
+    with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
+         patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request:
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_api_response.copy()
+
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
+
+        assert isinstance(result, dict)
+        assert "raw_input" not in result
+        assert "raw_input_truncated" not in result
+        assert result["decoded_input"]["parameters"][0] == "short_string"
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_info_truncates_raw_input(mock_ctx):
+    """Verify raw_input is truncated when it's too long and there's no decoded_input."""
+    chain_id = "1"
+    tx_hash = "0x123"
+    mock_base_url = "https://eth.blockscout.com"
+    long_raw_input = "0x" + "a" * INPUT_DATA_TRUNCATION_LIMIT
+    mock_api_response = {
+        "hash": tx_hash,
+        "decoded_input": None,
+        "raw_input": long_raw_input
+    }
+
+    with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
+         patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request:
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_api_response.copy()
+
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
+
+        assert isinstance(result, str)
+        assert "**Note on Truncated Data:**" in result
+
+        json_part = result.split("----")[0]
+        data = json.loads(json_part)
+
+        assert data["raw_input_truncated"] is True
+        assert len(data["raw_input"]) == INPUT_DATA_TRUNCATION_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_info_truncates_decoded_input(mock_ctx):
+    """Verify a parameter in decoded_input is truncated."""
+    chain_id = "1"
+    tx_hash = "0x123"
+    mock_base_url = "https://eth.blockscout.com"
+    long_param = "0x" + "a" * INPUT_DATA_TRUNCATION_LIMIT
+    mock_api_response = {
+        "hash": tx_hash,
+        "decoded_input": {"parameters": [long_param]},
+        "raw_input": "0xshort"
+    }
+
+    with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
+         patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request:
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_api_response.copy()
+
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
+
+        assert isinstance(result, str)
+        assert "**Note on Truncated Data:**" in result
+
+        json_part = result.split("----")[0]
+        data = json.loads(json_part)
+
+        param = data["decoded_input"]["parameters"][0]
+        assert param["value_truncated"] is True
+        assert len(param["value_sample"]) == INPUT_DATA_TRUNCATION_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_info_keeps_and_truncates_raw_input_when_flagged(mock_ctx):
+    """Verify raw_input is kept but truncated when include_raw_input is True."""
+    chain_id = "1"
+    tx_hash = "0x123"
+    mock_base_url = "https://eth.blockscout.com"
+    long_raw_input = "0x" + "a" * INPUT_DATA_TRUNCATION_LIMIT
+    mock_api_response = {
+        "hash": tx_hash,
+        "decoded_input": {"parameters": ["short"]},
+        "raw_input": long_raw_input
+    }
+
+    with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
+         patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request:
+        mock_get_url.return_value = mock_api_response.copy()
+        mock_request.return_value = mock_api_response.copy()
+
+        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx, include_raw_input=True)
+
+        assert isinstance(result, str)
+        assert "**Note on Truncated Data:**" in result
+
+        json_part = result.split("----")[0]
+        data = json.loads(json_part)
+
+        assert "raw_input" in data
+        assert data["raw_input_truncated"] is True
+        assert len(data["raw_input"]) == INPUT_DATA_TRUNCATION_LIMIT
 @pytest.mark.asyncio
 async def test_get_transaction_info_not_found(mock_ctx):
     """
@@ -298,81 +416,4 @@ async def test_get_transaction_logs_success(mock_ctx):
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
-@pytest.mark.asyncio
-async def test_get_transaction_info_removes_raw_input_by_default(mock_ctx):
-    """Verify raw_input is removed by default when decoded_input is present."""
-    # ARRANGE
-    chain_id = "1"
-    tx_hash = "0x123"
-    mock_base_url = "https://eth.blockscout.com"
-    mock_api_response = {
-        "hash": tx_hash,
-        "decoded_input": {"method_call": "transfer(...)"},
-        "raw_input": "0xverylongstring"
-    }
-
-    with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
-         patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request:
-
-        mock_get_url.return_value = mock_base_url
-        mock_request.return_value = mock_api_response.copy()
-
-        # ACT
-        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
-
-        # ASSERT
-        assert "raw_input" not in result
-        assert "decoded_input" in result
-
-@pytest.mark.asyncio
-async def test_get_transaction_info_keeps_raw_input_when_flagged(mock_ctx):
-    """Verify raw_input is kept when include_raw_input is True."""
-    # ARRANGE
-    chain_id = "1"
-    tx_hash = "0x123"
-    mock_base_url = "https://eth.blockscout.com"
-    mock_api_response = {
-        "hash": tx_hash,
-        "decoded_input": {"method_call": "transfer(...)"},
-        "raw_input": "0xverylongstring"
-    }
-
-    with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
-         patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request:
-
-        mock_get_url.return_value = mock_base_url
-        mock_request.return_value = mock_api_response.copy()
-
-        # ACT
-        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx, include_raw_input=True)
-
-        # ASSERT
-        assert "raw_input" in result
-        assert result["raw_input"] == "0xverylongstring"
-
-@pytest.mark.asyncio
-async def test_get_transaction_info_keeps_raw_input_if_no_decoded(mock_ctx):
-    """Verify raw_input is kept by default if decoded_input is null."""
-    # ARRANGE
-    chain_id = "1"
-    tx_hash = "0x123"
-    mock_base_url = "https://eth.blockscout.com"
-    mock_api_response = {
-        "hash": tx_hash,
-        "decoded_input": None,
-        "raw_input": "0xverylongstring"
-    }
-
-    with patch('blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url', new_callable=AsyncMock) as mock_get_url, \
-         patch('blockscout_mcp_server.tools.transaction_tools.make_blockscout_request', new_callable=AsyncMock) as mock_request:
-
-        mock_get_url.return_value = mock_base_url
-        mock_request.return_value = mock_api_response.copy()
-
-        # ACT
-        result = await get_transaction_info(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
-
-        # ASSERT
-        assert "raw_input" in result
-        assert result["raw_input"] == "0xverylongstring"
 


### PR DESCRIPTION
## Summary
- introduce `INPUT_DATA_TRUNCATION_LIMIT` constant
- implement recursive truncation helper for nested data
- enhance `get_transaction_info` with input data truncation
- update docs and rules for new truncation strategy
- expand unit and integration tests for new behavior

## Testing
- `pytest -q`
- `pytest -m integration -q`

------
https://chatgpt.com/codex/tasks/task_b_6854d0255cbc832382355014a44a0170