### PR TITLE
Add pagination integration tests

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -20,7 +20,7 @@ This directory `.cursor/rules` contains rule files that govern the behavior and 
 
 - **`200-development-testing-workflow.mdc`** - Mandatory testing workflow for all code changes including unit tests, integration tests, and validation steps
 - **`210-unit-testing-guidelines.mdc`** - Detailed unit testing patterns including mocking strategies, assertion guidelines, and file organization
-- **`220-integration-testing-guidelines.mdc`** - Integration testing guidelines for validating API contracts and data extraction logic
+- **`220-integration-testing-guidelines.mdc`** - Integration testing guidelines, including pagination tests for cursor-based APIs
 
 ### Meta Rules (900-999)
 

--- a/.cursor/rules/220-integration-testing-guidelines.mdc
+++ b/.cursor/rules/220-integration-testing-guidelines.mdc
@@ -118,7 +118,7 @@ async def test_get_tokens_by_address_pagination_integration(mock_ctx):
 
     # ASSERT 1: Check for and extract the cursor.
     assert "To get the next page call" in first_page_result
-    cursor_match = re.search(r'cursor="([^\"]+)"', first_page_result)
+    cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
     assert cursor_match is not None, "Could not find cursor in the first page response."
     cursor = cursor_match.group(1)
 
@@ -128,7 +128,9 @@ async def test_get_tokens_by_address_pagination_integration(mock_ctx):
     # ASSERT 2: Verify the second page.
     assert "Error" not in second_page_result
     first_page_data = json.loads(first_page_result.split("----")[0])
-    second_page_data = json.loads(second_page_result) # Second page may not have a hint.
+    # Second page may or may not have a hint, so splitting is the safest way to parse.
+    second_page_json_str = second_page_result.split("----")[0]
+    second_page_data = json.loads(second_page_json_str)
     
     assert len(second_page_data) > 0
     assert first_page_data[0] != second_page_data[0]

--- a/.cursor/rules/220-integration-testing-guidelines.mdc
+++ b/.cursor/rules/220-integration-testing-guidelines.mdc
@@ -86,6 +86,54 @@ async def test_get_latest_block_data_extraction(mock_ctx):
     assert len(result["hash"]) == 66  # 0x + 64 hex chars
 ```
 
+- **What to Avoid:** Do not re-test complex formatting logic already covered by unit tests. The focus is on verifying the *data extraction* was successful.
+
+**Testing Pagination and Cursors:**
+
+For tools that support cursor-based pagination, a specific two-step test is required to validate the full lifecycle of the feature.
+
+- **Purpose:** To verify that a cursor generated from a first call can be successfully used in a second call to retrieve the next page of data.
+- **Process:**
+  1.  Make an initial call to the tool without a cursor.
+  2.  Extract the cursor string from the response's pagination hint.
+  3.  Make a second call to the same tool, passing the extracted cursor.
+  4.  Assert that the second call succeeds and that its data is different from the first call's data.
+
+**Example:**
+```python
+import re
+import json
+import pytest
+from blockscout_mcp_server.tools.address_tools import get_tokens_by_address
+
+@pytest.mark.integration
+async def test_get_tokens_by_address_pagination_integration(mock_ctx):
+    """Tests that get_tokens_by_address can use a cursor to fetch a second page."""
+    # ARRANGE: Use a stable address known to have many results.
+    address = "0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503" # Binance Wallet
+    chain_id = "1"
+
+    # ACT 1: Get the first page and cursor.
+    first_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+    # ASSERT 1: Check for and extract the cursor.
+    assert "To get the next page call" in first_page_result
+    cursor_match = re.search(r'cursor="([^\"]+)"', first_page_result)
+    assert cursor_match is not None, "Could not find cursor in the first page response."
+    cursor = cursor_match.group(1)
+
+    # ACT 2: Use the cursor to get the next page.
+    second_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+
+    # ASSERT 2: Verify the second page.
+    assert "Error" not in second_page_result
+    first_page_data = json.loads(first_page_result.split("----")[0])
+    second_page_data = json.loads(second_page_result) # Second page may not have a hint.
+    
+    assert len(second_page_data) > 0
+    assert first_page_data[0] != second_page_data[0]
+```
+
 ## General Rules for All Integration Tests
 
 ### Use Stable Targets

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -1,4 +1,5 @@
 import json
+import re
 import pytest
 
 from blockscout_mcp_server.tools.address_tools import (
@@ -158,3 +159,93 @@ async def test_get_address_info_integration(mock_ctx):
     usdc_tag = next((tag for tag in metadata["tags"] if tag.get("slug") == "usdc"), None)
     assert usdc_tag is not None, "Could not find the 'usdc' tag in metadata"
     assert usdc_tag["name"].lower() in {"usd coin", "usdc"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_tokens_by_address_pagination_integration(mock_ctx):
+    """Tests that get_tokens_by_address can successfully use a cursor to fetch a second page."""
+    address = "0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503"
+    chain_id = "1"
+
+    first_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+    assert "To get the next page call" in first_page_result
+    cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
+    assert cursor_match is not None, "Could not find cursor in the first page response."
+    cursor = cursor_match.group(1)
+    assert len(cursor) > 0
+
+    second_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+
+    assert "Error: Invalid or expired pagination cursor" not in second_page_result
+
+    first_page_json_str = first_page_result.split("----")[0]
+    second_page_json_str = second_page_result.split("----")[0]
+
+    first_page_data = json.loads(first_page_json_str)
+    second_page_data = json.loads(second_page_json_str)
+
+    assert isinstance(second_page_data, list)
+    assert len(second_page_data) > 0
+    assert first_page_data[0] != second_page_data[0]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_nft_tokens_by_address_pagination_integration(mock_ctx):
+    """Tests that nft_tokens_by_address can successfully use a cursor to fetch a second page."""
+    address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    chain_id = "1"
+
+    first_page_result = await nft_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+    assert "To get the next page call" in first_page_result
+    cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
+    assert cursor_match is not None, "Could not find cursor in the first page response."
+    cursor = cursor_match.group(1)
+    assert len(cursor) > 0
+
+    second_page_result = await nft_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+
+    assert "Error: Invalid or expired pagination cursor" not in second_page_result
+
+    first_page_json_str = first_page_result.split("----")[0]
+    second_page_json_str = second_page_result.split("----")[0]
+
+    first_page_data = json.loads(first_page_json_str)
+    second_page_data = json.loads(second_page_json_str)
+
+    assert isinstance(second_page_data, list)
+    assert len(second_page_data) > 0
+    assert first_page_data[0] != second_page_data[0]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_address_logs_pagination_integration(mock_ctx):
+    """Tests that get_address_logs can successfully use a cursor to fetch a second page."""
+    address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    chain_id = "1"
+
+    first_page_result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+    assert "To get the next page call" in first_page_result
+    cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
+    assert cursor_match is not None, "Could not find cursor in the first page response."
+    cursor = cursor_match.group(1)
+    assert len(cursor) > 0
+
+    second_page_result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+
+    assert "Error: Invalid or expired pagination cursor" not in second_page_result
+
+    first_page_json_str = first_page_result.split("----")[0].split("**Address logs JSON:**\n")[-1]
+    second_page_json_str = second_page_result.split("----")[0].split("**Address logs JSON:**\n")[-1]
+
+    first_page_data = json.loads(first_page_json_str)
+    second_page_data = json.loads(second_page_json_str)
+
+    assert isinstance(second_page_data.get("items"), list)
+    assert len(second_page_data["items"]) > 0
+    assert first_page_data["items"][0] != second_page_data["items"][0]

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -1,5 +1,6 @@
 import json
 import re
+import httpx
 import pytest
 
 from blockscout_mcp_server.tools.address_tools import (
@@ -168,7 +169,10 @@ async def test_get_tokens_by_address_pagination_integration(mock_ctx):
     address = "0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503"
     chain_id = "1"
 
-    first_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx)
+    try:
+        first_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx)
+    except httpx.HTTPStatusError as e:
+        pytest.skip(f"API request failed, skipping pagination test: {e}")
 
     assert "To get the next page call" in first_page_result
     cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
@@ -176,7 +180,10 @@ async def test_get_tokens_by_address_pagination_integration(mock_ctx):
     cursor = cursor_match.group(1)
     assert len(cursor) > 0
 
-    second_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+    try:
+        second_page_result = await get_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+    except httpx.HTTPStatusError as e:
+        pytest.fail(f"API request for the second page failed with cursor: {e}")
 
     assert "Error: Invalid or expired pagination cursor" not in second_page_result
 
@@ -198,7 +205,10 @@ async def test_nft_tokens_by_address_pagination_integration(mock_ctx):
     address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
     chain_id = "1"
 
-    first_page_result = await nft_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx)
+    try:
+        first_page_result = await nft_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx)
+    except httpx.HTTPStatusError as e:
+        pytest.skip(f"API request failed, skipping pagination test: {e}")
 
     assert "To get the next page call" in first_page_result
     cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
@@ -206,7 +216,10 @@ async def test_nft_tokens_by_address_pagination_integration(mock_ctx):
     cursor = cursor_match.group(1)
     assert len(cursor) > 0
 
-    second_page_result = await nft_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+    try:
+        second_page_result = await nft_tokens_by_address(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+    except httpx.HTTPStatusError as e:
+        pytest.fail(f"API request for the second page failed with cursor: {e}")
 
     assert "Error: Invalid or expired pagination cursor" not in second_page_result
 
@@ -228,7 +241,10 @@ async def test_get_address_logs_pagination_integration(mock_ctx):
     address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
     chain_id = "1"
 
-    first_page_result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
+    try:
+        first_page_result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx)
+    except httpx.HTTPStatusError as e:
+        pytest.skip(f"API request failed, skipping pagination test: {e}")
 
     assert "To get the next page call" in first_page_result
     cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
@@ -236,7 +252,10 @@ async def test_get_address_logs_pagination_integration(mock_ctx):
     cursor = cursor_match.group(1)
     assert len(cursor) > 0
 
-    second_page_result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+    try:
+        second_page_result = await get_address_logs(chain_id=chain_id, address=address, ctx=mock_ctx, cursor=cursor)
+    except httpx.HTTPStatusError as e:
+        pytest.fail(f"API request for the second page failed with cursor: {e}")
 
     assert "Error: Invalid or expired pagination cursor" not in second_page_result
 

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -92,7 +92,7 @@ async def test_get_transaction_logs_pagination_integration(mock_ctx):
     try:
         second_page_result = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx, cursor=cursor)
     except httpx.HTTPStatusError as e:
-        pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
+        pytest.fail(f"Failed to fetch the second page of transaction logs due to an API error: {e}")
 
     assert "Error: Invalid or expired pagination cursor" not in second_page_result
 

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -1,6 +1,7 @@
 import pytest
 
 import json
+import re
 import httpx
 from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT, INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.tools.common import get_blockscout_base_url
@@ -69,6 +70,41 @@ async def test_get_transaction_logs_integration(mock_ctx):
     assert isinstance(first_log["block_number"], int)
     assert isinstance(first_log["index"], int)
     assert isinstance(first_log["topics"], list)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_transaction_logs_pagination_integration(mock_ctx):
+    """Tests that get_transaction_logs can successfully use a cursor to fetch a second page."""
+    tx_hash = "0x293b638403324a2244a8245e41b3b145e888a26e3a51353513030034a26a4e41"
+
+    try:
+        first_page_result = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
+    except httpx.HTTPStatusError as e:
+        pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
+
+    assert "To get the next page call" in first_page_result
+    cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
+    assert cursor_match is not None, "Could not find cursor in the first page response."
+    cursor = cursor_match.group(1)
+    assert len(cursor) > 0
+
+    try:
+        second_page_result = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx, cursor=cursor)
+    except httpx.HTTPStatusError as e:
+        pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
+
+    assert "Error: Invalid or expired pagination cursor" not in second_page_result
+
+    first_page_json_str = first_page_result.split("----")[0].split("**Transaction logs JSON:**\n")[-1]
+    second_page_json_str = second_page_result.split("----")[0].split("**Transaction logs JSON:**\n")[-1]
+
+    first_page_data = json.loads(first_page_json_str)
+    second_page_data = json.loads(second_page_json_str)
+
+    assert isinstance(second_page_data.get("items"), list)
+    assert len(second_page_data["items"]) > 0
+    assert first_page_data["items"][0] != second_page_data["items"][0]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add integration tests that exercise cursor-based pagination
- test pagination for address tools
- test pagination for transaction tools
- document pagination testing approach

Closes #60

------
https://chatgpt.com/codex/tasks/task_b_6859d608a1ec8323b097539a9e462e81