### PR TITLE
Use common dockerSetup job, add deploy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
   IMAGE_NAME: blockscout/mcp-server
 
 jobs:
-  push:
+  build-and-push:
     name: Docker build and docker push
     timeout-minutes: 30
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/main.yml` to improve the Docker image build and deployment process. Key changes include renaming and restructuring the build job, enhancing multi-platform support, introducing regex-based tag extraction, and adding a new deployment stage for staging instances.

### Workflow Enhancements:

* **Job Renaming and Restructuring**: The `build-docker-image` job was renamed to `build-and-push`, with updated steps for repository checkout, regex-based tag extraction, and multi-platform Docker image building.
* **Multi-Platform Docker Builds**: Added support for `linux/amd64` and `linux/arm64/v8` platforms, along with advanced caching options (`cache-to: type=gha,mode=max`).
* **Regex-Based Tag Extraction**: Implemented a regex match step to extract tag names or branch names for Docker image tagging. This ensures dynamic and accurate tagging based on the GitHub reference.

### Deployment Additions:

* **New Deployment Stage**: Introduced a `deploy_stage` job that triggers the deployment of a staging instance if the workflow runs on the `main` branch. This includes fetching Vault credentials and triggering another workflow for deployment.