### PR TITLE
Refactor transaction_summary to return structured response

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -95,6 +95,16 @@ class EnsAddressData(BaseModel):
     )
 
 
+# --- Model for transaction_summary Data Payload ---
+class TransactionSummaryData(BaseModel):
+    """A structured representation of a transaction summary."""
+
+    summary: str | None = Field(
+        None,
+        description="The human-readable summary of the transaction, or null if no summary is available.",
+    )
+
+
 # --- Models for get_transaction_info Data Payload ---
 class TokenTransfer(BaseModel):
     """Represents a single token transfer within a transaction."""

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -5,7 +5,12 @@ import httpx
 import pytest
 
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT, LOG_DATA_TRUNCATION_LIMIT
-from blockscout_mcp_server.models import TokenTransfer, ToolResponse, TransactionInfoData
+from blockscout_mcp_server.models import (
+    TokenTransfer,
+    ToolResponse,
+    TransactionInfoData,
+    TransactionSummaryData,
+)
 from blockscout_mcp_server.tools.common import get_blockscout_base_url
 from blockscout_mcp_server.tools.transaction_tools import (
     get_token_transfers_by_address,
@@ -30,14 +35,14 @@ async def test_transaction_summary_integration(mock_ctx):
     tx_hash = "0x5c7f2f244d91ec281c738393da0be6a38bc9045e29c0566da8c11e7a2f7cbc64"
     result = await transaction_summary(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
 
-    # Assert that the result is a non-empty string
-    assert isinstance(result, str)
-    assert len(result) > 0
+    # Assert that the tool returns a structured response
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, TransactionSummaryData)
 
-    # Assert that the tool's formatting prefix is present. This confirms
-    # that the tool successfully extracted the summary data and proceeded
-    # with formatting, rather than returning "No summary available."
-    assert "# Transaction Summary from Blockscout Transaction Interpreter" in result
+    # The summary can be a string or None
+    assert isinstance(result.data.summary, str | type(None))
+    if isinstance(result.data.summary, str):
+        assert len(result.data.summary) > 0
 
 
 @pytest.mark.integration

--- a/tests/tools/test_transaction_tools.py
+++ b/tests/tools/test_transaction_tools.py
@@ -448,3 +448,40 @@ async def test_transaction_summary_no_summary_available(mock_ctx):
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/transactions/{tx_hash}/summary")
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_transaction_summary_handles_non_string_summary(mock_ctx):
+    """Verify transaction_summary correctly handles a non-string summary."""
+    # ARRANGE
+    chain_id = "1"
+    tx_hash = "0xcomplex"
+    mock_base_url = "https://eth.blockscout.com"
+
+    complex_summary = ["First part of summary.", "Second part of summary."]
+    mock_api_response = {"data": {"summaries": complex_summary}}
+
+    with (
+        patch(
+            "blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request",
+            new_callable=AsyncMock,
+        ) as mock_request,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_api_response
+
+        # ACT
+        result = await transaction_summary(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
+
+        # ASSERT
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data, TransactionSummaryData)
+        assert result.data.summary == '["First part of summary.", "Second part of summary."]'
+        mock_get_url.assert_called_once_with(chain_id)
+        mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/transactions/{tx_hash}/summary")
+        assert mock_ctx.report_progress.call_count == 3
+        assert mock_ctx.info.call_count == 3


### PR DESCRIPTION
## Summary
- add `TransactionSummaryData` model
- return structured `ToolResponse` from `transaction_summary`
- adjust tests for new data model

Closes #88

------
https://chatgpt.com/codex/tasks/task_b_685edfbdf3188323b709be328c1df3d9