### PR TITLE
Refactor get_address_info to return structured response

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -44,6 +44,17 @@ class InstructionsData(BaseModel):
     )
 
 
+# --- Models for get_address_info Data Payload ---
+class AddressInfoData(BaseModel):
+    """A structured representation of the combined address information."""
+
+    basic_info: dict[str, Any] = Field(description="Core on-chain data for the address from the Blockscout API.")
+    metadata: dict[str, Any] | None = Field(
+        None,
+        description="Optional metadata, such as public tags, from the Metadata service.",
+    )
+
+
 # --- The Main Standardized Response Model ---
 class ToolResponse(BaseModel, Generic[T]):
     """A standardized, structured response for all MCP tools, generic over the data payload type."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@
 import json
 
 from blockscout_mcp_server.models import (
+    AddressInfoData,
     InstructionsData,
     NextCallInfo,
     PaginationInfo,
@@ -148,3 +149,13 @@ def test_tool_response_with_empty_lists():
     assert json_output["data_description"] == []
     assert json_output["notes"] == []
     assert json_output["instructions"] == []
+
+
+def test_address_info_data_model():
+    """Verify AddressInfoData holds basic and metadata info."""
+    basic = {"hash": "0xabc", "is_contract": False}
+    metadata = {"tags": [{"name": "Known"}]}
+    data = AddressInfoData(basic_info=basic, metadata=metadata)
+
+    assert data.basic_info == basic
+    assert data.metadata == metadata

--- a/tests/tools/test_address_tools.py
+++ b/tests/tools/test_address_tools.py
@@ -1,10 +1,10 @@
 # tests/tools/test_address_tools.py
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
+from blockscout_mcp_server.models import AddressInfoData, ToolResponse
 from blockscout_mcp_server.tools.address_tools import (
     get_address_info,
     get_tokens_by_address,
@@ -430,10 +430,11 @@ async def test_get_address_info_success_with_metadata(mock_ctx):
             api_path="/api/v1/metadata", params={"addresses": address, "chainId": chain_id}
         )
 
-        assert "Basic address info:" in result
-        assert json.dumps(mock_blockscout_response) in result
-        assert "Metadata associated with the address:" in result
-        assert json.dumps(mock_metadata_response["addresses"][address]) in result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, AddressInfoData)
+        assert result.data.basic_info == mock_blockscout_response
+        assert result.data.metadata == mock_metadata_response["addresses"][address]
+        assert result.notes is None
 
         assert mock_ctx.report_progress.call_count == 4
         assert mock_ctx.info.call_count == 4
@@ -468,9 +469,91 @@ async def test_get_address_info_success_without_metadata(mock_ctx):
 
         result = await get_address_info(chain_id=chain_id, address=address, ctx=mock_ctx)
 
-        assert "Basic address info:" in result
-        assert json.dumps(mock_blockscout_response) in result
-        assert "Metadata associated with the address:" not in result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, AddressInfoData)
+        assert result.data.basic_info == mock_blockscout_response
+        assert result.data.metadata is None
+        assert result.notes is None
 
         assert mock_ctx.report_progress.call_count == 4
         assert mock_ctx.info.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_get_address_info_metadata_failure(mock_ctx):
+    """Return ToolResponse with notes when metadata API fails."""
+    chain_id = "1"
+    address = "0x123abc"
+    mock_base_url = "https://eth.blockscout.com"
+
+    mock_blockscout_response = {"hash": address, "is_contract": False}
+    metadata_error = httpx.RequestError("Network error")
+
+    with (
+        patch(
+            "blockscout_mcp_server.tools.address_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.address_tools.make_blockscout_request",
+            new_callable=AsyncMock,
+        ) as mock_bs_request,
+        patch(
+            "blockscout_mcp_server.tools.address_tools.make_metadata_request",
+            new_callable=AsyncMock,
+        ) as mock_meta_request,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_bs_request.return_value = mock_blockscout_response
+        mock_meta_request.side_effect = metadata_error
+
+        result = await get_address_info(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, AddressInfoData)
+        assert result.data.basic_info == mock_blockscout_response
+        assert result.data.metadata is None
+        assert result.notes is not None and len(result.notes) == 1
+
+        assert mock_ctx.report_progress.call_count == 4
+        assert mock_ctx.info.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_get_address_info_blockscout_failure(mock_ctx):
+    """Ensure exception is raised when primary Blockscout call fails."""
+    chain_id = "1"
+    address = "0x123abc"
+    mock_base_url = "https://eth.blockscout.com"
+
+    api_error = httpx.HTTPStatusError("Not Found", request=MagicMock(), response=MagicMock(status_code=404))
+
+    with (
+        patch(
+            "blockscout_mcp_server.tools.address_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.address_tools.make_blockscout_request",
+            new_callable=AsyncMock,
+        ) as mock_bs_request,
+        patch(
+            "blockscout_mcp_server.tools.address_tools.make_metadata_request",
+            new_callable=AsyncMock,
+        ) as mock_meta_request,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_bs_request.side_effect = api_error
+        mock_meta_request.return_value = {}
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await get_address_info(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+        mock_get_url.assert_called_once_with(chain_id)
+        mock_bs_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/addresses/{address}")
+        mock_meta_request.assert_called_once_with(
+            api_path="/api/v1/metadata", params={"addresses": address, "chainId": chain_id}
+        )
+
+        assert mock_ctx.report_progress.call_count == 2
+        assert mock_ctx.info.call_count == 2


### PR DESCRIPTION
## Summary
- add `AddressInfoData` to models
- return `ToolResponse[AddressInfoData]` from `get_address_info`
- update unit tests for new return type
- update integration tests for structured response

Closes #74


------
https://chatgpt.com/codex/tasks/task_b_685c6870eed88323b13be15031bbaeb8