### PR TITLE
Refactor log models and tools

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -237,14 +237,13 @@ class NftCollectionHolding(BaseModel):
     )
 
 
-# --- Model for get_address_logs Data Payload ---
-class LogItemShort(BaseModel):
-    """Represents a single log item, optimized for context when the address is redundant."""
+# --- Model for get_address_logs and get_transaction_logs Data Payloads ---
+class LogItemBase(BaseModel):
+    """Common fields for log items from Blockscout."""
 
     model_config = ConfigDict(extra="allow")
 
     block_number: int | None = Field(None, description="The block where the event was emitted.")
-    transaction_hash: str | None = Field(None, description="The transaction that triggered the event.")
     topics: list[str | None] | None = Field(None, description="Raw indexed event parameters.")
     data: str | None = Field(
         None,
@@ -252,14 +251,16 @@ class LogItemShort(BaseModel):
     )
     decoded: dict[str, Any] | None = Field(None, description="Decoded event parameters, if available.")
     index: int | None = Field(None, description="The log's position within the block.")
-    data_truncated: bool | None = Field(
-        None,
-        description="Flag indicating if the 'data' or 'decoded' field was shortened.",
-    )
+
+
+class AddressLogItem(LogItemBase):
+    """Represents a single log item when the address is redundant."""
+
+    transaction_hash: str | None = Field(None, description="The transaction that triggered the event.")
 
 
 # --- Model for get_transaction_logs Data Payload ---
-class LogItem(LogItemShort):
+class TransactionLogItem(LogItemBase):
     """Represents a single log item with its originating contract address."""
 
     address: str | None = Field(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,7 +1,7 @@
-from blockscout_mcp_server.models import LogItem, LogItemShort
+from blockscout_mcp_server.models import AddressLogItem, TransactionLogItem
 
 
-def is_log_a_truncated_call_executed(log: LogItem | LogItemShort) -> bool:
+def is_log_a_truncated_call_executed(log: TransactionLogItem | AddressLogItem) -> bool:
     """Checks if a log item is a 'CallExecuted' event with a truncated 'data' parameter."""
     if not (isinstance(log.decoded, dict) and log.decoded.get("method_call", "").startswith("CallExecuted")):
         return False

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -3,7 +3,7 @@ import pytest
 
 from blockscout_mcp_server.models import (
     AddressInfoData,
-    LogItemShort,
+    AddressLogItem,
     NftCollectionHolding,
     ToolResponse,
 )
@@ -57,7 +57,7 @@ async def test_get_address_logs_integration(mock_ctx):
     assert len(result.data) > 0
 
     first_log = result.data[0]
-    assert isinstance(first_log, LogItemShort)
+    assert isinstance(first_log, AddressLogItem)
     assert isinstance(first_log.transaction_hash, str)
     assert first_log.transaction_hash.startswith("0x")
     assert isinstance(first_log.block_number, int)

--- a/tests/integration/test_transaction_tools_integration.py
+++ b/tests/integration/test_transaction_tools_integration.py
@@ -4,10 +4,10 @@ import pytest
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT, LOG_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import (
     AdvancedFilterItem,
-    LogItem,
     TokenTransfer,
     ToolResponse,
     TransactionInfoData,
+    TransactionLogItem,
     TransactionSummaryData,
 )
 from blockscout_mcp_server.tools.common import get_blockscout_base_url
@@ -61,7 +61,7 @@ async def test_get_transaction_logs_integration(mock_ctx):
 
     # 3. Validate the schema of the first transformed log item.
     first_log = result.data[0]
-    assert isinstance(first_log, LogItem)
+    assert isinstance(first_log, TransactionLogItem)
     if first_log.data_truncated is not None:
         assert isinstance(first_log.data_truncated, bool)
 

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -6,10 +6,10 @@ import pytest
 
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import (
-    LogItem,
     TokenTransfer,
     ToolResponse,
     TransactionInfoData,
+    TransactionLogItem,
 )
 from blockscout_mcp_server.tools.transaction_tools import get_transaction_info, get_transaction_logs
 
@@ -414,7 +414,7 @@ async def test_get_transaction_logs_success(mock_ctx):
     }
 
     expected_log_items = [
-        LogItem(
+        TransactionLogItem(
             address="0xcontract1...",
             block_number=19000000,
             data="0xdata123...",
@@ -422,7 +422,7 @@ async def test_get_transaction_logs_success(mock_ctx):
             index=0,
             topics=["0xtopic1...", "0xtopic2..."],
         ),
-        LogItem(
+        TransactionLogItem(
             address="0xcontract2...",
             block_number=19000000,
             data="0xdata456...",
@@ -456,7 +456,7 @@ async def test_get_transaction_logs_success(mock_ctx):
         )
 
         assert isinstance(result, ToolResponse)
-        assert isinstance(result.data[0], LogItem)
+        assert isinstance(result.data[0], TransactionLogItem)
         for actual, expected in zip(result.data, expected_log_items):
             assert actual.address == expected.address
             assert actual.block_number == expected.block_number
@@ -464,6 +464,7 @@ async def test_get_transaction_logs_success(mock_ctx):
             assert actual.decoded == expected.decoded
             assert actual.index == expected.index
             assert actual.topics == expected.topics
+        assert "transaction_hash" not in result.data[0].model_dump()
         assert result.pagination is None
 
         assert mock_ctx.report_progress.call_count == 3

--- a/tests/tools/test_transaction_tools_3.py
+++ b/tests/tools/test_transaction_tools_3.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from blockscout_mcp_server.models import LogItem, ToolResponse
+from blockscout_mcp_server.models import ToolResponse, TransactionLogItem
 from blockscout_mcp_server.tools.common import encode_cursor
 from blockscout_mcp_server.tools.transaction_tools import get_transaction_logs
 
@@ -21,7 +21,7 @@ async def test_get_transaction_logs_empty_logs(mock_ctx):
 
     mock_api_response = {"items": []}
 
-    expected_log_items: list[LogItem] = []
+    expected_log_items: list[TransactionLogItem] = []
 
     with (
         patch(
@@ -119,7 +119,7 @@ async def test_get_transaction_logs_complex_logs(mock_ctx):
     }
 
     expected_log_items = [
-        LogItem(
+        TransactionLogItem(
             address="0xa0b86a33e6dd0ba3c70de3b8e2b9e48cd6efb7b0",
             block_number=19000000,
             data="0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
@@ -191,7 +191,7 @@ async def test_get_transaction_logs_with_pagination(mock_ctx):
     }
 
     expected_log_items = [
-        LogItem(
+        TransactionLogItem(
             address="0xcontract1",
             block_number=1,
             data="0x",
@@ -332,7 +332,7 @@ async def test_get_transaction_logs_with_truncation_note(mock_ctx):
 
         # ASSERT
         expected_log_items = [
-            LogItem(
+            TransactionLogItem(
                 address=None,
                 block_number=None,
                 data=truncated_item["data"],
@@ -396,7 +396,7 @@ async def test_get_transaction_logs_with_decoded_truncation_note(mock_ctx):
         result = await get_transaction_logs(chain_id=chain_id, transaction_hash=hash, ctx=mock_ctx)
 
         expected_log_items = [
-            LogItem(
+            TransactionLogItem(
                 address=None,
                 block_number=None,
                 data=truncated_item["data"],


### PR DESCRIPTION
## Summary
- optimize log item models to split address and transaction variants
- refactor `get_address_logs` and `get_transaction_logs` to build curated log items
- update tests for new models

Closes #109

## Testing
- `pytest tests/tools/test_address_logs.py -v`
- `pytest tests/tools/test_transaction_tools_2.py tests/tools/test_transaction_tools_3.py -v`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686464b3af0883239743968f68bad0f3