### PR TITLE
Refactor get_chains_list to return structured data

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -121,34 +121,9 @@ sequenceDiagram
 
 This approach provides immense benefits, including clarity for the AI, improved testability, and a consistent, predictable API contract.
 
-**Example: Structured Response from `__get_instructions__`**
+**Example: Structured Response from `get_chains_list`**
 
-To illustrate this pattern, the `__get_instructions__` tool returns a `ToolResponse[InstructionsData]`. The `InstructionsData` model provides a structured view of the server's metadata. The final JSON response looks like this:
-
-```json
-{
-  "data": {
-    "version": "0.3.1",
-    "general_rules": [
-      "If you receive an error...",
-      "All Blockscout API tools require a chain_id parameter:",
-      "..."
-    ],
-    "recommended_chains": [
-      { "name": "Ethereum", "chain_id": 1 },
-      { "name": "Polygon PoS", "chain_id": 137 }
-    ]
-  },
-  "data_description": null,
-  "notes": null,
-  "instructions": null,
-  "pagination": null
-}
-```
-
-This example demonstrates how a tool-specific data model fits cleanly into the standardized `data` field of the `ToolResponse`.
-
-This standardized model is flexible. For tools that return simpler data structures, like a list of items, the `data` field directly holds that list. For example, the `get_chains_list` tool returns a `ToolResponse[list[ChainInfo]]`, which serializes to the following clean JSON:
+To illustrate this pattern, the `get_chains_list` tool returns a `ToolResponse[list[ChainInfo]]`. The `data` field holds a list of `ChainInfo` items. The final JSON response looks like this:
 
 ```json
 {
@@ -163,6 +138,8 @@ This standardized model is flexible. For tools that return simpler data structur
   "pagination": null
 }
 ```
+
+This example demonstrates how a tool-specific data model fits cleanly into the standardized `data` field of the `ToolResponse`.
 
 3. **Response Processing and Context Optimization**:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -148,6 +148,22 @@ To illustrate this pattern, the `__get_instructions__` tool returns a `ToolRespo
 
 This example demonstrates how a tool-specific data model fits cleanly into the standardized `data` field of the `ToolResponse`.
 
+This standardized model is flexible. For tools that return simpler data structures, like a list of items, the `data` field directly holds that list. For example, the `get_chains_list` tool returns a `ToolResponse[list[ChainInfo]]`, which serializes to the following clean JSON:
+
+```json
+{
+  "data": [
+    { "name": "Arbitrum One", "chain_id": 42161 },
+    { "name": "Base", "chain_id": 8453 },
+    { "name": "Ethereum", "chain_id": 1 }
+  ],
+  "data_description": null,
+  "notes": null,
+  "instructions": null,
+  "pagination": null
+}
+```
+
 3. **Response Processing and Context Optimization**:
 
    The server employs a comprehensive strategy to **conserve LLM context** by intelligently processing API responses before forwarding them to the MCP Host. This prevents overwhelming the LLM context window with excessive blockchain data, ensuring efficient tool selection and reasoning.

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -33,8 +33,8 @@ class LatestBlockData(BaseModel):
 
 
 # --- Models for __get_instructions__ Data Payload ---
-class RecommendedChain(BaseModel):
-    """Represents a popular blockchain with its essential identifiers."""
+class ChainInfo(BaseModel):
+    """Represents a blockchain with its essential identifiers."""
 
     name: str = Field(description="The common name of the blockchain (e.g., 'Ethereum').")
     chain_id: int = Field(description="The unique numeric identifier for the chain.")
@@ -47,7 +47,7 @@ class InstructionsData(BaseModel):
     general_rules: list[str] = Field(
         description="A list of general operational rules for interacting with this server."
     )
-    recommended_chains: list[RecommendedChain] = Field(
+    recommended_chains: list[ChainInfo] = Field(
         description="A list of popular chains with their names and IDs, useful for quick lookups."
     )
 

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -1,19 +1,20 @@
 from mcp.server.fastmcp import Context
 
+from blockscout_mcp_server.models import ChainInfo, ToolResponse
 from blockscout_mcp_server.tools.common import (
+    build_tool_response,
     make_chainscout_request,
     report_and_log_progress,
 )
 
 
-async def get_chains_list(ctx: Context) -> str:
+async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
     """
     Get the list of known blockchain chains with their IDs.
     Useful for getting a chain ID when the chain name is known. This information can be used in other tools that require a chain ID to request information.
     """  # noqa: E501
     api_path = "/api/chains/list"
 
-    # Report start of operation
     await report_and_log_progress(
         ctx,
         progress=0.0,
@@ -23,7 +24,6 @@ async def get_chains_list(ctx: Context) -> str:
 
     response_data = await make_chainscout_request(api_path=api_path)
 
-    # Report completion
     await report_and_log_progress(
         ctx,
         progress=1.0,
@@ -31,21 +31,15 @@ async def get_chains_list(ctx: Context) -> str:
         message="Successfully fetched chains list.",
     )
 
-    # Format the response as a text output
-    output_lines = ["The list of known chains with their ids:"]
-
-    # Check if response_data is a list and has entries
-    if isinstance(response_data, list) and response_data:
-        # Sort chains by name for better readability
+    chains: list[ChainInfo] = []
+    if isinstance(response_data, list):
         sorted_chains = sorted(response_data, key=lambda x: x.get("name", ""))
+        for item in sorted_chains:
+            if item.get("name") and item.get("chainid"):
+                try:
+                    chain_id = int(item["chainid"])
+                except (TypeError, ValueError):
+                    continue
+                chains.append(ChainInfo(name=item["name"], chain_id=chain_id))
 
-        for chain in sorted_chains:
-            name = chain.get("name")
-            chain_id = chain.get("chainid")
-            if name is not None and chain_id is not None:
-                output_lines.append(f"{name}: {chain_id}")
-    else:
-        output_lines.append("No chains found or invalid response format.")
-
-    # Join all lines with newlines
-    return "\n".join(output_lines)
+    return build_tool_response(data=chains)

--- a/blockscout_mcp_server/tools/get_instructions.py
+++ b/blockscout_mcp_server/tools/get_instructions.py
@@ -6,8 +6,8 @@ from blockscout_mcp_server.constants import (
     SERVER_VERSION,
 )
 from blockscout_mcp_server.models import (
+    ChainInfo,
     InstructionsData,
-    RecommendedChain,
     ToolResponse,
 )
 from blockscout_mcp_server.tools.common import build_tool_response, report_and_log_progress
@@ -31,7 +31,7 @@ async def __get_instructions__(ctx: Context) -> ToolResponse[InstructionsData]:
     instructions_data = InstructionsData(
         version=SERVER_VERSION,
         general_rules=GENERAL_RULES,
-        recommended_chains=[RecommendedChain(**chain) for chain in RECOMMENDED_CHAINS],
+        recommended_chains=[ChainInfo(**chain) for chain in RECOMMENDED_CHAINS],
     )
 
     # Report completion

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -1,19 +1,19 @@
 import pytest
 
+from blockscout_mcp_server.models import ToolResponse
 from blockscout_mcp_server.tools.chains_tools import get_chains_list
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_get_chains_list_integration(mock_ctx):
-    """Tests that get_chains_list returns a formatted string and contains known, stable chains."""
+    """Tests that get_chains_list returns structured data with expected chains."""
     result = await get_chains_list(ctx=mock_ctx)
 
-    # Assert that the result is a string and not empty
-    assert isinstance(result, str)
-    assert len(result) > 0
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, list)
+    assert len(result.data) > 0
 
-    # Assert that the output contains a well-known, stable chain entry.
-    # This verifies that the name and chainid fields were correctly extracted and formatted.
-    assert "Ethereum: 1" in result
-    assert "Polygon PoS: 137" in result
+    eth_chain = next((chain for chain in result.data if chain.name == "Ethereum"), None)
+    assert eth_chain is not None
+    assert eth_chain.chain_id == 1

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -17,3 +17,7 @@ async def test_get_chains_list_integration(mock_ctx):
     eth_chain = next((chain for chain in result.data if chain.name == "Ethereum"), None)
     assert eth_chain is not None
     assert eth_chain.chain_id == 1
+
+    polygon_chain = next((chain for chain in result.data if chain.name == "Polygon PoS"), None)
+    assert polygon_chain is not None
+    assert polygon_chain.chain_id == 137

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,10 +3,10 @@
 import json
 
 from blockscout_mcp_server.models import (
+    ChainInfo,
     InstructionsData,
     NextCallInfo,
     PaginationInfo,
-    RecommendedChain,
     ToolResponse,
 )
 
@@ -31,7 +31,7 @@ def test_tool_response_complex_data():
     instructions_data = InstructionsData(
         version="1.0.0",
         general_rules=["Rule 1"],
-        recommended_chains=[RecommendedChain(name="TestChain", chain_id=123)],
+        recommended_chains=[ChainInfo(name="TestChain", chain_id=123)],
     )
     response = ToolResponse[InstructionsData](data=instructions_data)
     assert response.data.version == "1.0.0"
@@ -72,16 +72,16 @@ def test_pagination_info():
     assert pagination_info.next_call.params["param"] == "value"
 
 
-def test_recommended_chain():
-    """Test RecommendedChain model."""
-    chain = RecommendedChain(name="Ethereum", chain_id=1)
+def test_chain_info():
+    """Test ChainInfo model."""
+    chain = ChainInfo(name="Ethereum", chain_id=1)
     assert chain.name == "Ethereum"
     assert chain.chain_id == 1
 
 
 def test_instructions_data():
     """Test InstructionsData model."""
-    chains = [RecommendedChain(name="Ethereum", chain_id=1), RecommendedChain(name="Polygon", chain_id=137)]
+    chains = [ChainInfo(name="Ethereum", chain_id=1), ChainInfo(name="Polygon", chain_id=137)]
     instructions = InstructionsData(version="2.0.0", general_rules=["Rule 1", "Rule 2"], recommended_chains=chains)
     assert instructions.version == "2.0.0"
     assert len(instructions.general_rules) == 2

--- a/tests/tools/test_chains_tools.py
+++ b/tests/tools/test_chains_tools.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from blockscout_mcp_server.models import ChainInfo, ToolResponse
 from blockscout_mcp_server.tools.chains_tools import get_chains_list
 
 
@@ -19,8 +20,10 @@ async def test_get_chains_list_success(mock_ctx):
         {"name": "Polygon PoS", "chainid": "137"},
     ]
 
-    # This is the expected string output from the tool function.
-    expected_output = "The list of known chains with their ids:\nEthereum: 1\nPolygon PoS: 137"
+    expected_data = [
+        ChainInfo(name="Ethereum", chain_id=1),
+        ChainInfo(name="Polygon PoS", chain_id=137),
+    ]
 
     # Use `patch` to replace the real `make_chainscout_request` with our mock.
     # The string points to where the function is *used*.
@@ -38,8 +41,8 @@ async def test_get_chains_list_success(mock_ctx):
         # Was the API helper called correctly?
         mock_request.assert_called_once_with(api_path="/api/chains/list")
 
-        # Did the function return the correctly formatted string?
-        assert result == expected_output
+        assert isinstance(result, ToolResponse)
+        assert result.data == expected_data
 
         # Was progress reported correctly? (Check the number of calls)
         assert mock_ctx.report_progress.call_count == 2
@@ -55,7 +58,7 @@ async def test_get_chains_list_empty_response(mock_ctx):
 
     # Empty response
     mock_api_response = []
-    expected_output = "The list of known chains with their ids:\nNo chains found or invalid response format."
+    expected_data: list[ChainInfo] = []
 
     with patch(
         "blockscout_mcp_server.tools.chains_tools.make_chainscout_request", new_callable=AsyncMock
@@ -67,7 +70,8 @@ async def test_get_chains_list_empty_response(mock_ctx):
 
         # ASSERT
         mock_request.assert_called_once_with(api_path="/api/chains/list")
-        assert result == expected_output
+        assert isinstance(result, ToolResponse)
+        assert result.data == expected_data
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
 
@@ -81,7 +85,7 @@ async def test_get_chains_list_invalid_response_format(mock_ctx):
 
     # Invalid response (not a list)
     mock_api_response = {"error": "Invalid data"}
-    expected_output = "The list of known chains with their ids:\nNo chains found or invalid response format."
+    expected_data: list[ChainInfo] = []
 
     with patch(
         "blockscout_mcp_server.tools.chains_tools.make_chainscout_request", new_callable=AsyncMock
@@ -93,7 +97,8 @@ async def test_get_chains_list_invalid_response_format(mock_ctx):
 
         # ASSERT
         mock_request.assert_called_once_with(api_path="/api/chains/list")
-        assert result == expected_output
+        assert isinstance(result, ToolResponse)
+        assert result.data == expected_data
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
 
@@ -115,7 +120,10 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
     ]
 
     # Only valid entries should appear in output
-    expected_output = "The list of known chains with their ids:\nEthereum: 1\nPolygon PoS: 137"
+    expected_data = [
+        ChainInfo(name="Ethereum", chain_id=1),
+        ChainInfo(name="Polygon PoS", chain_id=137),
+    ]
 
     with patch(
         "blockscout_mcp_server.tools.chains_tools.make_chainscout_request", new_callable=AsyncMock
@@ -127,7 +135,8 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
 
         # ASSERT
         mock_request.assert_called_once_with(api_path="/api/chains/list")
-        assert result == expected_output
+        assert isinstance(result, ToolResponse)
+        assert result.data == expected_data
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
 


### PR DESCRIPTION
## Summary
- rename RecommendedChain model to ChainInfo
- use ChainInfo in instructions tool and tests
- update get_chains_list to return ToolResponse with ChainInfo objects
- adjust unit & integration tests for new response
- document ToolResponse list example in SPEC

Closes #77

------
https://chatgpt.com/codex/tasks/task_b_685c7043406c8323ae80a9d46a8fec87