### PR TITLE
Refactor get_transaction_logs output

### DIFF
--- a/.cursor/rules/210-unit-testing-guidelines.mdc
+++ b/.cursor/rules/210-unit-testing-guidelines.mdc
@@ -38,33 +38,6 @@ For tools that return a `ToolResponse` object containing structured data, **DO N
 
 However, the approach depends on the complexity of the tool.
 
-#### The Simple Case: One Serialization Call
-
-If the tool under test is the only function calling `json.dumps`, the approach is straightforward.
-
-**Correct Usage:**
-```python
-# In a test for a tool like get_transaction_logs
-from unittest.mock import patch, AsyncMock
-from blockscout_mcp_server.models import ToolResponse
-
-@pytest.mark.asyncio
-async def test_get_transaction_logs_correctly_prepares_json(mock_ctx):
-    # ... (Arrange mocks for API calls)
-    mock_api_response = {"items": [...]} 
-
-    # Patch json.dumps where it is used in the tool's module
-    with patch('blockscout_mcp_server.tools.transaction_tools.json.dumps') as mock_json_dumps:
-        mock_json_dumps.return_value = '{"fake_json": true}'  # Return value doesn't matter
-
-        # ACT
-        result = await get_transaction_logs(..., ctx=mock_ctx)
-
-        # ASSERT
-        # Verify that the tool returned a ToolResponse with the correct data
-        assert isinstance(result, ToolResponse)
-        assert result.data == mock_api_response
-```
 
 
 ### C. Handling Repetitive Data in Assertions (DAMP vs. DRY)

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -216,7 +216,7 @@ class NftCollectionHolding(BaseModel):
     )
 
 
-# --- Models for Log Items ---
+# --- Model for get_address_logs Data Payload ---
 class LogItemShort(BaseModel):
     """Represents a single log item, optimized for context when the address is redundant."""
 
@@ -237,6 +237,7 @@ class LogItemShort(BaseModel):
     )
 
 
+# --- Model for get_transaction_logs Data Payload ---
 class LogItem(LogItemShort):
     """Represents a single log item with its originating contract address."""
 

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -216,9 +216,9 @@ class NftCollectionHolding(BaseModel):
     )
 
 
-# --- Model for get_address_logs Data Payload ---
-class LogItem(BaseModel):
-    """Represents a single log item from an address."""
+# --- Models for Log Items ---
+class LogItemShort(BaseModel):
+    """Represents a single log item, optimized for context when the address is redundant."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -234,6 +234,15 @@ class LogItem(BaseModel):
     data_truncated: bool | None = Field(
         None,
         description="Flag indicating if the 'data' or 'decoded' field was shortened.",
+    )
+
+
+class LogItem(LogItemShort):
+    """Represents a single log item with its originating contract address."""
+
+    address: str | None = Field(
+        None,
+        description="The contract address that emitted the log.",
     )
 
 

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -6,7 +6,7 @@ from pydantic import Field
 
 from blockscout_mcp_server.models import (
     AddressInfoData,
-    LogItem,
+    LogItemShort,
     NextCallInfo,
     NftCollectionHolding,
     NftCollectionInfo,
@@ -270,7 +270,7 @@ async def get_address_logs(
             description="The pagination cursor from a previous response to get the next page of results.",
         ),
     ] = None,
-) -> ToolResponse[list[LogItem]]:
+) -> ToolResponse[list[LogItemShort]]:
     """
     Get comprehensive logs emitted by a specific address.
     Returns enriched logs, primarily focusing on decoded event parameters with their types and values (if event decoding is applicable).
@@ -308,7 +308,7 @@ async def get_address_logs(
 
     original_items, was_truncated = _process_and_truncate_log_items(response_data.get("items", []))
 
-    log_items = [LogItem.model_validate(item) for item in original_items]
+    log_items = [LogItemShort.model_validate(item) for item in original_items]
 
     data_description = [
         "Items Structure:",

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -448,24 +448,35 @@ async def get_transaction_logs(
 
     data_description = [
         "Items Structure:",
-        "address: The contract address that emitted the log (string)",
-        "block_number: Block where the event was emitted",
-        "index: Log position within the block",
-        "topics: Raw indexed event parameters (first topic is event signature hash)",
-        "data: Raw non-indexed event parameters (hex encoded). May be truncated.",
-        "decoded: If available, the decoded event with its name and parameters",
-        "data_truncated: (Optional) true if the data field was shortened.",
-        "Event Decoding in decoded field:",
-        "method_call: Actually the event signature",
-        "method_id: Actually the event signature hash",
-        "parameters: Decoded event parameters with names, types, values, and indexing status",
+        "- `address`: The contract address that emitted the log (string)",
+        "- `block_number`: Block where the event was emitted",
+        "- `index`: Log position within the block",
+        "- `topics`: Raw indexed event parameters (first topic is event signature hash)",
+        "- `data`: Raw non-indexed event parameters (hex encoded). **May be truncated.**",
+        "- `decoded`: If available, the decoded event with its name and parameters",
+        "- `data_truncated`: (Optional) `true` if the `data` or `decoded` field was shortened.",
+        "Event Decoding in `decoded` field:",
+        (
+            "- `method_call`: **Actually the event signature** "
+            '(e.g., "Transfer(address indexed from, address indexed to, uint256 value)")'
+        ),
+        "- `method_id`: **Actually the event signature hash** (first 4 bytes of keccak256 hash)",
+        "- `parameters`: Decoded event parameters with names, types, values, and indexing status",
     ]
 
     notes = None
     if was_truncated:
         notes = [
-            "One or more log items in this response had a data field that was too large and has been truncated.",
-            f"To get the full log data, request {base_url}/api/v2/transactions/{transaction_hash}/logs",
+            (
+                "One or more log items in this response had a `data` field that was "
+                'too large and has been truncated (indicated by `"data_truncated": true`).'
+            ),
+            (
+                "If the full log data is crucial for your analysis, you can retrieve the complete, "
+                "untruncated logs for this transaction programmatically. For example, using curl:"
+            ),
+            f'`curl "{base_url}/api/v2/transactions/{transaction_hash}/logs"`',
+            "You would then need to parse the JSON response and find the specific log by its index.",
         ]
 
     pagination = None

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,17 @@
+from blockscout_mcp_server.models import LogItem, LogItemShort
+
+
+def is_log_a_truncated_call_executed(log: LogItem | LogItemShort) -> bool:
+    """Checks if a log item is a 'CallExecuted' event with a truncated 'data' parameter."""
+    if not (isinstance(log.decoded, dict) and log.decoded.get("method_call", "").startswith("CallExecuted")):
+        return False
+
+    data_param = next(
+        (p for p in log.decoded.get("parameters", []) if p.get("name") == "data"),
+        None,
+    )
+    if not data_param:
+        return False
+
+    value = data_param.get("value")
+    return isinstance(value, dict) and value.get("value_truncated") is True

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -1,11 +1,9 @@
-import json
-import re
-
 import httpx
 import pytest
 
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT, LOG_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import (
+    LogItem,
     TokenTransfer,
     ToolResponse,
     TransactionInfoData,
@@ -21,19 +19,12 @@ from blockscout_mcp_server.tools.transaction_tools import (
 )
 
 
-def _extract_next_cursor(result_str: str) -> str | None:
-    if "cursor" not in result_str:
-        return None
-    return result_str.split('cursor="')[1].split('"')[0]
-
-
-def _find_truncated_call_executed_function_in_logs(data: dict) -> bool:
+def _find_truncated_call_executed_function_in_logs(logs: list[LogItem]) -> bool:
     call_executed_log = next(
         (
             item
-            for item in data.get("items", [])
-            if isinstance(item.get("decoded"), dict)
-            and item["decoded"].get("method_call", "").startswith("CallExecuted")
+            for item in logs
+            if isinstance(item.decoded, dict) and item.decoded.get("method_call", "").startswith("CallExecuted")
         ),
         None,
     )
@@ -41,7 +32,7 @@ def _find_truncated_call_executed_function_in_logs(data: dict) -> bool:
         return False
 
     data_param = next(
-        (p for p in call_executed_log["decoded"].get("parameters", []) if p.get("name") == "data"),
+        (p for p in call_executed_log.decoded.get("parameters", []) if p.get("name") == "data"),
         None,
     )
     if not data_param:
@@ -77,36 +68,30 @@ async def test_get_transaction_logs_integration(mock_ctx):
     # This transaction on Ethereum Mainnet is known to have many logs, ensuring a paginated response.
     tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
     try:
-        result_str = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
     except httpx.HTTPStatusError as e:
         pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
 
     # 1. Verify that pagination is working correctly
-    assert isinstance(result_str, str)
-    assert "To get the next page call" in result_str
-    assert 'cursor="' in result_str
-    assert "**Transaction logs JSON:**" in result_str
+    assert isinstance(result, ToolResponse)
+    assert result.pagination is not None
 
-    # 2. Parse the JSON and verify the basic structure
-    json_part = result_str.split("----")[0]
-    data = json.loads(json_part.split("**Transaction logs JSON:**\n")[-1])
-    assert "items" in data
-    assert isinstance(data["items"], list)
-    assert len(data["items"]) > 0
+    # 2. Verify the basic structure
+    assert isinstance(result.data, list)
+    assert len(result.data) > 0
 
     # 3. Validate the schema of the first transformed log item.
-    first_log = data["items"][0]
-    expected_keys = {"address", "block_number", "data", "decoded", "index", "topics"}
-    assert expected_keys.issubset(first_log.keys())
-    if "data_truncated" in first_log:
-        assert isinstance(first_log["data_truncated"], bool)
+    first_log = result.data[0]
+    assert isinstance(first_log, LogItem)
+    if first_log.data_truncated is not None:
+        assert isinstance(first_log.data_truncated, bool)
 
     # 4. Validate the data types of key fields.
-    assert isinstance(first_log["address"], str)
-    assert first_log["address"].startswith("0x")
-    assert isinstance(first_log["block_number"], int)
-    assert isinstance(first_log["index"], int)
-    assert isinstance(first_log["topics"], list)
+    assert isinstance(first_log.address, str)
+    assert first_log.address.startswith("0x")
+    assert isinstance(first_log.block_number, int)
+    assert isinstance(first_log.index, int)
+    assert isinstance(first_log.topics, list)
 
 
 @pytest.mark.integration
@@ -116,34 +101,23 @@ async def test_get_transaction_logs_pagination_integration(mock_ctx):
     tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
 
     try:
-        first_page_result = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
+        first_page_response = await get_transaction_logs(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx)
     except httpx.HTTPStatusError as e:
         pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
 
-    assert "To get the next page call" in first_page_result
-    cursor_match = re.search(r'cursor="([^"]+)"', first_page_result)
-    assert cursor_match is not None, "Could not find cursor in the first page response."
-    cursor = cursor_match.group(1)
-    assert len(cursor) > 0
+    assert first_page_response.pagination is not None
+    cursor = first_page_response.pagination.next_call.params["cursor"]
 
     try:
-        second_page_result = await get_transaction_logs(
+        second_page_response = await get_transaction_logs(
             chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx, cursor=cursor
         )
     except httpx.HTTPStatusError as e:
         pytest.fail(f"Failed to fetch the second page of transaction logs due to an API error: {e}")
 
-    assert "Error: Invalid or expired pagination cursor" not in second_page_result
-
-    first_page_json_str = first_page_result.split("----")[0].split("**Transaction logs JSON:**\n")[-1]
-    second_page_json_str = second_page_result.split("----")[0].split("**Transaction logs JSON:**\n")[-1]
-
-    first_page_data = json.loads(first_page_json_str)
-    second_page_data = json.loads(second_page_json_str)
-
-    assert isinstance(second_page_data.get("items"), list)
-    assert len(second_page_data["items"]) > 0
-    assert first_page_data["items"][0] != second_page_data["items"][0]
+    assert isinstance(second_page_response, ToolResponse)
+    assert second_page_response.data
+    assert first_page_response.data[0] != second_page_response.data[0]
 
 
 @pytest.mark.integration
@@ -158,24 +132,21 @@ async def test_get_transaction_logs_with_truncation_integration(mock_ctx):
     chain_id = "1"
 
     # Resolve the base URL the same way the tool does
-    base_url = await get_blockscout_base_url(chain_id)
+    await get_blockscout_base_url(chain_id)
     try:
-        result_str = await get_transaction_logs(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=tx_hash, ctx=mock_ctx)
     except httpx.HTTPStatusError as e:
         pytest.skip(f"Transaction data is currently unavailable from the API: {e}")
 
-    assert "**Note on Truncated Data:**" in result_str
-    assert f'`curl "{base_url}/api/v2/transactions/{tx_hash}/logs"`' in result_str
+    assert result.notes is not None
+    assert "One or more log items" in result.notes[0]
 
-    json_part = result_str.split("**Transaction logs JSON:**\n")[1].split("----")[0]
-    data = json.loads(json_part)
-    assert "items" in data and isinstance(data["items"], list) and len(data["items"]) > 0
-
-    truncated_item = next((item for item in data["items"] if item.get("data_truncated")), None)
+    assert isinstance(result.data, list) and result.data
+    truncated_item = next((item for item in result.data if item.data_truncated), None)
     assert truncated_item is not None
-    assert truncated_item["data_truncated"] is True
-    assert "data" in truncated_item
-    assert len(truncated_item["data"]) == LOG_DATA_TRUNCATION_LIMIT
+    assert truncated_item.data_truncated is True
+    assert truncated_item.data is not None
+    assert len(truncated_item.data) == LOG_DATA_TRUNCATION_LIMIT
 
 
 @pytest.mark.integration
@@ -339,7 +310,7 @@ async def test_get_transaction_logs_paginated_search_for_truncation(mock_ctx):
 
     for page_num in range(MAX_PAGES_TO_CHECK):
         try:
-            result_str = await get_transaction_logs(
+            result = await get_transaction_logs(
                 chain_id=chain_id,
                 transaction_hash=tx_hash,
                 ctx=mock_ctx,
@@ -348,14 +319,11 @@ async def test_get_transaction_logs_paginated_search_for_truncation(mock_ctx):
         except httpx.HTTPStatusError as e:
             pytest.skip(f"API request failed on page {page_num + 1}: {e}")
 
-        json_part = result_str.split("**Transaction logs JSON:**\n")[1].split("----")[0]
-        data = json.loads(json_part)
-
-        if _find_truncated_call_executed_function_in_logs(data):
+        if _find_truncated_call_executed_function_in_logs(result.data):
             found_truncated_log = True
             break
 
-        next_cursor = _extract_next_cursor(result_str)
+        next_cursor = result.pagination.next_call.params["cursor"] if result.pagination else None
         if next_cursor:
             cursor = next_cursor
         else:

--- a/tests/tools/test_address_logs.py
+++ b/tests/tools/test_address_logs.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from blockscout_mcp_server.models import ToolResponse
+from blockscout_mcp_server.models import LogItemShort, ToolResponse
 from blockscout_mcp_server.tools.address_tools import get_address_logs
 from blockscout_mcp_server.tools.common import encode_cursor
 
@@ -53,6 +53,7 @@ async def test_get_address_logs_success(mock_ctx):
         mock_process_logs.assert_called_once_with(mock_api_response["items"])
 
         assert isinstance(result, ToolResponse)
+        assert isinstance(result.data[0], LogItemShort)
         assert result.data[0].transaction_hash == "0xtx123..."
         assert result.data_description is not None
         assert "Items Structure:" in result.data_description[0]
@@ -107,6 +108,7 @@ async def test_get_address_logs_with_pagination(mock_ctx):
 
         mock_encode_cursor.assert_called_once_with(mock_api_response["next_page_params"])
         assert isinstance(result, ToolResponse)
+        assert isinstance(result.data[0], LogItemShort)
         assert result.pagination is not None
         assert result.pagination.next_call.tool_name == "get_address_logs"
         assert result.pagination.next_call.params["cursor"] == fake_cursor

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -5,7 +5,12 @@ import httpx
 import pytest
 
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
-from blockscout_mcp_server.models import TokenTransfer, ToolResponse, TransactionInfoData
+from blockscout_mcp_server.models import (
+    LogItem,
+    TokenTransfer,
+    ToolResponse,
+    TransactionInfoData,
+)
 from blockscout_mcp_server.tools.transaction_tools import get_transaction_info, get_transaction_logs
 
 
@@ -408,57 +413,58 @@ async def test_get_transaction_logs_success(mock_ctx):
         ],
     }
 
-    expected_transformed_response = {
-        "items": [
-            {
-                "address": "0xcontract1...",
-                "block_number": 19000000,
-                "data": "0xdata123...",
-                "decoded": {"name": "EventA"},
-                "index": 0,
-                "topics": ["0xtopic1...", "0xtopic2..."],
-            },
-            {
-                "address": "0xcontract2...",
-                "block_number": 19000000,
-                "data": "0xdata456...",
-                "decoded": {"name": "EventB"},
-                "index": 1,
-                "topics": ["0xtopic3..."],
-            },
-        ],
-    }
+    expected_log_items = [
+        LogItem(
+            address="0xcontract1...",
+            block_number=19000000,
+            data="0xdata123...",
+            decoded={"name": "EventA"},
+            index=0,
+            topics=["0xtopic1...", "0xtopic2..."],
+        ),
+        LogItem(
+            address="0xcontract2...",
+            block_number=19000000,
+            data="0xdata456...",
+            decoded={"name": "EventB"},
+            index=1,
+            topics=["0xtopic3..."],
+        ),
+    ]
 
     # Patch json.dumps in the transaction_tools module
     with (
         patch(
-            "blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url", new_callable=AsyncMock
+            "blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
         ) as mock_get_url,
         patch(
-            "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request", new_callable=AsyncMock
+            "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request",
+            new_callable=AsyncMock,
         ) as mock_request,
-        patch("blockscout_mcp_server.tools.transaction_tools.json.dumps") as mock_json_dumps,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
-        # We don't care what json.dumps returns, only that it's called correctly
-        mock_json_dumps.return_value = "{...}"
 
         # ACT
         result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
-        # Assert that json.dumps was called with the transformed data
-        mock_json_dumps.assert_called_once_with(expected_transformed_response)
-
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
             base_url=mock_base_url, api_path=f"/api/v2/transactions/{hash}/logs", params={}
         )
 
-        # Verify the result starts with the expected prefix
-        expected_prefix = "**Items Structure:**"
-        assert result.startswith(expected_prefix)
+        assert isinstance(result, ToolResponse)
+        assert isinstance(result.data[0], LogItem)
+        for actual, expected in zip(result.data, expected_log_items):
+            assert actual.model_extra["address"] == expected.address
+            assert actual.block_number == expected.block_number
+            assert actual.data == expected.data
+            assert actual.decoded == expected.decoded
+            assert actual.index == expected.index
+            assert actual.topics == expected.topics
+        assert result.pagination is None
 
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -458,7 +458,7 @@ async def test_get_transaction_logs_success(mock_ctx):
         assert isinstance(result, ToolResponse)
         assert isinstance(result.data[0], LogItem)
         for actual, expected in zip(result.data, expected_log_items):
-            assert actual.model_extra["address"] == expected.address
+            assert actual.address == expected.address
             assert actual.block_number == expected.block_number
             assert actual.data == expected.data
             assert actual.decoded == expected.decoded

--- a/tests/tools/test_transaction_tools_3.py
+++ b/tests/tools/test_transaction_tools_3.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from blockscout_mcp_server.models import LogItem, ToolResponse
 from blockscout_mcp_server.tools.common import encode_cursor
 from blockscout_mcp_server.tools.transaction_tools import get_transaction_logs
 
@@ -20,11 +21,8 @@ async def test_get_transaction_logs_empty_logs(mock_ctx):
 
     mock_api_response = {"items": []}
 
-    expected_transformed_response = {
-        "items": [],
-    }
+    expected_log_items: list[LogItem] = []
 
-    # Patch json.dumps directly since it's imported locally in the function
     with (
         patch(
             "blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url", new_callable=AsyncMock
@@ -33,29 +31,23 @@ async def test_get_transaction_logs_empty_logs(mock_ctx):
             "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request", new_callable=AsyncMock
         ) as mock_request,
         patch("blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items") as mock_process_logs,
-        patch("blockscout_mcp_server.tools.transaction_tools.json.dumps") as mock_json_dumps,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
         mock_process_logs.return_value = (mock_api_response["items"], False)
-        # We don't care what json.dumps returns, only that it's called correctly
-        mock_json_dumps.return_value = "{...}"
 
         # ACT
         result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
-        # Assert that json.dumps was called with the transformed data
-        mock_json_dumps.assert_called_once_with(expected_transformed_response)
-
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
             base_url=mock_base_url, api_path=f"/api/v2/transactions/{hash}/logs", params={}
         )
         mock_process_logs.assert_called_once_with(mock_api_response["items"])
-
-        # Verify the result structure
-        assert result.startswith("**Items Structure:**")
+        assert isinstance(result, ToolResponse)
+        assert result.pagination is None
+        assert result.data == expected_log_items
 
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
@@ -126,24 +118,21 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
         ],
     }
 
-    expected_transformed_response = {
-        "items": [
-            {
-                "address": "0xa0b86a33e6dd0ba3c70de3b8e2b9e48cd6efb7b0",
-                "block_number": 19000000,
-                "data": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
-                "decoded": {"name": "Transfer"},
-                "index": 42,
-                "topics": [
-                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-                    "0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
-                    "0x000000000000000000000000f81c1a7e8d3c1a1d3c1a1d3c1a1d3c1a1d3c1a1d",
-                ],
-            }
-        ],
-    }
+    expected_log_items = [
+        LogItem(
+            address="0xa0b86a33e6dd0ba3c70de3b8e2b9e48cd6efb7b0",
+            block_number=19000000,
+            data="0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+            decoded={"name": "Transfer"},
+            index=42,
+            topics=[
+                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                "0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
+                "0x000000000000000000000000f81c1a7e8d3c1a1d3c1a1d3c1a1d3c1a1d3c1a1d",
+            ],
+        )
+    ]
 
-    # Patch json.dumps directly since it's imported locally in the function
     with (
         patch(
             "blockscout_mcp_server.tools.transaction_tools.get_blockscout_base_url", new_callable=AsyncMock
@@ -151,28 +140,28 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
         patch(
             "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request", new_callable=AsyncMock
         ) as mock_request,
-        patch("blockscout_mcp_server.tools.transaction_tools.json.dumps") as mock_json_dumps,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
-        # We don't care what json.dumps returns, only that it's called correctly
-        mock_json_dumps.return_value = "{...}"
 
         # ACT
         result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
-        # Assert that json.dumps was called with the transformed data
-        mock_json_dumps.assert_called_once_with(expected_transformed_response)
-
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
             base_url=mock_base_url, api_path=f"/api/v2/transactions/{hash}/logs", params={}
         )
-
-        # Verify the result starts with the expected prefix
-        expected_prefix = "**Items Structure:**"
-        assert result.startswith(expected_prefix)
+        assert isinstance(result, ToolResponse)
+        assert result.pagination is None
+        actual = result.data[0]
+        expected = expected_log_items[0]
+        assert actual.model_extra["address"] == expected.address
+        assert actual.block_number == expected.block_number
+        assert actual.data == expected.data
+        assert actual.decoded == expected.decoded
+        assert actual.index == expected.index
+        assert actual.topics == expected.topics
 
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
@@ -201,21 +190,18 @@ async def test_get_transaction_logs_with_pagination(mock_ctx):
         "next_page_params": {"block_number": 0, "index": "0", "items_count": 50},
     }
 
-    expected_transformed_response = {
-        "items": [
-            {
-                "address": "0xcontract1",
-                "block_number": 1,
-                "data": "0x",
-                "decoded": None,
-                "index": 0,
-                "topics": [],
-            }
-        ],
-    }
+    expected_log_items = [
+        LogItem(
+            address="0xcontract1",
+            block_number=1,
+            data="0x",
+            decoded=None,
+            index=0,
+            topics=[],
+        )
+    ]
 
     fake_cursor = "ENCODED_CURSOR"
-    fake_json_body = "{...}"
 
     with (
         patch(
@@ -227,23 +213,26 @@ async def test_get_transaction_logs_with_pagination(mock_ctx):
             new_callable=AsyncMock,
         ) as mock_request,
         patch("blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items") as mock_process_logs,
-        patch("blockscout_mcp_server.tools.transaction_tools.json.dumps") as mock_json_dumps,
         patch("blockscout_mcp_server.tools.transaction_tools.encode_cursor") as mock_encode_cursor,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
         mock_process_logs.return_value = (mock_api_response["items"], False)
-        mock_json_dumps.return_value = fake_json_body
         mock_encode_cursor.return_value = fake_cursor
 
         result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
-        mock_json_dumps.assert_called_once_with(expected_transformed_response)
         mock_encode_cursor.assert_called_once_with(mock_api_response["next_page_params"])
-
-        assert result.startswith("**Items Structure:**")
-        assert fake_json_body in result
-        assert f'cursor="{fake_cursor}"' in result
+        assert isinstance(result, ToolResponse)
+        actual = result.data[0]
+        expected = expected_log_items[0]
+        assert actual.model_extra["address"] == expected.address
+        assert actual.block_number == expected.block_number
+        assert actual.data == expected.data
+        assert actual.decoded == expected.decoded
+        assert actual.index == expected.index
+        assert actual.topics == expected.topics
+        assert result.pagination.next_call.params["cursor"] == fake_cursor
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
@@ -278,14 +267,12 @@ async def test_get_transaction_logs_with_cursor(mock_ctx):
             new_callable=AsyncMock,
         ) as mock_request,
         patch("blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items") as mock_process_logs,
-        patch("blockscout_mcp_server.tools.transaction_tools.json.dumps") as mock_json_dumps,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
         mock_process_logs.return_value = (mock_api_response["items"], False)
-        mock_json_dumps.return_value = "{...}"
 
-        await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, cursor=cursor, ctx=mock_ctx)
+        result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, cursor=cursor, ctx=mock_ctx)
 
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(
@@ -293,8 +280,10 @@ async def test_get_transaction_logs_with_cursor(mock_ctx):
             api_path=f"/api/v2/transactions/{hash}/logs",
             params=decoded_params,
         )
-        mock_json_dumps.assert_called_once_with({"items": []})
         mock_process_logs.assert_called_once_with(mock_api_response["items"])
+        assert isinstance(result, ToolResponse)
+        assert result.pagination is None
+        assert result.data == []
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 
@@ -310,11 +299,8 @@ async def test_get_transaction_logs_invalid_cursor(mock_ctx):
         "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request",
         new_callable=AsyncMock,
     ) as mock_request:
-        result = await get_transaction_logs(
-            chain_id=chain_id, transaction_hash=hash, cursor=invalid_cursor, ctx=mock_ctx
-        )
-
-        assert "Error: Invalid or expired pagination cursor" in result
+        with pytest.raises(ValueError):
+            await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, cursor=invalid_cursor, ctx=mock_ctx)
         mock_request.assert_not_called()
 
 
@@ -336,35 +322,40 @@ async def test_get_transaction_logs_with_truncation_note(mock_ctx):
             "blockscout_mcp_server.tools.transaction_tools.make_blockscout_request", new_callable=AsyncMock
         ) as mock_request,
         patch("blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items") as mock_process_logs,
-        patch("blockscout_mcp_server.tools.transaction_tools.json.dumps") as mock_json_dumps,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
         mock_process_logs.return_value = ([truncated_item], True)
-        mock_json_dumps.return_value = '{"fake":true}'
 
         # ACT
         result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         # ASSERT
-        expected_transformed = {
-            "items": [
-                {
-                    "address": None,
-                    "block_number": None,
-                    "data": truncated_item["data"],
-                    "decoded": None,
-                    "index": None,
-                    "topics": None,
-                    "data_truncated": True,
-                }
-            ]
-        }
+        expected_log_items = [
+            LogItem(
+                address=None,
+                block_number=None,
+                data=truncated_item["data"],
+                decoded=None,
+                index=None,
+                topics=None,
+                data_truncated=True,
+            )
+        ]
 
         mock_process_logs.assert_called_once_with(mock_api_response["items"])
-        mock_json_dumps.assert_called_once_with(expected_transformed)
-        assert "**Note on Truncated Data:**" in result
-        assert f'`curl "{mock_base_url}/api/v2/transactions/{hash}/logs"`' in result
+        assert isinstance(result, ToolResponse)
+        actual = result.data[0]
+        expected = expected_log_items[0]
+        assert actual.model_extra.get("address") == expected.address
+        assert actual.block_number == expected.block_number
+        assert actual.data == expected.data
+        assert actual.decoded == expected.decoded
+        assert actual.index == expected.index
+        assert actual.topics == expected.topics
+        assert actual.data_truncated == expected.data_truncated
+        assert result.notes is not None
+        assert "One or more log items" in result.notes[0]
 
 
 @pytest.mark.asyncio
@@ -397,28 +388,32 @@ async def test_get_transaction_logs_with_decoded_truncation_note(mock_ctx):
             new_callable=AsyncMock,
         ) as mock_request,
         patch("blockscout_mcp_server.tools.transaction_tools._process_and_truncate_log_items") as mock_process_logs,
-        patch("blockscout_mcp_server.tools.transaction_tools.json.dumps") as mock_json_dumps,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_api_response
         mock_process_logs.return_value = ([truncated_item], True)
-        mock_json_dumps.return_value = '{"fake":true}'
 
         result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
-        expected_transformed = {
-            "items": [
-                {
-                    "address": None,
-                    "block_number": None,
-                    "data": truncated_item["data"],
-                    "decoded": truncated_item["decoded"],
-                    "index": None,
-                    "topics": None,
-                }
-            ]
-        }
+        expected_log_items = [
+            LogItem(
+                address=None,
+                block_number=None,
+                data=truncated_item["data"],
+                decoded=truncated_item["decoded"],
+                index=None,
+                topics=None,
+            )
+        ]
         mock_process_logs.assert_called_once_with(mock_api_response["items"])
-        mock_json_dumps.assert_called_once_with(expected_transformed)
-        assert "**Note on Truncated Data:**" in result
-        assert f'`curl "{mock_base_url}/api/v2/transactions/{hash}/logs"`' in result
+        assert isinstance(result, ToolResponse)
+        actual = result.data[0]
+        expected = expected_log_items[0]
+        assert actual.model_extra.get("address") == expected.address
+        assert actual.block_number == expected.block_number
+        assert actual.data == expected.data
+        assert actual.decoded == expected.decoded
+        assert actual.index == expected.index
+        assert actual.topics == expected.topics
+        assert result.notes is not None
+        assert "One or more log items" in result.notes[0]

--- a/tests/tools/test_transaction_tools_3.py
+++ b/tests/tools/test_transaction_tools_3.py
@@ -156,7 +156,7 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
         assert result.pagination is None
         actual = result.data[0]
         expected = expected_log_items[0]
-        assert actual.model_extra["address"] == expected.address
+        assert actual.address == expected.address
         assert actual.block_number == expected.block_number
         assert actual.data == expected.data
         assert actual.decoded == expected.decoded
@@ -226,7 +226,7 @@ async def test_get_transaction_logs_with_pagination(mock_ctx):
         assert isinstance(result, ToolResponse)
         actual = result.data[0]
         expected = expected_log_items[0]
-        assert actual.model_extra["address"] == expected.address
+        assert actual.address == expected.address
         assert actual.block_number == expected.block_number
         assert actual.data == expected.data
         assert actual.decoded == expected.decoded


### PR DESCRIPTION
## Summary
- return `ToolResponse[list[LogItem]]` from `get_transaction_logs`
- adjust unit and integration tests for structured output
- update unit testing docs to remove obsolete json.dumps example

Closes #103

------
https://chatgpt.com/codex/tasks/task_b_686312c557b08323a40c8255b5543564