### PR TITLE
Refactor transaction_summary to retain structured list

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -100,9 +100,12 @@ class EnsAddressData(BaseModel):
 class TransactionSummaryData(BaseModel):
     """A structured representation of a transaction summary."""
 
-    summary: str | None = Field(
+    summary: list | None = Field(
         None,
-        description="The human-readable summary of the transaction, or null if no summary is available.",
+        description=(
+            "List of summary objects for generating human-readable transaction descriptions, "
+            "or null if no summary data is available."
+        ),
     )
 
 

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -324,8 +324,6 @@ async def transaction_summary(
     await report_and_log_progress(ctx, progress=2.0, total=2.0, message="Successfully fetched transaction summary.")
 
     summary = response_data.get("data", {}).get("summaries")
-    if summary is not None and not isinstance(summary, str):
-        summary = json.dumps(summary)
 
     summary_data = TransactionSummaryData(summary=summary)
 

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -39,9 +39,9 @@ async def test_transaction_summary_integration(mock_ctx):
     assert isinstance(result, ToolResponse)
     assert isinstance(result.data, TransactionSummaryData)
 
-    # The summary can be a string or None
-    assert isinstance(result.data.summary, str | type(None))
-    if isinstance(result.data.summary, str):
+    # The summary can be a list or None.
+    assert isinstance(result.data.summary, list | type(None))
+    if isinstance(result.data.summary, list):
         assert len(result.data.summary) > 0
 
 

--- a/tests/tools/test_transaction_tools.py
+++ b/tests/tools/test_transaction_tools.py
@@ -385,7 +385,7 @@ async def test_transaction_summary_without_wrapper(mock_ctx):
     mock_base_url = "https://eth.blockscout.com"
 
     summary_text = "This is a test transaction summary."
-    mock_api_response = {"data": {"summaries": summary_text}}
+    mock_api_response = {"data": {"summaries": [summary_text]}}
 
     with (
         patch(
@@ -404,7 +404,7 @@ async def test_transaction_summary_without_wrapper(mock_ctx):
         # ASSERT
         assert isinstance(result, ToolResponse)
         assert isinstance(result.data, TransactionSummaryData)
-        assert result.data.summary == summary_text
+        assert result.data.summary == [summary_text]
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/transactions/{tx_hash}/summary")
 
@@ -480,7 +480,7 @@ async def test_transaction_summary_handles_non_string_summary(mock_ctx):
         # ASSERT
         assert isinstance(result, ToolResponse)
         assert isinstance(result.data, TransactionSummaryData)
-        assert result.data.summary == '["First part of summary.", "Second part of summary."]'
+        assert result.data.summary == complex_summary  # Assert it's the original list
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/transactions/{tx_hash}/summary")
         assert mock_ctx.report_progress.call_count == 3


### PR DESCRIPTION
## Summary
- update TransactionSummaryData model to return a list
- simplify transaction_summary logic
- adjust unit/integration tests for new summary type

Closes #100

------
https://chatgpt.com/codex/tasks/task_b_6862f12710d08323ad5ff55c218288fa