### PR TITLE
Refactor advanced filter tools

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -161,6 +161,27 @@ class TransactionInfoData(BaseModel):
     raw_input_truncated: bool | None = Field(default=None, description="Indicates if raw_input was truncated.")
 
 
+# --- Model for get_transactions_by_address and get_token_transfers_by_address Data Payload ---
+class AdvancedFilterItem(BaseModel):
+    """Represents a single item from the advanced filter API response,
+    explicitly defining only the fields that are transformed by the tool.
+    Other fields are passed through dynamically.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    from_address: str | None = Field(
+        default=None,
+        alias="from",
+        description="The sender address.",
+    )
+    to_address: str | None = Field(
+        default=None,
+        alias="to",
+        description="The recipient address.",
+    )
+
+
 # --- Model for get_tokens_by_address Data Payload ---
 class TokenHoldingData(BaseModel):
     """Represents a single token holding with its associated metadata."""

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from blockscout_mcp_server.config import config
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import (
+    AdvancedFilterItem,
     LogItem,
     NextCallInfo,
     PaginationInfo,
@@ -126,7 +127,7 @@ async def get_transactions_by_address(
     methods: Annotated[
         str | None, Field(description="A method signature to filter transactions by (e.g 0x304e6ade)")
     ] = None,
-) -> dict:
+) -> ToolResponse[list[AdvancedFilterItem]]:
     """
     Get transactions for an address within a specific time range.
     Use cases:
@@ -194,8 +195,9 @@ async def get_transactions_by_address(
 
     transformed_items = [_transform_advanced_filter_item(item, fields_to_remove) for item in original_items]
 
-    response_data["items"] = transformed_items
-    return response_data
+    result_data = [AdvancedFilterItem.model_validate(item) for item in transformed_items]
+
+    return build_tool_response(data=result_data)
 
 
 async def get_token_transfers_by_address(
@@ -220,7 +222,7 @@ async def get_token_transfers_by_address(
             description="An ERC-20 token contract address to filter transfers by a specific token. If omitted, returns transfers of all tokens."  # noqa: E501
         ),
     ] = None,
-) -> dict:
+) -> ToolResponse[list[AdvancedFilterItem]]:
     """
     Get ERC-20 token transfers for an address within a specific time range.
     Use cases:
@@ -288,8 +290,9 @@ async def get_token_transfers_by_address(
 
     transformed_items = [_transform_advanced_filter_item(item, fields_to_remove) for item in original_items]
 
-    response_data["items"] = transformed_items
-    return response_data
+    result_data = [AdvancedFilterItem.model_validate(item) for item in transformed_items]
+
+    return build_tool_response(data=result_data)
 
 
 async def transaction_summary(

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -3,6 +3,7 @@ import pytest
 
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT, LOG_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import (
+    AdvancedFilterItem,
     LogItem,
     TokenTransfer,
     ToolResponse,
@@ -231,19 +232,20 @@ async def test_get_transactions_by_address_integration(mock_ctx):
         ctx=mock_ctx,
     )
 
-    assert isinstance(result, dict)
-    assert "items" in result
-    items = result["items"]
+    assert isinstance(result, ToolResponse)
+    items = result.data
     assert isinstance(items, list)
 
     if not items:
         pytest.skip("No transactions found for the given address and time range.")
 
     for item in items:
-        assert isinstance(item.get("from"), str)
-        assert isinstance(item.get("to"), str)
-        assert "token" not in item
-        assert "total" not in item
+        assert isinstance(item, AdvancedFilterItem)
+        assert isinstance(item.from_address, str | type(None))
+        assert isinstance(item.to_address, str | type(None))
+        item_dict = item.model_dump(by_alias=True)
+        assert "token" not in item_dict
+        assert "total" not in item_dict
 
 
 @pytest.mark.integration
@@ -259,19 +261,20 @@ async def test_get_token_transfers_by_address_integration(mock_ctx):
         ctx=mock_ctx,
     )
 
-    assert isinstance(result, dict)
-    assert "items" in result
-    items = result["items"]
+    assert isinstance(result, ToolResponse)
+    items = result.data
     assert isinstance(items, list)
 
     if not items:
         pytest.skip("No token transfers found for the given address and time range.")
 
     for item in items:
-        assert isinstance(item.get("from"), str)
-        assert isinstance(item.get("to"), str)
-        assert "value" not in item
-        assert "internal_transaction_index" not in item
+        assert isinstance(item, AdvancedFilterItem)
+        assert isinstance(item.from_address, str | type(None))
+        assert isinstance(item.to_address, str | type(None))
+        item_dict = item.model_dump(by_alias=True)
+        assert "value" not in item_dict
+        assert "internal_transaction_index" not in item_dict
 
 
 @pytest.mark.integration

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -246,6 +246,9 @@ async def test_get_transactions_by_address_integration(mock_ctx):
         item_dict = item.model_dump(by_alias=True)
         assert "token" not in item_dict
         assert "total" not in item_dict
+        assert "hash" in item_dict
+        assert "timestamp" in item_dict
+        assert "value" in item_dict
 
 
 @pytest.mark.integration
@@ -275,6 +278,10 @@ async def test_get_token_transfers_by_address_integration(mock_ctx):
         item_dict = item.model_dump(by_alias=True)
         assert "value" not in item_dict
         assert "internal_transaction_index" not in item_dict
+        assert "hash" in item_dict
+        assert "timestamp" in item_dict
+        assert "token" in item_dict
+        assert "total" in item_dict
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add `AdvancedFilterItem` model
- refactor `get_transactions_by_address` and `get_token_transfers_by_address` to return `ToolResponse`
- update unit and integration tests

Closes #105

------
https://chatgpt.com/codex/tasks/task_b_686367ed77588323a3ec2f35d709c95b