### PR TITLE
Fix for integration tests to verify decoded log data truncation

### DIFF
--- a/.cursor/rules/220-integration-testing-guidelines.mdc
+++ b/.cursor/rules/220-integration-testing-guidelines.mdc
@@ -88,6 +88,51 @@ async def test_get_latest_block_data_extraction(mock_ctx):
 
 - **What to Avoid:** Do not re-test complex formatting logic already covered by unit tests. The focus is on verifying the *data extraction* was successful.
 
+#### Handling Paginated Data
+
+For tools that return paginated data, integration tests must be robust enough to find specific data patterns that may not be on the first page. Instead of assuming data is in the initial response, tests should loop through pages.
+
+**Best Practice:**
+- Use a `while` or `for` loop with a `max_pages_to_check` limit to prevent infinite loops.
+- In each iteration, call the tool with the current `cursor`.
+- Inspect the response for the target data. If found, break the loop.
+- If not found, parse the new cursor from the response string and continue to the next page.
+- If the data is not found after checking the maximum number of pages, the test should be skipped with a clear message.
+
+**Example:**
+```python
+import pytest
+
+@pytest.mark.integration
+async def test_tool_with_pagination_search(mock_ctx):
+    """Test that we can find specific data by searching across pages."""
+    MAX_PAGES_TO_CHECK = 5
+    cursor = None
+    found_item = None
+
+    for _ in range(MAX_PAGES_TO_CHECK):
+        # Call the paginated tool
+        result_str = await some_paginated_tool(chain_id="1", cursor=cursor, ctx=mock_ctx)
+
+        # Logic to parse JSON and search for the specific item
+        # ...
+        # if item_is_found:
+        #     found_item = item
+        #     break
+
+        # Extract next cursor if more pages exist
+        if "To get the next page call" in result_str:
+            cursor = result_str.split('cursor="')[1].split('"')[0]
+        else:
+            break
+    
+    if not found_item:
+        pytest.skip(f"Could not find target item within {MAX_PAGES_TO_CHECK} pages.")
+
+    # Assertions on the found_item
+    assert found_item["some_field"] == "expected_value"
+```
+
 **Testing Pagination and Cursors:**
 
 For tools that support cursor-based pagination, a specific two-step test is required to validate the full lifecycle of the feature.
@@ -136,51 +181,6 @@ async def test_get_tokens_by_address_pagination_integration(mock_ctx):
     assert first_page_data[0] != second_page_data[0]
 ```
 
-
-#### Handling Paginated Data
-
-For tools that return paginated data, integration tests must be robust enough to find specific data patterns that may not be on the first page. Instead of assuming data is in the initial response, tests should loop through pages.
-
-**Best Practice:**
-- Use a `while` or `for` loop with a `max_pages_to_check` limit to prevent infinite loops.
-- In each iteration, call the tool with the current `cursor`.
-- Inspect the response for the target data. If found, break the loop.
-- If not found, parse the new cursor from the response string and continue to the next page.
-- If the data is not found after checking the maximum number of pages, the test should be skipped with a clear message.
-
-**Example:**
-```python
-import pytest
-
-@pytest.mark.integration
-async def test_tool_with_pagination_search(mock_ctx):
-    """Test that we can find specific data by searching across pages."""
-    MAX_PAGES_TO_CHECK = 5
-    cursor = None
-    found_item = None
-
-    for _ in range(MAX_PAGES_TO_CHECK):
-        # Call the paginated tool
-        result_str = await some_paginated_tool(chain_id="1", cursor=cursor, ctx=mock_ctx)
-
-        # Logic to parse JSON and search for the specific item
-        # ...
-        # if item_is_found:
-        #     found_item = item
-        #     break
-
-        # Extract next cursor if more pages exist
-        if "To get the next page call" in result_str:
-            cursor = result_str.split('cursor="')[1].split('"')[0]
-        else:
-            break
-    
-    if not found_item:
-        pytest.skip(f"Could not find target item within {MAX_PAGES_TO_CHECK} pages.")
-
-    # Assertions on the found_item
-    assert found_item["some_field"] == "expected_value"
-```
 ## General Rules for All Integration Tests
 
 ### Use Stable Targets
@@ -221,6 +221,14 @@ pytest -m integration
 # Run everything except integration tests
 pytest -m "not integration"
 ```
+
+**Important:** Always use the `-v` (verbose) flag when running integration tests to see the reason for any skipped tests:
+
+```bash
+pytest -m integration -v
+```
+
+This verbose output will show you why specific tests were skipped (e.g., network connectivity issues, missing API keys, or external service unavailability), which is crucial for understanding the test results and debugging integration issues.
 
 ### Error Handling
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,4 +38,4 @@ jobs:
       # This command uses the -m flag to run ONLY the tests marked with "integration".
       - name: Run integration tests
         run: |
-          pytest -m integration
+          pytest -m integration -v

--- a/TESTING.md
+++ b/TESTING.md
@@ -84,8 +84,12 @@ The project also includes a suite of integration tests that verify live connecti
 To run **only** the integration tests, use the `-m` flag to select the `integration` marker:
 
 ```bash
-pytest -m integration
+pytest -m integration -v
 ```
+
+**Important:** Always use the `-v` (verbose) flag when running integration tests to see the reason for any skipped tests.
+
+This verbose output will show you why specific tests were skipped (e.g., network connectivity issues, missing API keys, or external service unavailability), which is crucial for understanding the test results.
 
 This command is useful for periodically checking the health of our external dependencies or before deploying a new version.
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
 # Integration tests for Blockscout MCP Server
 #
 # These tests make real network calls to live APIs and are slower than unit tests.
-# Run with: pytest -m integration 
+# Run with: pytest -m integration -v

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -3,7 +3,7 @@ import re
 import httpx
 import pytest
 
-from .utils import _find_truncated_scope_function_in_logs, _extract_next_cursor
+from .utils import _find_truncated_call_executed_function_in_logs, _extract_next_cursor
 
 from blockscout_mcp_server.tools.address_tools import (
     get_address_info,
@@ -221,7 +221,7 @@ async def test_get_address_logs_paginated_search_for_truncation(mock_ctx):
     """
     Tests that get_address_logs can find truncated data by searching across pages.
     """
-    address = "0x703806E61847984346d2D7DDd853049627e50A40"
+    address = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7"
     chain_id = "1"
     MAX_PAGES_TO_CHECK = 5
     cursor = None
@@ -241,7 +241,7 @@ async def test_get_address_logs_paginated_search_for_truncation(mock_ctx):
         json_part = result_str.split("**Address logs JSON:**\n")[1].split("----")[0]
         data = json.loads(json_part)
 
-        if _find_truncated_scope_function_in_logs(data):
+        if _find_truncated_call_executed_function_in_logs(data):
             found_truncated_log = True
             break
 
@@ -253,5 +253,5 @@ async def test_get_address_logs_paginated_search_for_truncation(mock_ctx):
 
     if not found_truncated_log:
         pytest.skip(
-            f"Could not find a truncated 'ScopeFunction' log within the first {MAX_PAGES_TO_CHECK} pages."
+            f"Could not find a truncated 'CallExecuted' log within the first {MAX_PAGES_TO_CHECK} pages."
         )

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -44,7 +44,7 @@ async def test_get_transaction_logs_integration(mock_ctx):
     try:
         result_str = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
     except httpx.HTTPStatusError as e:
-        pytest.fail(f"Transaction data is currently unavailable from the API: {e}")
+        pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
 
     # 1. Verify that pagination is working correctly
     assert isinstance(result_str, str)
@@ -78,7 +78,7 @@ async def test_get_transaction_logs_integration(mock_ctx):
 @pytest.mark.asyncio
 async def test_get_transaction_logs_pagination_integration(mock_ctx):
     """Tests that get_transaction_logs can successfully use a cursor to fetch a second page."""
-    tx_hash = "0x293b638403324a2244a8245e41b3b145e888a26e3a51353513030034a26a4e41"
+    tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
 
     try:
         first_page_result = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -4,7 +4,7 @@ import json
 import re
 import httpx
 
-from .utils import _find_truncated_scope_function_in_logs, _extract_next_cursor
+from .utils import _find_truncated_call_executed_function_in_logs, _extract_next_cursor
 from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT, INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.tools.common import get_blockscout_base_url
 from blockscout_mcp_server.tools.transaction_tools import (
@@ -322,7 +322,7 @@ async def test_get_transaction_logs_paginated_search_for_truncation(mock_ctx):
         json_part = result_str.split("**Transaction logs JSON:**\n")[1].split("----")[0]
         data = json.loads(json_part)
 
-        if _find_truncated_scope_function_in_logs(data):
+        if _find_truncated_call_executed_function_in_logs(data):
             found_truncated_log = True
             break
 
@@ -334,5 +334,5 @@ async def test_get_transaction_logs_paginated_search_for_truncation(mock_ctx):
 
     if not found_truncated_log:
         pytest.skip(
-            f"Could not find a truncated 'ScopeFunction' log within the first {MAX_PAGES_TO_CHECK} pages."
+            f"Could not find a truncated 'CallExecuted' log within the first {MAX_PAGES_TO_CHECK} pages."
         )

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -40,11 +40,11 @@ async def test_transaction_summary_integration(mock_ctx):
 async def test_get_transaction_logs_integration(mock_ctx):
     """Tests that get_transaction_logs returns a paginated response and validates the schema."""
     # This transaction on Ethereum Mainnet is known to have many logs, ensuring a paginated response.
-    tx_hash = "0x293b638403324a2244a8245e41b3b145e888a26e3a51353513030034a26a4e41"
+    tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
     try:
         result_str = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
     except httpx.HTTPStatusError as e:
-        pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
+        pytest.fail(f"Transaction data is currently unavailable from the API: {e}")
 
     # 1. Verify that pagination is working correctly
     assert isinstance(result_str, str)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -3,34 +3,35 @@
 from __future__ import annotations
 
 
-def _find_truncated_scope_function_in_logs(data: dict) -> bool:
-    """Return True if data contains a truncated 'ScopeFunction' log."""
+def _find_truncated_call_executed_function_in_logs(data: dict) -> bool:
+    """Return True if data contains a truncated 'CallExecuted' log."""
     scope_function_log = next(
         (
             item
             for item in data.get("items", [])
             if isinstance(item.get("decoded"), dict)
-            and item["decoded"].get("method_call", "").startswith("ScopeFunction")
+            and item["decoded"].get("method_call", "").startswith("CallExecuted")
         ),
         None,
     )
     if not scope_function_log:
         return False
 
-    conditions_param = next(
+    data_param = next(
         (
             p
             for p in scope_function_log["decoded"].get("parameters", [])
-            if p.get("name") == "conditions"
+            if p.get("name") == "data"
         ),
         None,
     )
-    if not conditions_param:
+    if not data_param:
         return False
-
-    for condition_tuple in conditions_param.get("value", []):
-        if isinstance(condition_tuple[-1], dict) and condition_tuple[-1].get("value_truncated"):
-            return True
+    
+    # Check if value is a dict with truncation info
+    value = data_param.get("value")
+    if isinstance(value, dict) and value.get("value_truncated"):
+        return True
 
     return False
 


### PR DESCRIPTION
This pull request enhances integration testing by:
- Refactoring utility methods to properly search truncated decoded log data
- Updating test cases with new transaction hashes
- Enforcing -v (verbose) flag usage for improved debugging.
- Including verbose output in CI workflows.