### PR TITLE
Refactor `lookup_token_by_symbol` to return structured response

### DIFF
--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -206,20 +206,47 @@ extracted_data = {
 return build_tool_response(data=extracted_data)
 ```
 
-#### 3. Process JSON Arrays (`return_type: ToolResponse[list[dict]]`)
+#### 3. Process JSON Arrays with a Specific Item Model (`return_type: ToolResponse[list[MyItemModel]]`)
 
-Use when iterating through items and formatting each one:
+Use when iterating through items and formatting each one into a specific Pydantic model. This is the preferred pattern over returning a generic `list[dict]`.
+
+**Example: `lookup_token_by_symbol`**
 
 ```python
-items = response_data.get("items", [])
-formatted_items = []
-for item in items:
-    formatted_items.append({
-        "id": item.get("id"),
-        "name": item.get("name"),
-        # Other fields to extract
-    })
-return build_tool_response(data=formatted_items)
+from blockscout_mcp_server.models import ToolResponse, TokenSearchResult # Specific model
+from blockscout_mcp_server.tools.common import build_tool_response
+
+# In a real scenario, TokenSearchResult would be in `models.py`
+# class TokenSearchResult(BaseModel):
+#     address: str
+#     name: str
+#     ...
+
+async def lookup_token_by_symbol(
+    chain_id: str, symbol: str
+) -> ToolResponse[list[TokenSearchResult]]: # Note the specific return type
+    """Search for token addresses by symbol or name."""
+    response_data = await make_blockscout_request(...) # API call
+
+    items = response_data.get("items", [])
+    
+    # Create a list of strongly-typed Pydantic objects
+    search_results = []
+    for item in items:
+        search_results.append(
+            TokenSearchResult(
+                address=item.get("address_hash", ""),
+                name=item.get("name", ""),
+                # ... other fields
+            )
+        )
+    
+    # Optionally add notes, for example, about truncation
+    notes = None
+    if len(items) > SOME_LIMIT:
+        notes = ["Result list was truncated."]
+
+    return build_tool_response(data=search_results, notes=notes)
 ```
 
 #### 4. Using a Specific Data Model for the Payload (`return_type: ToolResponse[MyDataModel]`)

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -59,6 +59,21 @@ class ContractAbiData(BaseModel):
     abi: list | None = Field(description="The Application Binary Interface (ABI) of the smart contract.")
 
 
+# --- Model for lookup_token_by_symbol Data Payload ---
+class TokenSearchResult(BaseModel):
+    """Represents a single token found by a search query."""
+
+    address: str = Field(description="The contract address of the token.")
+    name: str = Field(description="The full name of the token (e.g., 'USD Coin').")
+    symbol: str = Field(description="The symbol of the token (e.g., 'USDC').")
+    token_type: str = Field(description="The token standard (e.g., 'ERC-20').")
+    total_supply: str = Field(description="The total supply of the token.")
+    circulating_market_cap: str | None = Field(description="The circulating market cap, if available.")
+    exchange_rate: str | None = Field(description="The current exchange rate, if available.")
+    is_smart_contract_verified: bool = Field(description="Indicates if the token's contract is verified.")
+    is_verified_via_admin_panel: bool = Field(description="Indicates if the token is verified by the Blockscout team.")
+
+
 # --- Models for get_address_info Data Payload ---
 class AddressInfoData(BaseModel):
     """A structured representation of the combined address information."""

--- a/blockscout_mcp_server/tools/search_tools.py
+++ b/blockscout_mcp_server/tools/search_tools.py
@@ -3,7 +3,9 @@ from typing import Annotated
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
+from blockscout_mcp_server.models import TokenSearchResult, ToolResponse
 from blockscout_mcp_server.tools.common import (
+    build_tool_response,
     get_blockscout_base_url,
     make_blockscout_request,
     report_and_log_progress,
@@ -17,7 +19,7 @@ async def lookup_token_by_symbol(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     symbol: Annotated[str, Field(description="Token symbol or name to search for")],
     ctx: Context,
-) -> list[dict]:
+) -> ToolResponse[list[TokenSearchResult]]:
     """
     Search for token addresses by symbol or name. Returns multiple potential
     matches based on symbol or token name similarity. Only the first
@@ -54,22 +56,32 @@ async def lookup_token_by_symbol(
         message="Successfully completed token search.",
     )
 
-    # Extract and format items from the response
-    items = response_data.get("items", [])[:TOKEN_RESULTS_LIMIT]
-    formatted_items = []
+    all_items = response_data.get("items", [])
+    notes = None
 
-    for item in items:
-        formatted_item = {
-            "address": item.get("address_hash", ""),
-            "name": item.get("name", ""),
-            "symbol": item.get("symbol", ""),
-            "token_type": item.get("token_type", ""),
-            "total_supply": item.get("total_supply", ""),
-            "circulating_market_cap": item.get("circulating_market_cap", ""),
-            "exchange_rate": item.get("exchange_rate", ""),
-            "is_smart_contract_verified": item.get("is_smart_contract_verified", False),
-            "is_verified_via_admin_panel": item.get("is_verified_via_admin_panel", False),
-        }
-        formatted_items.append(formatted_item)
+    if len(all_items) > TOKEN_RESULTS_LIMIT:
+        notes = [
+            (
+                f"The number of results exceeds the limit of {TOKEN_RESULTS_LIMIT}. "
+                f"Only the first {TOKEN_RESULTS_LIMIT} are shown."
+            )
+        ]
 
-    return formatted_items
+    items_to_process = all_items[:TOKEN_RESULTS_LIMIT]
+
+    search_results = [
+        TokenSearchResult(
+            address=item.get("address_hash", ""),
+            name=item.get("name", ""),
+            symbol=item.get("symbol", ""),
+            token_type=item.get("token_type", ""),
+            total_supply=item.get("total_supply", ""),
+            circulating_market_cap=item.get("circulating_market_cap"),
+            exchange_rate=item.get("exchange_rate"),
+            is_smart_contract_verified=item.get("is_smart_contract_verified", False),
+            is_verified_via_admin_panel=item.get("is_verified_via_admin_panel", False),
+        )
+        for item in items_to_process
+    ]
+
+    return build_tool_response(data=search_results, notes=notes)

--- a/tests/integration/test_search_tools_integration.py
+++ b/tests/integration/test_search_tools_integration.py
@@ -1,6 +1,7 @@
 import pytest
 
-from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
+from blockscout_mcp_server.models import TokenSearchResult, ToolResponse
+from blockscout_mcp_server.tools.search_tools import TOKEN_RESULTS_LIMIT, lookup_token_by_symbol
 
 
 @pytest.mark.integration
@@ -8,8 +9,16 @@ from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
 async def test_lookup_token_by_symbol_integration(mock_ctx):
     result = await lookup_token_by_symbol(chain_id="1", symbol="USDC", ctx=mock_ctx)
 
-    assert isinstance(result, list) and len(result) > 0
-    first_item = result[0]
-    assert "address" in first_item and first_item["address"].startswith("0x")
-    assert "name" in first_item and isinstance(first_item["name"], str)
-    assert "symbol" in first_item and isinstance(first_item["symbol"], str)
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, list)
+
+    if result.data:
+        assert isinstance(result.data[0], TokenSearchResult)
+        assert result.data[0].address.startswith("0x")
+        assert isinstance(result.data[0].name, str)
+
+    if len(result.data) == TOKEN_RESULTS_LIMIT:
+        assert result.notes is not None
+        assert f"exceeds the limit of {TOKEN_RESULTS_LIMIT}" in result.notes[0]
+    else:
+        assert result.notes is None

--- a/tests/integration/test_search_tools_integration.py
+++ b/tests/integration/test_search_tools_integration.py
@@ -17,8 +17,7 @@ async def test_lookup_token_by_symbol_integration(mock_ctx):
         assert result.data[0].address.startswith("0x")
         assert isinstance(result.data[0].name, str)
 
-    if len(result.data) == TOKEN_RESULTS_LIMIT:
-        assert result.notes is not None
-        assert f"exceeds the limit of {TOKEN_RESULTS_LIMIT}" in result.notes[0]
-    else:
+    if len(result.data) < TOKEN_RESULTS_LIMIT:
         assert result.notes is None
+    elif result.notes is not None:
+        assert f"exceeds the limit of {TOKEN_RESULTS_LIMIT}" in result.notes[0]


### PR DESCRIPTION
## Summary
- define `TokenSearchResult` model
- return `ToolResponse[list[TokenSearchResult]]` from `lookup_token_by_symbol`
- update unit and integration tests for structured response
- document new list processing pattern in docs

Closes #82

------
https://chatgpt.com/codex/tasks/task_b_685c87a006e483239cb164e43e48644a