### PR TITLE
Improve log truncation for decoded fields

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -11,7 +11,7 @@ This directory `.cursor/rules` contains rule files that govern the behavior and 
 
 ### MCP Tool Development (100-199)
 
-- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions and patterns, including data truncation techniques
+- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions and patterns, including simple and recursive data truncation techniques
 - **`120-mcp-tool-arguments.mdc`** - Rules for modifying existing MCP tool functions, emphasizing context conservation and purpose clarity
 - **`130-version-management.mdc`** - Version update procedures requiring synchronization across pyproject.toml, __init__.py, and constants.py
 - **`140-tool-description.mdc`** - Guidelines for writing effective tool descriptions with character limits and formatting rules

--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -11,7 +11,7 @@ This directory `.cursor/rules` contains rule files that govern the behavior and 
 
 ### MCP Tool Development (100-199)
 
-- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions and patterns, including simple and recursive data truncation techniques
+- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions and patterns, including data truncation techniques
 - **`120-mcp-tool-arguments.mdc`** - Rules for modifying existing MCP tool functions, emphasizing context conservation and purpose clarity
 - **`130-version-management.mdc`** - Version update procedures requiring synchronization across pyproject.toml, __init__.py, and constants.py
 - **`140-tool-description.mdc`** - Guidelines for writing effective tool descriptions with character limits and formatting rules

--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -456,22 +456,24 @@ return "\n".join(output_parts)
 **Key Points:**
 - Always use `return_exceptions=True`
 
-#### 8. Truncating Large Data Fields to Save Context (`return_type: str`)
+#### 8. Truncating Large and Nested Data Fields to Save Context (`return_type: str`)
 
-**Rationale:** Some API fields, like the `data` field in transaction logs, can be extremely large and consume excessive LLM context. To handle this, we truncate the data and explicitly flag the truncation to the agent, guiding it on how to retrieve the full data if needed.
+**Rationale:** Some API fields, like the raw `data` field or deeply nested values inside a log's `decoded` object, can be extremely large and consume excessive LLM context. We shorten these values and explicitly flag the truncation, guiding the agent on how to retrieve the full data if needed.
 
 **Implementation Pattern:**
 This pattern uses a shared helper to centralize the truncation logic and conditionally adds an instructional note to the output.
 
 ```python
-from .common import _process_and_truncate_log_items # Fictional helper for this example
+from .common import _process_and_truncate_log_items # Shared helper handles both raw and decoded truncation
 
 async def tool_with_large_data_fields(chain_id: str, hash: str, ctx: Context) -> str:
     # 1. Get raw response from API
     base_url = await get_blockscout_base_url(chain_id)
     raw_response = await make_blockscout_request(...)
 
-    # 2. Use the helper to process items and check for truncation
+    # 2. Use the helper to process items and check for truncation.
+    #    It shortens the raw `data` field and any long strings inside
+    #    the nested `decoded` structure.
     processed_items, was_truncated = _process_and_truncate_log_items(
         raw_response.get("items", [])
     )

--- a/SPEC.md
+++ b/SPEC.md
@@ -154,6 +154,7 @@ sequenceDiagram
 
     - **Mechanism**: If a log's `data` field (a hex string) exceeds a predefined limit of 1026 characters (representing 512 bytes of data plus the '0x' prefix), it is truncated.
     - **Flagging**: A new boolean field, `data_truncated: true`, is added to the log item to explicitly signal that the data has been shortened.
+    - **Decoded Truncation**: Oversized string values inside the `decoded` dictionary are recursively replaced with `{"value_sample": "...", "value_truncated": true}`.
     - **Guidance**: When truncation occurs, a note is added to the tool's output. This note explains the flag and provides a `curl` command template, guiding the agent on how to programmatically fetch the complete, untruncated data if required for deeper analysis.
 
     This approach maintains a small context footprint by default while providing a reliable "escape hatch" for high-fidelity data retrieval when necessary.

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -384,6 +384,13 @@ def _process_and_truncate_log_items(items: list) -> tuple[list, bool]:
             item_copy["data"] = data[:LOG_DATA_TRUNCATION_LIMIT]
             item_copy["data_truncated"] = True
             was_truncated = True
+
+        decoded = item_copy.get("decoded")
+        if isinstance(decoded, dict):
+            processed_decoded, decoded_was_truncated = _recursively_truncate_and_flag_long_strings(decoded)
+            item_copy["decoded"] = processed_decoded
+            if decoded_was_truncated:
+                was_truncated = True
         processed_items.append(item_copy)
     return processed_items, was_truncated
 

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -374,7 +374,12 @@ def _recursively_truncate_and_flag_long_strings(data: Any) -> tuple[Any, bool]:
 
 
 def _process_and_truncate_log_items(items: list) -> tuple[list, bool]:
-    """Processes log items, truncating the 'data' field if it exceeds a limit."""
+    """Truncate large log values.
+
+    Shortens the raw ``data`` field and recursively trims long strings within
+    the ``decoded`` dictionary of each item. Returns the processed list and a
+    flag indicating whether any truncation occurred.
+    """
     processed_items = []
     was_truncated = False
     for item in items:

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -105,6 +105,60 @@ async def test_get_transaction_logs_with_truncation_integration(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_get_transaction_logs_with_decoded_truncation_integration(mock_ctx):
+    """Ensure truncated decoded parameters trigger the instructional note."""
+    tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
+    chain_id = "1"
+
+    base_url = await get_blockscout_base_url(chain_id)
+    try:
+        result_str = await get_transaction_logs(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
+    except httpx.HTTPStatusError as e:
+        pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
+
+    assert "**Note on Truncated Data:**" in result_str
+    assert f"`curl \"{base_url}/api/v2/transactions/{tx_hash}/logs\"`" in result_str
+
+    json_part = result_str.split("**Transaction logs JSON:**\n")[1].split("----")[0]
+    data = json.loads(json_part)
+
+    scope_function_log = next(
+        (
+            item
+            for item in data.get("items", [])
+            if isinstance(item.get("decoded"), dict)
+            and item["decoded"].get("method_call", "").startswith("ScopeFunction")
+        ),
+        None,
+    )
+
+    if not scope_function_log:
+        pytest.skip("Could not find a 'ScopeFunction' event log in the live data.")
+
+    conditions_param = next(
+        (
+            p
+            for p in scope_function_log["decoded"].get("parameters", [])
+            if p.get("name") == "conditions"
+        ),
+        None,
+    )
+
+    if not conditions_param:
+        pytest.skip("Could not find 'conditions' parameter in the 'ScopeFunction' event.")
+
+    found_truncation = False
+    for condition_tuple in conditions_param.get("value", []):
+        if isinstance(condition_tuple[-1], dict) and condition_tuple[-1].get("value_truncated"):
+            found_truncation = True
+            break
+
+    if not found_truncation:
+        pytest.skip("Could not find a truncated 'bytes' value in the 'conditions' parameter.")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_get_transaction_info_integration(mock_ctx):
     """Tests that get_transaction_info returns full data and omits raw_input by default."""
     # This is a stable transaction with a known decoded input (a swap).

--- a/tests/tools/test_address_logs.py
+++ b/tests/tools/test_address_logs.py
@@ -344,3 +344,59 @@ async def test_get_address_logs_with_truncation_note(mock_ctx):
         mock_json_dumps.assert_called_once_with(expected_transformed)
         assert "**Note on Truncated Data:**" in result
         assert f"`curl \"{mock_base_url}/api/v2/transactions/{{THE_TRANSACTION_HASH}}/logs\"`" in result
+
+
+@pytest.mark.asyncio
+async def test_get_address_logs_with_decoded_truncation_note(mock_ctx):
+    """Verify truncation note when decoded field is truncated."""
+    chain_id = "1"
+    address = "0x123abc"
+    mock_base_url = "https://eth.blockscout.com"
+
+    truncated_item = {
+        "data": "0xshort",
+        "decoded": {
+            "parameters": [
+                {
+                    "name": "foo",
+                    "value": {"value_sample": "0x", "value_truncated": True},
+                }
+            ]
+        },
+    }
+    mock_api_response = {"items": [truncated_item]}
+
+    with patch(
+        "blockscout_mcp_server.tools.address_tools.get_blockscout_base_url",
+        new_callable=AsyncMock,
+    ) as mock_get_url, patch(
+        "blockscout_mcp_server.tools.address_tools.make_blockscout_request",
+        new_callable=AsyncMock,
+    ) as mock_request, patch(
+        "blockscout_mcp_server.tools.address_tools._process_and_truncate_log_items"
+    ) as mock_process_logs, patch(
+        "blockscout_mcp_server.tools.address_tools.json.dumps"
+    ) as mock_json_dumps:
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_api_response
+        mock_process_logs.return_value = ([truncated_item], True)
+        mock_json_dumps.return_value = "{\"fake\":true}"
+
+        result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+        expected_transformed = {
+            "items": [
+                {
+                    "block_number": None,
+                    "data": truncated_item["data"],
+                    "decoded": truncated_item["decoded"],
+                    "index": None,
+                    "topics": None,
+                    "transaction_hash": None,
+                }
+            ]
+        }
+        mock_process_logs.assert_called_once_with(mock_api_response["items"])
+        mock_json_dumps.assert_called_once_with(expected_transformed)
+        assert "**Note on Truncated Data:**" in result
+        assert f"`curl \"{mock_base_url}/api/v2/transactions/{{THE_TRANSACTION_HASH}}/logs\"`" in result

--- a/tests/tools/test_transaction_tools_3.py
+++ b/tests/tools/test_transaction_tools_3.py
@@ -351,3 +351,59 @@ async def test_get_transaction_logs_with_truncation_note(mock_ctx):
         assert "**Note on Truncated Data:**" in result
         assert f"`curl \"{mock_base_url}/api/v2/transactions/{hash}/logs\"`" in result
 
+
+@pytest.mark.asyncio
+async def test_get_transaction_logs_with_decoded_truncation_note(mock_ctx):
+    """Verify truncation note appears when decoded data is truncated."""
+    chain_id = "1"
+    hash = "0xabc123"
+    mock_base_url = "https://eth.blockscout.com"
+
+    truncated_item = {
+        "data": "0xshort",
+        "decoded": {
+            "parameters": [
+                {
+                    "name": "foo",
+                    "value": {"value_sample": "0x", "value_truncated": True},
+                }
+            ]
+        },
+    }
+    mock_api_response = {"items": [truncated_item]}
+
+    with patch(
+        "blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url",
+        new_callable=AsyncMock,
+    ) as mock_get_url, patch(
+        "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request",
+        new_callable=AsyncMock,
+    ) as mock_request, patch(
+        "blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items"
+    ) as mock_process_logs, patch(
+        "blockscout_mcp_server.tools.transaction_tools.json.dumps"
+    ) as mock_json_dumps:
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_api_response
+        mock_process_logs.return_value = ([truncated_item], True)
+        mock_json_dumps.return_value = "{\"fake\":true}"
+
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
+
+        expected_transformed = {
+            "items": [
+                {
+                    "address": None,
+                    "block_number": None,
+                    "data": truncated_item["data"],
+                    "decoded": truncated_item["decoded"],
+                    "index": None,
+                    "topics": None,
+                }
+            ]
+        }
+        mock_process_logs.assert_called_once_with(mock_api_response["items"])
+        mock_json_dumps.assert_called_once_with(expected_transformed)
+        assert "**Note on Truncated Data:**" in result
+        assert f"`curl \"{mock_base_url}/api/v2/transactions/{hash}/logs\"`" in result
+


### PR DESCRIPTION
## Summary
- recursively truncate long decoded values in log items
- document truncation of decoded parameters in SPEC
- update truncation guidance in rules
- add unit and integration tests for decoded truncation
- refine integration checks for ScopeFunction conditions

Closes #57

------
https://chatgpt.com/codex/tasks/task_b_6855edb0590c832385e73b3ea54a0e9b