### PR TITLE
Refactor get_latest_block to return ToolResponse

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -11,7 +11,7 @@ This directory `.cursor/rules` contains rule files that govern the behavior and 
 
 ### MCP Tool Development (100-199)
 
-- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions and patterns, including data truncation techniques
+- **`110-new-mcp-tool.mdc`** - Comprehensive guide for adding new MCP tool functions and patterns, including data truncation and structured response techniques
 - **`120-mcp-tool-arguments.mdc`** - Rules for modifying existing MCP tool functions, emphasizing context conservation and purpose clarity
 - **`130-version-management.mdc`** - Version update procedures requiring synchronization across pyproject.toml, __init__.py, and constants.py
 - **`140-tool-description.mdc`** - Guidelines for writing effective tool descriptions with character limits and formatting rules

--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -228,25 +228,32 @@ For tools that have a well-defined output structure, you should define a specifi
 
 ```python
 from pydantic import BaseModel, Field
-from blockscout_mcp_server.models import ToolResponse
+from blockscout_mcp_server.models import ToolResponse, LatestBlockData
+from blockscout_mcp_server.tools.common import build_tool_response, make_blockscout_request
 
-# Define a specific model for the data
-class LatestBlockData(BaseModel):
-    block_number: int = Field(description="The block number (height) in the blockchain")
-    timestamp: str = Field(description="The timestamp when the block was mined (ISO format)")
-    hash: str = Field(description="The unique hash identifier of the block")
+# In a real scenario, this model would be in `models.py`
+# class LatestBlockData(BaseModel):
+#     block_number: int = Field(description="The block number (height) in the blockchain")
+#     timestamp: str = Field(description="The timestamp when the block was mined (ISO format)")
 
 async def get_latest_block(chain_id: str) -> ToolResponse[LatestBlockData]:
     """Gets the latest block information."""
-    raw_data = await make_blockscout_request(...) # returns a dict
+    # The actual API returns a list, we take the first item.
+    raw_data_list = await make_blockscout_request(
+        base_url=await get_blockscout_base_url(chain_id),
+        api_path="/api/v2/main-page/blocks"
+    )
+    if not raw_data_list:
+        raise ValueError("No block data returned from API.")
+
+    raw_data = raw_data_list[0]
 
     # Validate and structure the data using your specific model
     block_data = LatestBlockData(
-        block_number=raw_data.get("number"),
+        block_number=raw_data.get("height"),
         timestamp=raw_data.get("timestamp"),
-        hash=raw_data.get("hash")
     )
-    
+
     return build_tool_response(data=block_data)
 ```
 

--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -229,7 +229,7 @@ For tools that have a well-defined output structure, you should define a specifi
 ```python
 from pydantic import BaseModel, Field
 from blockscout_mcp_server.models import ToolResponse, LatestBlockData
-from blockscout_mcp_server.tools.common import build_tool_response, make_blockscout_request
+from blockscout_mcp_server.tools.common import build_tool_response, make_blockscout_request, get_blockscout_base_url
 
 # In a real scenario, this model would be in `models.py`
 # class LatestBlockData(BaseModel):

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -24,6 +24,14 @@ class PaginationInfo(BaseModel):
     next_call: NextCallInfo
 
 
+# --- Model for get_latest_block Data Payload ---
+class LatestBlockData(BaseModel):
+    """Represents the essential data for the latest block."""
+
+    block_number: int = Field(description="The block number (height) in the blockchain")
+    timestamp: str = Field(description="The timestamp when the block was mined (ISO format)")
+
+
 # --- Models for __get_instructions__ Data Payload ---
 class RecommendedChain(BaseModel):
     """Represents a popular blockchain with its essential identifiers."""

--- a/blockscout_mcp_server/tools/block_tools.py
+++ b/blockscout_mcp_server/tools/block_tools.py
@@ -5,7 +5,9 @@ from typing import Annotated
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
+from blockscout_mcp_server.models import LatestBlockData, ToolResponse
 from blockscout_mcp_server.tools.common import (
+    build_tool_response,
     get_blockscout_base_url,
     make_blockscout_request,
     report_and_log_progress,
@@ -108,7 +110,7 @@ async def get_block_info(
 
 async def get_latest_block(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")], ctx: Context
-) -> dict:
+) -> ToolResponse[LatestBlockData]:
     """
     Get the latest indexed block number and timestamp, which represents the most recent state of the blockchain.
     No transactions or token transfers can exist beyond this point, making it useful as a reference timestamp for other API calls.
@@ -146,7 +148,11 @@ async def get_latest_block(
     # The API returns a list. Extract data from the first item as per responseTemplate
     if response_data and isinstance(response_data, list) and len(response_data) > 0:
         first_block = response_data[0]
-        return {"block_number": first_block.get("height"), "timestamp": first_block.get("timestamp")}
+        block_data = LatestBlockData(
+            block_number=first_block.get("height"),
+            timestamp=first_block.get("timestamp"),
+        )
+        return build_tool_response(data=block_data)
 
-    # Return empty values if no data is available
-    return {"block_number": None, "timestamp": None}
+    # Handle cases with no data by raising an error
+    raise ValueError("Could not retrieve latest block data from the API.")

--- a/tests/integration/test_block_tools_integration.py
+++ b/tests/integration/test_block_tools_integration.py
@@ -10,9 +10,12 @@ from blockscout_mcp_server.tools.block_tools import get_block_info, get_latest_b
 async def test_get_latest_block_integration(mock_ctx):
     result = await get_latest_block(chain_id="1", ctx=mock_ctx)
 
-    assert isinstance(result, dict)
-    assert "block_number" in result and isinstance(result["block_number"], int)
-    assert "timestamp" in result and isinstance(result["timestamp"], str)
+    assert hasattr(result, "data")
+    assert hasattr(result.data, "block_number")
+    assert hasattr(result.data, "timestamp")
+    assert isinstance(result.data.block_number, int)
+    assert isinstance(result.data.timestamp, str)
+    assert result.data.block_number > 0
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- define `LatestBlockData` Pydantic model
- return `ToolResponse[LatestBlockData]` from `get_latest_block`
- update unit and integration tests for new structure
- document model usage in development rules

Closes #73

------
https://chatgpt.com/codex/tasks/task_b_685c681e782083238e4270b91fe43c3e