### PR TITLE
chore: Update ChainInfo, SPEC.md Examples, and Tool Behavior Comments

### DIFF
--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -18,16 +18,16 @@ GENERAL_RULES = [
 ]
 
 RECOMMENDED_CHAINS = [
-    {"name": "Ethereum", "chain_id": 1},
-    {"name": "Polygon PoS", "chain_id": 137},
-    {"name": "Base", "chain_id": 8453},
-    {"name": "Arbitrum One", "chain_id": 42161},
-    {"name": "OP Mainnet", "chain_id": 10},
-    {"name": "ZkSync Era", "chain_id": 324},
-    {"name": "Polygon zkEVM", "chain_id": 1101},
-    {"name": "Gnosis", "chain_id": 100},
-    {"name": "Celo", "chain_id": 42220},
-    {"name": "Scroll", "chain_id": 534352},
+    {"name": "Ethereum", "chain_id": "1"},
+    {"name": "Polygon PoS", "chain_id": "137"},
+    {"name": "Base", "chain_id": "8453"},
+    {"name": "Arbitrum One", "chain_id": "42161"},
+    {"name": "OP Mainnet", "chain_id": "10"},
+    {"name": "ZkSync Era", "chain_id": "324"},
+    {"name": "Polygon zkEVM", "chain_id": "1101"},
+    {"name": "Gnosis", "chain_id": "100"},
+    {"name": "Celo", "chain_id": "42220"},
+    {"name": "Scroll", "chain_id": "534352"},
 ]
 
 SERVER_NAME = "blockscout-mcp-server"

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -163,12 +163,9 @@ class TransactionInfoData(BaseModel):
 
 # --- Model for get_transactions_by_address and get_token_transfers_by_address Data Payload ---
 class AdvancedFilterItem(BaseModel):
-    """Represents a single item from the advanced filter API response,
-    explicitly defining only the fields that are transformed by the tool.
-    Other fields are passed through dynamically.
-    """
+    """Represents a single item from the advanced filter API response."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow")  # External APIs may add new fields; allow them to avoid validation errors
 
     from_address: str | None = Field(
         default=None,
@@ -241,7 +238,7 @@ class NftCollectionHolding(BaseModel):
 class LogItemBase(BaseModel):
     """Common fields for log items from Blockscout."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow")  # Just to allow `data_truncated` field to be added to the response
 
     block_number: int | None = Field(None, description="The block where the event was emitted.")
     topics: list[str | None] | None = Field(None, description="Raw indexed event parameters.")
@@ -253,6 +250,7 @@ class LogItemBase(BaseModel):
     index: int | None = Field(None, description="The log's position within the block.")
 
 
+# --- Model for get_address_logs Data Payload ---
 class AddressLogItem(LogItemBase):
     """Represents a single log item when the address is redundant."""
 

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -37,7 +37,7 @@ class ChainInfo(BaseModel):
     """Represents a blockchain with its essential identifiers."""
 
     name: str = Field(description="The common name of the blockchain (e.g., 'Ethereum').")
-    chain_id: int = Field(description="The unique numeric identifier for the chain.")
+    chain_id: str = Field(description="The unique identifier for the chain.")
 
 
 # --- Model for __get_instructions__ Data Payload ---

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -320,6 +320,7 @@ async def get_address_logs(
     original_items, was_truncated = _process_and_truncate_log_items(response_data.get("items", []))
 
     log_items: list[AddressLogItem] = []
+    # To preserve the LLM context, only specific fields are added to the response
     for item in original_items:
         curated_item = {
             "block_number": item.get("block_number"),

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -135,6 +135,7 @@ async def get_tokens_by_address(
     items_data = response_data.get("items", [])
     token_holdings = []
     for item in items_data:
+        # To preserve the LLM context, only specific fields are added to the response
         token = item.get("token", {})
         token_holdings.append(
             TokenHoldingData(
@@ -150,6 +151,9 @@ async def get_tokens_by_address(
             )
         )
 
+    # Since there could be more than one page of tokens for the same address,
+    # the pagination information is extracted from API response and added explicitly
+    # to the tool response
     pagination = None
     next_page_params = response_data.get("next_page_params")
     if next_page_params:
@@ -217,6 +221,8 @@ async def nft_tokens_by_address(
 
         token_instances: list[NftTokenInstance] = []
         for instance in item.get("token_instances", []):
+            # To preserve the LLM context, only specific fields for NFT instances are
+            # added to the response
             metadata = instance.get("metadata", {}) or {}
             token_instances.append(
                 NftTokenInstance(
@@ -229,6 +235,8 @@ async def nft_tokens_by_address(
                 )
             )
 
+        # To preserve the LLM context, only specific fields for NFT collections are
+        # added to the response
         collection_info = NftCollectionInfo(
             type=token.get("type", ""),
             address=token.get("address_hash", ""),
@@ -246,6 +254,9 @@ async def nft_tokens_by_address(
             )
         )
 
+    # Since there could be more than one page of collections for the same address,
+    # the pagination information is extracted from API response and added explicitly
+    # to the tool response
     pagination = None
     next_page_params = response_data.get("next_page_params")
     if next_page_params:
@@ -342,6 +353,9 @@ async def get_address_logs(
             f'`curl "{base_url}/api/v2/transactions/{{THE_TRANSACTION_HASH}}/logs"`',
         ]
 
+    # Since there could be more than one page of logs for the same address,
+    # the pagination information is extracted from API response and added explicitly
+    # to the tool response
     pagination = None
     next_page_params = response_data.get("next_page_params")
     if next_page_params:

--- a/blockscout_mcp_server/tools/block_tools.py
+++ b/blockscout_mcp_server/tools/block_tools.py
@@ -89,6 +89,9 @@ async def get_block_info(
         message="Successfully fetched all block data.",
     )
 
+    # The block details are added to the response as they are returned by the API.
+    # Where as for transactions only the hashes are added. AI agents can use the hashes
+    # to get the full transaction details using the `get_transaction_info` tool.
     block_data = BlockInfoData(block_details=block_info_result, transaction_hashes=tx_hashes)
     return build_tool_response(data=block_data, notes=notes)
 
@@ -130,9 +133,11 @@ async def get_latest_block(
         message="Successfully fetched latest block data.",
     )
 
-    # The API returns a list. Extract data from the first item as per responseTemplate
+    # The API returns a list. Extract data from the first item
     if response_data and isinstance(response_data, list) and len(response_data) > 0:
         first_block = response_data[0]
+        # The main idea of this tool is to provide the latest block number of the chain.
+        # The timestamp is provided to be used as a reference timestamp for other API calls.
         block_data = LatestBlockData(
             block_number=first_block.get("height"),
             timestamp=first_block.get("timestamp"),

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -33,13 +33,12 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
 
     chains: list[ChainInfo] = []
     if isinstance(response_data, list):
-        sorted_chains = sorted(response_data, key=lambda x: x.get("name", ""))
-        for item in sorted_chains:
-            if item.get("name") and item.get("chainid"):
-                try:
-                    chain_id = int(item["chainid"])
-                except (TypeError, ValueError):
-                    continue
-                chains.append(ChainInfo(name=item["name"], chain_id=chain_id))
+        # 1. No need to sort the chains as per the nature of Chainscout: most popular chains are at the top
+        # 2. The chain ID can be either numeric or string, so we don't need to convert it to int
+        chains.extend(
+            ChainInfo(name=item["name"], chain_id=item["chainid"])
+            for item in response_data
+            if item.get("name") and item.get("chainid")
+        )
 
     return build_tool_response(data=chains)

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -12,6 +12,9 @@ from blockscout_mcp_server.tools.common import (
 )
 
 
+# The contracts sources are not returned by MCP tools as they consume too much context.
+# More elegant solution needs to be found.
+
 async def get_contract_abi(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],
     address: Annotated[str, Field(description="Smart contract address")],
@@ -51,7 +54,7 @@ async def get_contract_abi(
         message="Successfully fetched contract ABI.",
     )
 
-    # Extract the ABI from the response and wrap it in a ToolResponse
+    # Extract the ABI from the API response as it is
     abi_data = ContractAbiData(abi=response_data.get("abi"))
 
     return build_tool_response(data=abi_data)

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -11,9 +11,9 @@ from blockscout_mcp_server.tools.common import (
     report_and_log_progress,
 )
 
-
 # The contracts sources are not returned by MCP tools as they consume too much context.
 # More elegant solution needs to be found.
+
 
 async def get_contract_abi(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],

--- a/blockscout_mcp_server/tools/ens_tools.py
+++ b/blockscout_mcp_server/tools/ens_tools.py
@@ -18,6 +18,7 @@ async def get_address_by_ens_name(
     Useful for when you need to convert an ENS domain name (e.g. "blockscout.eth")
     to its corresponding Ethereum address.
     """
+    # TODO: add support for other chains
     api_path = f"/api/v1/1/domains/{name}"
 
     # Report start of operation
@@ -38,7 +39,7 @@ async def get_address_by_ens_name(
         message=f"Successfully resolved ENS name {name}.",
     )
 
-    # Extract data as per responseTemplate: {"resolved_address": "{{.resolved_address.hash}}"}
+    # Only the address hash is added to the response
     resolved_address_info = response_data.get("resolved_address", {})
     address_hash = resolved_address_info.get("hash") if resolved_address_info else None
     ens_data = EnsAddressData(resolved_address=address_hash)

--- a/blockscout_mcp_server/tools/get_instructions.py
+++ b/blockscout_mcp_server/tools/get_instructions.py
@@ -12,7 +12,8 @@ from blockscout_mcp_server.models import (
 )
 from blockscout_mcp_server.tools.common import build_tool_response, report_and_log_progress
 
-
+# It is very important to keep the tool description in such form to force the LLM to call this tool first
+# before calling any other tool. Altering of the description could provide opportunity to LLM to skip this tool.
 async def __get_instructions__(ctx: Context) -> ToolResponse[InstructionsData]:
     """
     This tool MUST be called BEFORE any other tool.

--- a/blockscout_mcp_server/tools/get_instructions.py
+++ b/blockscout_mcp_server/tools/get_instructions.py
@@ -12,6 +12,7 @@ from blockscout_mcp_server.models import (
 )
 from blockscout_mcp_server.tools.common import build_tool_response, report_and_log_progress
 
+
 # It is very important to keep the tool description in such form to force the LLM to call this tool first
 # before calling any other tool. Altering of the description could provide opportunity to LLM to skip this tool.
 async def __get_instructions__(ctx: Context) -> ToolResponse[InstructionsData]:

--- a/blockscout_mcp_server/tools/search_tools.py
+++ b/blockscout_mcp_server/tools/search_tools.py
@@ -69,6 +69,7 @@ async def lookup_token_by_symbol(
 
     items_to_process = all_items[:TOKEN_RESULTS_LIMIT]
 
+    # To preserve the LLM context, only specific fields are added to the response
     search_results = [
         TokenSearchResult(
             address=item.get("address_hash", ""),

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -482,6 +482,9 @@ async def get_transaction_logs(
             "You would then need to parse the JSON response and find the specific log by its index.",
         ]
 
+    # Since there could be more than one page of logs for the same transaction,
+    # the pagination information is extracted from API response and added explicitly
+    # to the tool response
     pagination = None
     next_page_params = response_data.get("next_page_params")
     if next_page_params:

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -16,8 +16,8 @@ async def test_get_chains_list_integration(mock_ctx):
 
     eth_chain = next((chain for chain in result.data if chain.name == "Ethereum"), None)
     assert eth_chain is not None
-    assert eth_chain.chain_id == 1
+    assert eth_chain.chain_id == "1"
 
     polygon_chain = next((chain for chain in result.data if chain.name == "Polygon PoS"), None)
     assert polygon_chain is not None
-    assert polygon_chain.chain_id == 137
+    assert polygon_chain.chain_id == "137"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,7 @@ def test_tool_response_complex_data():
     instructions_data = InstructionsData(
         version="1.0.0",
         general_rules=["Rule 1"],
-        recommended_chains=[ChainInfo(name="TestChain", chain_id=123)],
+        recommended_chains=[ChainInfo(name="TestChain", chain_id="123")],
     )
     response = ToolResponse[InstructionsData](data=instructions_data)
     assert response.data.version == "1.0.0"
@@ -80,20 +80,20 @@ def test_pagination_info():
 
 def test_chain_info():
     """Test ChainInfo model."""
-    chain = ChainInfo(name="Ethereum", chain_id=1)
+    chain = ChainInfo(name="Ethereum", chain_id="1")
     assert chain.name == "Ethereum"
-    assert chain.chain_id == 1
+    assert chain.chain_id == "1"
 
 
 def test_instructions_data():
     """Test InstructionsData model."""
-    chains = [ChainInfo(name="Ethereum", chain_id=1), ChainInfo(name="Polygon", chain_id=137)]
+    chains = [ChainInfo(name="Ethereum", chain_id="1"), ChainInfo(name="Polygon", chain_id="137")]
     instructions = InstructionsData(version="2.0.0", general_rules=["Rule 1", "Rule 2"], recommended_chains=chains)
     assert instructions.version == "2.0.0"
     assert len(instructions.general_rules) == 2
     assert len(instructions.recommended_chains) == 2
     assert instructions.recommended_chains[0].name == "Ethereum"
-    assert instructions.recommended_chains[1].chain_id == 137
+    assert instructions.recommended_chains[1].chain_id == "137"
 
 
 def test_tool_response_serialization():

--- a/tests/tools/test_chains_tools.py
+++ b/tests/tools/test_chains_tools.py
@@ -21,8 +21,8 @@ async def test_get_chains_list_success(mock_ctx):
     ]
 
     expected_data = [
-        ChainInfo(name="Ethereum", chain_id=1),
-        ChainInfo(name="Polygon PoS", chain_id=137),
+        ChainInfo(name="Ethereum", chain_id="1"),
+        ChainInfo(name="Polygon PoS", chain_id="137"),
     ]
 
     # Use `patch` to replace the real `make_chainscout_request` with our mock.
@@ -121,8 +121,8 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
 
     # Only valid entries should appear in output
     expected_data = [
-        ChainInfo(name="Ethereum", chain_id=1),
-        ChainInfo(name="Polygon PoS", chain_id=137),
+        ChainInfo(name="Ethereum", chain_id="1"),
+        ChainInfo(name="Polygon PoS", chain_id="137"),
     ]
 
     with patch(

--- a/tests/tools/test_get_instructions.py
+++ b/tests/tools/test_get_instructions.py
@@ -12,7 +12,7 @@ async def test_get_instructions_success(mock_ctx):
     # ARRANGE
     mock_version = "1.2.3"
     mock_rules = ["Rule 1.", "Rule 2."]
-    mock_chains = [{"name": "TestChain", "chain_id": 999}]
+    mock_chains = [{"name": "TestChain", "chain_id": "999"}]
 
     with (
         patch("blockscout_mcp_server.tools.get_instructions.SERVER_VERSION", mock_version),
@@ -30,7 +30,7 @@ async def test_get_instructions_success(mock_ctx):
         assert result.data.general_rules == mock_rules
         assert len(result.data.recommended_chains) == 1
         assert result.data.recommended_chains[0].name == "TestChain"
-        assert result.data.recommended_chains[0].chain_id == 999
+        assert result.data.recommended_chains[0].chain_id == "999"
 
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2


### PR DESCRIPTION
- Type of `chain_id` in `ChainInfo` field is changed to str.
- Structured response examples in SPEC.md are replaced by one synthetic example.
- Added comments clarifying tools’ behavior.