### PR TITLE
Refactor __get_instructions__ to structured ToolResponse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ mcp-server/
                 3. It processes the JSON response from Blockscout.
                 4. It transforms this response into the desired output format.
             * Examples:
-                * `get_instructions.py`: Implements `__get_instructions__`, returning a pre-defined multi-line string with instructions and popular chain IDs.
+                * `get_instructions.py`: Implements `__get_instructions__`, returning special server instructions and popular chain IDs.
                 * `chains_tools.py`: Implements `get_chains_list`, returning a formatted list of blockchain chains with their IDs.
                 * `ens_tools.py`: Implements `get_address_by_ens_name` (fixed BENS endpoint, no chain_id).
                 * `search_tools.py`: Implements `lookup_token_by_symbol(chain_id, symbol)`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -119,7 +119,34 @@ sequenceDiagram
    - `instructions`: An optional list of suggested follow-up actions for the LLM to plan its next steps.
    - `pagination`: An optional object that provides structured information for retrieving the next page of results.
 
-   This approach provides immense benefits, including clarity for the AI, improved testability, and a consistent, predictable API contract.
+This approach provides immense benefits, including clarity for the AI, improved testability, and a consistent, predictable API contract.
+
+**Example: Structured Response from `__get_instructions__`**
+
+To illustrate this pattern, the `__get_instructions__` tool returns a `ToolResponse[InstructionsData]`. The `InstructionsData` model provides a structured view of the server's metadata. The final JSON response looks like this:
+
+```json
+{
+  "data": {
+    "version": "0.3.1",
+    "general_rules": [
+      "If you receive an error...",
+      "All Blockscout API tools require a chain_id parameter:",
+      "..."
+    ],
+    "recommended_chains": [
+      { "name": "Ethereum", "chain_id": 1 },
+      { "name": "Polygon PoS", "chain_id": 137 }
+    ]
+  },
+  "data_description": null,
+  "notes": null,
+  "instructions": null,
+  "pagination": null
+}
+```
+
+This example demonstrates how a tool-specific data model fits cleanly into the standardized `data` field of the `ToolResponse`.
 
 3. **Response Processing and Context Optimization**:
 

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -1,27 +1,34 @@
-"""
-Constants used throughout the Blockscout MCP Server.
-"""
+"""Constants used throughout the Blockscout MCP Server."""
 
-SERVER_INSTRUCTIONS = """
-Blockscout MCP server version: 0.3.1
+from blockscout_mcp_server import __version__
 
-If you receive an error "500 Internal Server Error" for any tool, retry calling this tool up to 3 times until successful.
+SERVER_VERSION = __version__
 
-All Blockscout API tools require a chain_id parameter:
-- If the chain ID to be used in the tools is not clear, use the tool `get_chains_list` to get chain IDs of all known chains.
-- If no chain is specified in the user's prompt, assume "Ethereum Mainnet" (chain_id: 1) as the default.
-- Here is the list of IDs of most popular chains:
-  * Ethereum: 1
-  * Polygon PoS: 137
-  * Base: 8453
-  * Arbitrum One: 42161
-  * OP Mainnet: 10
-  * ZkSync Era: 324
-  * Polygon zkEVM: 1101
-  * Gnosis: 100
-  * Celo: 42220
-  * Scroll: 534352
-"""  # noqa: E501
+GENERAL_RULES = [
+    (
+        'If you receive an error "500 Internal Server Error" for any tool, '
+        "retry calling this tool up to 3 times until successful."
+    ),
+    "All Blockscout API tools require a chain_id parameter:",
+    (
+        "If the chain ID to be used in the tools is not clear, use the tool "
+        "`get_chains_list` to get chain IDs of all known chains."
+    ),
+    'If no chain is specified in the user\'s prompt, assume "Ethereum Mainnet" (chain_id: 1) as the default.',
+]
+
+RECOMMENDED_CHAINS = [
+    {"name": "Ethereum", "chain_id": 1},
+    {"name": "Polygon PoS", "chain_id": 137},
+    {"name": "Base", "chain_id": 8453},
+    {"name": "Arbitrum One", "chain_id": 42161},
+    {"name": "OP Mainnet", "chain_id": 10},
+    {"name": "ZkSync Era", "chain_id": 324},
+    {"name": "Polygon zkEVM", "chain_id": 1101},
+    {"name": "Gnosis", "chain_id": 100},
+    {"name": "Celo", "chain_id": 42220},
+    {"name": "Scroll", "chain_id": 534352},
+]
 
 SERVER_NAME = "blockscout-mcp-server"
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -4,7 +4,12 @@ import typer
 import uvicorn
 from mcp.server.fastmcp import FastMCP
 
-from blockscout_mcp_server.constants import SERVER_INSTRUCTIONS, SERVER_NAME
+from blockscout_mcp_server.constants import (
+    GENERAL_RULES,
+    RECOMMENDED_CHAINS,
+    SERVER_NAME,
+    SERVER_VERSION,
+)
 from blockscout_mcp_server.tools.address_tools import (
     get_address_info,
     get_address_logs,
@@ -25,7 +30,21 @@ from blockscout_mcp_server.tools.transaction_tools import (
     transaction_summary,
 )
 
-mcp = FastMCP(name=SERVER_NAME, instructions=SERVER_INSTRUCTIONS)
+# Compose the instructions string for the MCP server constructor
+chains_list_str = "\n".join([f"  * {chain['name']}: {chain['chain_id']}" for chain in RECOMMENDED_CHAINS])
+composed_instructions = f"""
+Blockscout MCP server version: {SERVER_VERSION}
+
+{GENERAL_RULES[0]}
+
+{GENERAL_RULES[1]}
+- {GENERAL_RULES[2]}
+- {GENERAL_RULES[3]}
+- Here is the list of IDs of most popular chains:
+{chains_list_str}
+"""
+
+mcp = FastMCP(name=SERVER_NAME, instructions=composed_instructions)
 
 # Register the tools
 # The name of each tool will be its function name

--- a/blockscout_mcp_server/tools/get_instructions.py
+++ b/blockscout_mcp_server/tools/get_instructions.py
@@ -1,10 +1,19 @@
 from mcp.server.fastmcp import Context
 
-from blockscout_mcp_server.constants import SERVER_INSTRUCTIONS
-from blockscout_mcp_server.tools.common import report_and_log_progress
+from blockscout_mcp_server.constants import (
+    GENERAL_RULES,
+    RECOMMENDED_CHAINS,
+    SERVER_VERSION,
+)
+from blockscout_mcp_server.models import (
+    InstructionsData,
+    RecommendedChain,
+    ToolResponse,
+)
+from blockscout_mcp_server.tools.common import build_tool_response, report_and_log_progress
 
 
-async def __get_instructions__(ctx: Context) -> str:
+async def __get_instructions__(ctx: Context) -> ToolResponse[InstructionsData]:
     """
     This tool MUST be called BEFORE any other tool.
     Without calling it, the MCP server will not work as expected.
@@ -18,7 +27,14 @@ async def __get_instructions__(ctx: Context) -> str:
         message="Fetching server instructions...",
     )
 
-    # SERVER_INSTRUCTIONS is a constant, so this is immediate
+    # Construct the structured data payload
+    instructions_data = InstructionsData(
+        version=SERVER_VERSION,
+        general_rules=GENERAL_RULES,
+        recommended_chains=[RecommendedChain(**chain) for chain in RECOMMENDED_CHAINS],
+    )
+
+    # Report completion
     await report_and_log_progress(
         ctx,
         progress=1.0,
@@ -26,4 +42,4 @@ async def __get_instructions__(ctx: Context) -> str:
         message="Server instructions ready.",
     )
 
-    return SERVER_INSTRUCTIONS
+    return build_tool_response(data=instructions_data)

--- a/tests/tools/test_get_instructions.py
+++ b/tests/tools/test_get_instructions.py
@@ -1,137 +1,44 @@
-# tests/tools/test_get_instructions.py
 from unittest.mock import patch
 
 import pytest
 
+from blockscout_mcp_server.models import InstructionsData, ToolResponse
 from blockscout_mcp_server.tools.get_instructions import __get_instructions__
 
 
 @pytest.mark.asyncio
 async def test_get_instructions_success(mock_ctx):
-    """
-    Verify __get_instructions__ returns the SERVER_INSTRUCTIONS constant.
-    """
+    """Verify __get_instructions__ returns a structured ToolResponse[InstructionsData]."""
     # ARRANGE
-    # Mock the SERVER_INSTRUCTIONS constant
-    expected_instructions = """You are an AI assistant with access to Blockscout blockchain data. Use the available tools to:
+    mock_version = "1.2.3"
+    mock_rules = ["Rule 1.", "Rule 2."]
+    mock_chains = [{"name": "TestChain", "chain_id": 999}]
 
-1. Look up blockchain information (addresses, blocks, transactions, contracts)
-2. Resolve ENS domain names to addresses
-3. Search for tokens by symbol
-4. Get contract ABIs and smart contract information
-5. Find NFT and token holdings for addresses
-
-Always provide chain_id as the first parameter for blockchain-specific queries.
-Use descriptive responses and explain what the data means in context."""  # noqa: E501
-
-    with patch("blockscout_mcp_server.tools.get_instructions.SERVER_INSTRUCTIONS", expected_instructions):
+    with (
+        patch("blockscout_mcp_server.tools.get_instructions.SERVER_VERSION", mock_version),
+        patch("blockscout_mcp_server.tools.get_instructions.GENERAL_RULES", mock_rules),
+        patch("blockscout_mcp_server.tools.get_instructions.RECOMMENDED_CHAINS", mock_chains),
+    ):
         # ACT
         result = await __get_instructions__(ctx=mock_ctx)
 
         # ASSERT
-        assert result == expected_instructions
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, InstructionsData)
+
+        assert result.data.version == mock_version
+        assert result.data.general_rules == mock_rules
+        assert len(result.data.recommended_chains) == 1
+        assert result.data.recommended_chains[0].name == "TestChain"
+        assert result.data.recommended_chains[0].chain_id == 999
+
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
 
+        start_call = mock_ctx.report_progress.call_args_list[0]
+        assert start_call.kwargs["progress"] == 0.0
+        assert "Fetching server instructions" in start_call.kwargs["message"]
 
-@pytest.mark.asyncio
-async def test_get_instructions_no_progress_tracking(mock_ctx):
-    """
-    Verify __get_instructions__ works correctly even without progress tracking.
-    """
-    # ARRANGE
-    expected_instructions = "Test instructions content"
-
-    with patch("blockscout_mcp_server.tools.get_instructions.SERVER_INSTRUCTIONS", expected_instructions):
-        # ACT
-        result = await __get_instructions__(ctx=mock_ctx)
-
-        # ASSERT
-        assert result == expected_instructions
-        # Verify progress was reported
-        assert mock_ctx.report_progress.call_count == 2
-        assert mock_ctx.info.call_count == 2
-
-        # Verify the specific progress calls
-        progress_calls = mock_ctx.report_progress.call_args_list
-
-        # First call should be starting
-        start_call = progress_calls[0]
-        assert start_call[1]["progress"] == 0.0
-        assert start_call[1]["total"] == 1.0
-        assert "Fetching server instructions" in start_call[1]["message"]
-
-        # Second call should be completion
-        end_call = progress_calls[1]
-        assert end_call[1]["progress"] == 1.0
-        assert end_call[1]["total"] == 1.0
-        assert "Server instructions ready" in end_call[1]["message"]
-
-
-@pytest.mark.asyncio
-async def test_get_instructions_empty_instructions(mock_ctx):
-    """
-    Verify __get_instructions__ handles empty SERVER_INSTRUCTIONS gracefully.
-    """
-    # ARRANGE
-    expected_instructions = ""
-
-    with patch("blockscout_mcp_server.tools.get_instructions.SERVER_INSTRUCTIONS", expected_instructions):
-        # ACT
-        result = await __get_instructions__(ctx=mock_ctx)
-
-        # ASSERT
-        assert result == expected_instructions
-        assert mock_ctx.report_progress.call_count == 2
-        assert mock_ctx.info.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_get_instructions_multiline_instructions(mock_ctx):
-    """
-    Verify __get_instructions__ correctly handles multiline instructions.
-    """
-    # ARRANGE
-    expected_instructions = """Line 1 of instructions
-Line 2 of instructions
-Line 3 of instructions
-
-With empty lines and formatting."""
-
-    with patch("blockscout_mcp_server.tools.get_instructions.SERVER_INSTRUCTIONS", expected_instructions):
-        # ACT
-        result = await __get_instructions__(ctx=mock_ctx)
-
-        # ASSERT
-        assert result == expected_instructions
-        assert "Line 1 of instructions" in result
-        assert "Line 2 of instructions" in result
-        assert "Line 3 of instructions" in result
-        assert "With empty lines and formatting." in result
-        assert mock_ctx.report_progress.call_count == 2
-        assert mock_ctx.info.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_get_instructions_special_characters(mock_ctx):
-    """
-    Verify __get_instructions__ handles instructions with special characters.
-    """
-    # ARRANGE
-    expected_instructions = """Instructions with special chars: !@#$%^&*()
-Unicode: 📝 🔍 ⚡
-Quotes: "double" and 'single'
-Escapes: \n \t \\"""
-
-    with patch("blockscout_mcp_server.tools.get_instructions.SERVER_INSTRUCTIONS", expected_instructions):
-        # ACT
-        result = await __get_instructions__(ctx=mock_ctx)
-
-        # ASSERT
-        assert result == expected_instructions
-        assert "!@#$%^&*()" in result
-        assert "📝 🔍 ⚡" in result
-        assert '"double"' in result
-        assert "'single'" in result
-        assert mock_ctx.report_progress.call_count == 2
-        assert mock_ctx.info.call_count == 2
+        end_call = mock_ctx.report_progress.call_args_list[1]
+        assert end_call.kwargs["progress"] == 1.0
+        assert "Server instructions ready" in end_call.kwargs["message"]


### PR DESCRIPTION
## Summary
- break SERVER_INSTRUCTIONS string into structured constants
- build instructions string on server startup
- return ToolResponse[InstructionsData] from __get_instructions__
- update tests for new structured response
- clarify docs and AGENTS overview

Closes #71

------
https://chatgpt.com/codex/tasks/task_b_685c49a8a03883238262525e8f3df493