### PR TITLE
Change type of metadata attributes

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -206,8 +206,9 @@ class NftTokenInstance(BaseModel):
         None,
         description="A URL to an external site or application related to the NFT.",  # noqa: E501
     )
-    metadata_attributes: list | None = Field(
-        None, description="A list of metadata attributes (traits) associated with the NFT."
+    metadata_attributes: list | dict | None = Field(
+        None,
+        description="The metadata attributes (traits) associated with the NFT.",
     )
 
 

--- a/tests/integration/test_address_tools_integration.py
+++ b/tests/integration/test_address_tools_integration.py
@@ -19,7 +19,7 @@ from tests.integration.helpers import is_log_a_truncated_call_executed
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_nft_tokens_by_address_integration(mock_ctx):
-    address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"  # Vitalik Buterin
+    address = "0xA94b3E48215c72266f5006bcA6EE67Fff7122307"  # Address with NFT holdings
     result = await nft_tokens_by_address(chain_id="1", address=address, ctx=mock_ctx)
 
     assert isinstance(result, ToolResponse)
@@ -129,7 +129,7 @@ async def test_get_tokens_by_address_pagination_integration(mock_ctx):
 @pytest.mark.asyncio
 async def test_nft_tokens_by_address_pagination_integration(mock_ctx):
     """Tests that nft_tokens_by_address can successfully use a cursor to fetch a second page."""
-    address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    address = "0xA94b3E48215c72266f5006bcA6EE67Fff7122307"
     chain_id = "1"
 
     try:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -271,3 +271,42 @@ def test_nft_collection_holding_model():
     assert len(holding.token_instances) == 2
     assert holding.token_instances[0].metadata_attributes[0]["value"] == "Red"
     assert holding.token_instances[1].name == "NFT #2"
+
+
+def test_nft_token_instance_metadata_attributes_formats():
+    """Test NftTokenInstance handles both list and dict formats for metadata_attributes."""
+    from blockscout_mcp_server.models import NftTokenInstance
+
+    # Test with list format (multiple attributes)
+    instance_list = NftTokenInstance(
+        id="1",
+        name="Test NFT",
+        metadata_attributes=[
+            {"trait_type": "Body", "value": "Female"},
+            {"trait_type": "Hair", "value": "Wild Blonde"},
+            {"trait_type": "Eyes", "value": "Green Eye Shadow"}
+        ]
+    )
+    assert isinstance(instance_list.metadata_attributes, list)
+    assert len(instance_list.metadata_attributes) == 3
+    assert instance_list.metadata_attributes[0]["trait_type"] == "Body"
+    assert instance_list.metadata_attributes[0]["value"] == "Female"
+
+    # Test with dict format (single attribute)
+    instance_dict = NftTokenInstance(
+        id="2", 
+        name="Test NFT 2",
+        metadata_attributes={"trait_type": "Common", "value": "Gray"}
+    )
+    assert isinstance(instance_dict.metadata_attributes, dict)
+    assert instance_dict.metadata_attributes["trait_type"] == "Common"
+    assert instance_dict.metadata_attributes["value"] == "Gray"
+
+    # Test with None
+    instance_none = NftTokenInstance(id="3", name="Test NFT 3")
+    assert instance_none.metadata_attributes is None
+
+    # Test with empty list
+    instance_empty = NftTokenInstance(id="4", name="Test NFT 4", metadata_attributes=[])
+    assert isinstance(instance_empty.metadata_attributes, list)
+    assert len(instance_empty.metadata_attributes) == 0

--- a/tests/tools/test_address_tools_2.py
+++ b/tests/tools/test_address_tools_2.py
@@ -38,8 +38,20 @@ async def test_nft_tokens_by_address_success(mock_ctx):
                 },
                 "amount": "3",
                 "token_instances": [
-                    {"id": "123", "metadata": {"name": "Punk #123", "attributes": []}},
-                    {"id": "456", "metadata": {"name": "Punk #456", "attributes": []}},
+                    {
+                        "id": "123",
+                        "metadata": {
+                            "name": "Punk #123",
+                            "attributes": [{"trait_type": "Color", "value": "Blue"}],
+                        },
+                    },
+                    {
+                        "id": "456",
+                        "metadata": {
+                            "name": "Punk #456",
+                            "attributes": {"trait_type": "Common", "value": "Gray"},
+                        },
+                    },
                 ],
             }
         ]
@@ -75,6 +87,14 @@ async def test_nft_tokens_by_address_success(mock_ctx):
         assert holding.collection.address == "0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb"
         assert len(holding.token_instances) == 2
         assert holding.token_instances[0].name == "Punk #123"
+        # Test that list format metadata_attributes works
+        assert isinstance(holding.token_instances[0].metadata_attributes, list)
+        assert holding.token_instances[0].metadata_attributes[0]["trait_type"] == "Color"
+        assert holding.token_instances[0].metadata_attributes[0]["value"] == "Blue"
+        # Test that dict format metadata_attributes works
+        assert isinstance(holding.token_instances[1].metadata_attributes, dict)
+        assert holding.token_instances[1].metadata_attributes["trait_type"] == "Common"
+        assert holding.token_instances[1].metadata_attributes["value"] == "Gray"
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
 


### PR DESCRIPTION
Closes #113 

This pull request introduces changes to enhance the handling of `metadata_attributes` in the `NftTokenInstance` model, allowing support for both list and dictionary formats.