### PR TITLE
Refactor ENS name resolution tool

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -70,6 +70,16 @@ class AddressInfoData(BaseModel):
     )
 
 
+# --- Model for get_address_by_ens_name Data Payload ---
+class EnsAddressData(BaseModel):
+    """A structured representation of an ENS name resolution."""
+
+    resolved_address: str | None = Field(
+        None,
+        description=("The resolved Ethereum address corresponding to the ENS name, or null if not found."),
+    )
+
+
 # --- The Main Standardized Response Model ---
 class ToolResponse(BaseModel, Generic[T]):
     """A standardized, structured response for all MCP tools, generic over the data payload type."""

--- a/blockscout_mcp_server/tools/ens_tools.py
+++ b/blockscout_mcp_server/tools/ens_tools.py
@@ -3,7 +3,9 @@ from typing import Annotated
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
+from blockscout_mcp_server.models import EnsAddressData, ToolResponse
 from blockscout_mcp_server.tools.common import (
+    build_tool_response,
     make_bens_request,
     report_and_log_progress,
 )
@@ -11,7 +13,7 @@ from blockscout_mcp_server.tools.common import (
 
 async def get_address_by_ens_name(
     name: Annotated[str, Field(description="ENS domain name to resolve")], ctx: Context
-) -> dict:
+) -> ToolResponse[EnsAddressData]:
     """
     Useful for when you need to convert an ENS domain name (e.g. "blockscout.eth")
     to its corresponding Ethereum address.
@@ -38,6 +40,7 @@ async def get_address_by_ens_name(
 
     # Extract data as per responseTemplate: {"resolved_address": "{{.resolved_address.hash}}"}
     resolved_address_info = response_data.get("resolved_address", {})
-    address_hash = resolved_address_info.get("hash")
+    address_hash = resolved_address_info.get("hash") if resolved_address_info else None
+    ens_data = EnsAddressData(resolved_address=address_hash)
 
-    return {"resolved_address": address_hash}
+    return build_tool_response(data=ens_data)

--- a/tests/integration/test_ens_tools_integration.py
+++ b/tests/integration/test_ens_tools_integration.py
@@ -1,5 +1,6 @@
 import pytest
 
+from blockscout_mcp_server.models import EnsAddressData, ToolResponse
 from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
 
 
@@ -8,6 +9,7 @@ from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
 async def test_get_address_by_ens_name_integration(mock_ctx):
     result = await get_address_by_ens_name(name="vitalik.eth", ctx=mock_ctx)
 
-    assert isinstance(result, dict)
-    assert "resolved_address" in result
-    assert result["resolved_address"].lower() == "0xd8da6bf26964af9d7eed9e03e53415d37aa96045".lower()
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, EnsAddressData)
+    assert result.data.resolved_address is not None
+    assert result.data.resolved_address.lower() == "0xd8da6bf26964af9d7eed9e03e53415d37aa96045".lower()

--- a/tests/tools/test_ens_tools.py
+++ b/tests/tools/test_ens_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from blockscout_mcp_server.models import EnsAddressData, ToolResponse
 from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
 
 
@@ -26,7 +27,9 @@ async def test_get_address_by_ens_name_success(mock_ctx):
 
         # ASSERT
         mock_request.assert_called_once_with(api_path=f"/api/v1/1/domains/{ens_name}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, EnsAddressData)
+        assert result.data.resolved_address == expected_result["resolved_address"]
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
 
@@ -40,7 +43,6 @@ async def test_get_address_by_ens_name_missing_resolved_address(mock_ctx):
     ens_name = "nonexistent.eth"
 
     mock_api_response = {}  # No resolved_address field
-    expected_result = {"resolved_address": None}
 
     with patch("blockscout_mcp_server.tools.ens_tools.make_bens_request", new_callable=AsyncMock) as mock_request:
         mock_request.return_value = mock_api_response
@@ -50,7 +52,9 @@ async def test_get_address_by_ens_name_missing_resolved_address(mock_ctx):
 
         # ASSERT
         mock_request.assert_called_once_with(api_path=f"/api/v1/1/domains/{ens_name}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, EnsAddressData)
+        assert result.data.resolved_address is None
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
 
@@ -66,7 +70,6 @@ async def test_get_address_by_ens_name_missing_hash(mock_ctx):
     mock_api_response = {
         "resolved_address": {}  # No hash field
     }
-    expected_result = {"resolved_address": None}
 
     with patch("blockscout_mcp_server.tools.ens_tools.make_bens_request", new_callable=AsyncMock) as mock_request:
         mock_request.return_value = mock_api_response
@@ -76,7 +79,9 @@ async def test_get_address_by_ens_name_missing_hash(mock_ctx):
 
         # ASSERT
         mock_request.assert_called_once_with(api_path=f"/api/v1/1/domains/{ens_name}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, EnsAddressData)
+        assert result.data.resolved_address is None
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
 
@@ -120,7 +125,9 @@ async def test_get_address_by_ens_name_with_special_characters(mock_ctx):
 
         # ASSERT
         mock_request.assert_called_once_with(api_path=f"/api/v1/1/domains/{ens_name}")
-        assert result == expected_result
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, EnsAddressData)
+        assert result.data.resolved_address == expected_result["resolved_address"]
         assert mock_ctx.report_progress.call_count == 2
 
 


### PR DESCRIPTION
## Summary
- add `EnsAddressData` model for structured ENS lookup response
- update `get_address_by_ens_name` to return `ToolResponse` using the new model
- adjust unit and integration tests for the new response type

Closes #81

------
https://chatgpt.com/codex/tasks/task_b_685c876112dc8323b88349a9e9b0948a