### PR TITLE
Refactor get_contract_abi Tool

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -52,6 +52,13 @@ class InstructionsData(BaseModel):
     )
 
 
+# --- Model for get_contract_abi Data Payload ---
+class ContractAbiData(BaseModel):
+    """A structured representation of a smart contract's ABI."""
+
+    abi: list | None = Field(description="The Application Binary Interface (ABI) of the smart contract.")
+
+
 # --- The Main Standardized Response Model ---
 class ToolResponse(BaseModel, Generic[T]):
     """A standardized, structured response for all MCP tools, generic over the data payload type."""

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -58,7 +58,7 @@ class ContractAbiData(BaseModel):
 
     abi: list | None = Field(description="The Application Binary Interface (ABI) of the smart contract.")
 
-      
+
 # --- Models for get_address_info Data Payload ---
 class AddressInfoData(BaseModel):
     """A structured representation of the combined address information."""

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -3,7 +3,9 @@ from typing import Annotated
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
+from blockscout_mcp_server.models import ContractAbiData, ToolResponse
 from blockscout_mcp_server.tools.common import (
+    build_tool_response,
     get_blockscout_base_url,
     make_blockscout_request,
     report_and_log_progress,
@@ -14,7 +16,7 @@ async def get_contract_abi(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     address: Annotated[str, Field(description="Smart contract address")],
     ctx: Context,
-) -> dict:
+) -> ToolResponse[ContractAbiData]:
     """
     Get smart contract ABI (Application Binary Interface).
     An ABI defines all functions, events, their parameters, and return types. The ABI is required to format function calls or interpret contract data.
@@ -49,5 +51,7 @@ async def get_contract_abi(
         message="Successfully fetched contract ABI.",
     )
 
-    # Extract the ABI from the response as per responseTemplate: {"abi": "{{.abi}}"}
-    return {"abi": response_data.get("abi")}
+    # Extract the ABI from the response and wrap it in a ToolResponse
+    abi_data = ContractAbiData(abi=response_data.get("abi"))
+
+    return build_tool_response(data=abi_data)

--- a/tests/integration/test_contract_tools_integration.py
+++ b/tests/integration/test_contract_tools_integration.py
@@ -1,5 +1,6 @@
 import pytest
 
+from blockscout_mcp_server.models import ContractAbiData, ToolResponse
 from blockscout_mcp_server.tools.contract_tools import get_contract_abi
 
 
@@ -10,6 +11,7 @@ async def test_get_contract_abi_integration(mock_ctx):
     address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     result = await get_contract_abi(chain_id="1", address=address, ctx=mock_ctx)
 
-    assert isinstance(result, dict)
-    assert "abi" in result and isinstance(result["abi"], list)
-    assert len(result["abi"]) > 0
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, ContractAbiData)
+    assert isinstance(result.data.abi, list)
+    assert len(result.data.abi) > 0

--- a/tests/tools/test_contract_tools.py
+++ b/tests/tools/test_contract_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from blockscout_mcp_server.models import ContractAbiData, ToolResponse
 from blockscout_mcp_server.tools.contract_tools import get_contract_abi
 
 
@@ -17,50 +18,32 @@ async def test_get_contract_abi_success(mock_ctx):
     address = "0xa0b86a33e6dd0ba3c70de3b8e2b9e48cd6efb7b0"
     mock_base_url = "https://eth.blockscout.com"
 
-    mock_api_response = {
-        "abi": [
-            {
-                "inputs": [],
-                "name": "symbol",
-                "outputs": [{"internalType": "string", "name": "", "type": "string"}],
-                "stateMutability": "view",
-                "type": "function",
-            },
-            {
-                "inputs": [],
-                "name": "name",
-                "outputs": [{"internalType": "string", "name": "", "type": "string"}],
-                "stateMutability": "view",
-                "type": "function",
-            },
-        ]
-    }
-
-    expected_result = {
-        "abi": [
-            {
-                "inputs": [],
-                "name": "symbol",
-                "outputs": [{"internalType": "string", "name": "", "type": "string"}],
-                "stateMutability": "view",
-                "type": "function",
-            },
-            {
-                "inputs": [],
-                "name": "name",
-                "outputs": [{"internalType": "string", "name": "", "type": "string"}],
-                "stateMutability": "view",
-                "type": "function",
-            },
-        ]
-    }
+    mock_abi_list = [
+        {
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+        {
+            "inputs": [],
+            "name": "name",
+            "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+    ]
+    mock_api_response = {"abi": mock_abi_list}
 
     with (
         patch(
-            "blockscout_mcp_server.tools.contract_tools.get_blockscout_base_url", new_callable=AsyncMock
+            "blockscout_mcp_server.tools.contract_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
         ) as mock_get_url,
         patch(
-            "blockscout_mcp_server.tools.contract_tools.make_blockscout_request", new_callable=AsyncMock
+            "blockscout_mcp_server.tools.contract_tools.make_blockscout_request",
+            new_callable=AsyncMock,
         ) as mock_request,
     ):
         mock_get_url.return_value = mock_base_url
@@ -72,7 +55,9 @@ async def test_get_contract_abi_success(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, ContractAbiData)
+        assert result.data.abi == mock_abi_list
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
@@ -88,7 +73,6 @@ async def test_get_contract_abi_missing_abi_field(mock_ctx):
     mock_base_url = "https://eth.blockscout.com"
 
     mock_api_response = {}  # No abi field
-    expected_result = {"abi": None}
 
     with (
         patch(
@@ -107,7 +91,9 @@ async def test_get_contract_abi_missing_abi_field(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, ContractAbiData)
+        assert result.data.abi is None
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
@@ -123,7 +109,6 @@ async def test_get_contract_abi_empty_abi(mock_ctx):
     mock_base_url = "https://eth.blockscout.com"
 
     mock_api_response = {"abi": []}
-    expected_result = {"abi": []}
 
     with (
         patch(
@@ -142,7 +127,9 @@ async def test_get_contract_abi_empty_abi(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, ContractAbiData)
+        assert result.data.abi == []
         assert mock_ctx.report_progress.call_count == 3
 
 
@@ -274,35 +261,7 @@ async def test_get_contract_abi_complex_abi(mock_ctx):
         ]
     }
 
-    expected_result = {
-        "abi": [
-            {
-                "inputs": [{"internalType": "string", "name": "_name", "type": "string"}],
-                "stateMutability": "nonpayable",
-                "type": "constructor",
-            },
-            {
-                "anonymous": False,
-                "inputs": [
-                    {"indexed": True, "internalType": "address", "name": "from", "type": "address"},
-                    {"indexed": True, "internalType": "address", "name": "to", "type": "address"},
-                    {"indexed": False, "internalType": "uint256", "name": "value", "type": "uint256"},
-                ],
-                "name": "Transfer",
-                "type": "event",
-            },
-            {
-                "inputs": [
-                    {"internalType": "address", "name": "to", "type": "address"},
-                    {"internalType": "uint256", "name": "amount", "type": "uint256"},
-                ],
-                "name": "transfer",
-                "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
-                "stateMutability": "nonpayable",
-                "type": "function",
-            },
-        ]
-    }
+    mock_abi_list = mock_api_response["abi"]
 
     with (
         patch(
@@ -321,5 +280,7 @@ async def test_get_contract_abi_complex_abi(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, ContractAbiData)
+        assert result.data.abi == mock_abi_list
         assert mock_ctx.report_progress.call_count == 3

--- a/tests/tools/test_contract_tools.py
+++ b/tests/tools/test_contract_tools.py
@@ -8,6 +8,13 @@ from blockscout_mcp_server.models import ContractAbiData, ToolResponse
 from blockscout_mcp_server.tools.contract_tools import get_contract_abi
 
 
+def assert_contract_abi_response(result: ToolResponse, expected_abi) -> None:
+    """Verify the wrapper structure and ABI data."""
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, ContractAbiData)
+    assert result.data.abi == expected_abi
+
+
 @pytest.mark.asyncio
 async def test_get_contract_abi_success(mock_ctx):
     """
@@ -55,9 +62,7 @@ async def test_get_contract_abi_success(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert isinstance(result, ToolResponse)
-        assert isinstance(result.data, ContractAbiData)
-        assert result.data.abi == mock_abi_list
+        assert_contract_abi_response(result, mock_abi_list)
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
@@ -91,9 +96,7 @@ async def test_get_contract_abi_missing_abi_field(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert isinstance(result, ToolResponse)
-        assert isinstance(result.data, ContractAbiData)
-        assert result.data.abi is None
+        assert_contract_abi_response(result, None)
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
@@ -127,9 +130,7 @@ async def test_get_contract_abi_empty_abi(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert isinstance(result, ToolResponse)
-        assert isinstance(result.data, ContractAbiData)
-        assert result.data.abi == []
+        assert_contract_abi_response(result, [])
         assert mock_ctx.report_progress.call_count == 3
 
 
@@ -280,7 +281,5 @@ async def test_get_contract_abi_complex_abi(mock_ctx):
         # ASSERT
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
-        assert isinstance(result, ToolResponse)
-        assert isinstance(result.data, ContractAbiData)
-        assert result.data.abi == mock_abi_list
+        assert_contract_abi_response(result, mock_abi_list)
         assert mock_ctx.report_progress.call_count == 3


### PR DESCRIPTION
## Summary
- add `ContractAbiData` model
- refactor `get_contract_abi` to return `ToolResponse`
- update unit and integration tests for new response model

Closes #79

------
https://chatgpt.com/codex/tasks/task_b_685c750efa008323a0333cf04a4be240