### PR TITLE
Add explicit pagination instructions to improve LLM usage behavior

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -13,7 +13,7 @@ AI agents should consult the appropriate rule files based on the context of thei
 
 ### MCP Tool Development
 
-- **Follow** `.cursor/rules/110-new-mcp-tool.mdc` whenever creating new MCP tool functions or modifying existing  ones
+- **Follow** `.cursor/rules/110-new-mcp-tool.mdc` whenever creating new MCP tool functions or modifying existing ones
 - **Apply** `.cursor/rules/120-mcp-tool-arguments.mdc` rules to the tool's parameters list whenever modifying existing MCP tool functions
 - **Follow** `.cursor/rules/130-version-management.mdc` when updating the version of the MCP server
 - **Apply** `.cursor/rules/140-tool-description.mdc` rules to the tool's description field whenever creating a new MCP tool or updating an existing one

--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -166,6 +166,7 @@ async def tool_name(
     """
     Descriptive docstring explaining what the tool does.
     Include use cases and examples if helpful.
+    **SUPPORTS PAGINATION**: If response includes 'pagination' field, use the provided next_call to get additional pages.
     """
     # Construct API path, often with argument interpolation
     api_path = f"/api/v2/some_endpoint/{required_arg}"
@@ -360,6 +361,9 @@ Your tool should accept an optional `cursor` argument. If it's provided, use the
 **B. Generating Structured Pagination:**
 In your response, check for `next_page_params` from the API. If they exist, create `PaginationInfo` and `NextCallInfo` objects with the structured parameters for the next call.
 
+**C. Tool Description Guidelines:**
+For paginated tools, **MUST** include this exact notice in the docstring: `**SUPPORTS PAGINATION**: If response includes 'pagination' field, use the provided next_call to get additional pages.`
+
 **Complete Example Pattern:**
 
 ```python
@@ -376,6 +380,7 @@ async def paginated_tool_name(
 ) -> ToolResponse[list[dict]]:
     """
     A tool that demonstrates the correct way to handle pagination.
+    **SUPPORTS PAGINATION**: If response includes 'pagination' field, use the provided next_call to get additional pages.
     """
     api_path = f"/api/v2/some_paginated_endpoint/{address}"
     query_params = {}
@@ -416,7 +421,7 @@ async def paginated_tool_name(
 
 **Rationale:** Many Blockscout API endpoints return addresses as complex JSON objects containing the hash, name, tags, etc. To conserve LLM context and encourage compositional tool use, we must simplify these objects into a single address string. If the AI needs more details about an address, it should be guided to use the dedicated `get_address_info` tool.
 
-**Example: Transforming a Transaction Response**
+##### Example: Transforming a Transaction Response
 
 **Before (Raw API Response):**
 This is the verbose data we get from the Blockscout API.
@@ -545,11 +550,13 @@ async def tool_with_nested_data(chain_id: str, hash: str, ctx: Context) -> ToolR
 **CRITICAL: Always raise exceptions for error conditions, never return "error" responses.** The MCP framework converts exceptions to `isError=True`, but `ToolResponse` objects with error messages in `notes` are treated as successful responses (`isError=False`).
 
 **Exception Types:**
+
 - `ValueError`: Invalid input parameters
 - `RuntimeError`: API failures or infrastructure issues
 - `TimeoutError`: Timeout conditions
 
 **Notes Field Usage:**
+
 ```python
 # ✅ CORRECT: Warnings about successful data
 return build_tool_response(data=data, notes=["Data was truncated"])
@@ -640,4 +647,5 @@ return build_tool_response(data=combined_data, notes=notes)
 ```
 
 **Key Points:**
+
 - Always use `return_exceptions=True`

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -45,9 +45,9 @@ RECOMMENDED_CHAINS = [
 SERVER_NAME = "blockscout-mcp-server"
 
 # The maximum length for a log's `data` field before it's truncated.
-# 1026 = '0x' prefix + 1024 hex characters (512 bytes).
-LOG_DATA_TRUNCATION_LIMIT = 1026
+# 514 = '0x' prefix + 512 hex characters (256 bytes).
+LOG_DATA_TRUNCATION_LIMIT = 514
 
 # The maximum length for a transaction's input data field before it's truncated.
-# 1026 = '0x' prefix + 1024 hex characters (512 bytes).
-INPUT_DATA_TRUNCATION_LIMIT = 1026
+# 514 = '0x' prefix + 512 hex characters (256 bytes).
+INPUT_DATA_TRUNCATION_LIMIT = 514

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -15,6 +15,18 @@ GENERAL_RULES = [
         "`get_chains_list` to get chain IDs of all known chains."
     ),
     'If no chain is specified in the user\'s prompt, assume "Ethereum Mainnet" (chain_id: 1) as the default.',
+    (
+        "PAGINATION HANDLING: When any tool response includes a 'pagination' field, "
+        "this means there are additional pages of data available. "
+        "You MUST use the exact tool call provided in 'pagination.next_call' to fetch the next page. "
+        "The 'pagination.next_call' contains the complete tool name and all required parameters "
+        "(including the cursor) for the next page request."
+    ),
+    (
+        "If the user asks for comprehensive data or 'all' results, "
+        "and you receive a paginated response, continue calling the pagination tool calls "
+        "until you have gathered all available data or reached a reasonable limit."
+    ),
 ]
 
 RECOMMENDED_CHAINS = [

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -99,8 +99,8 @@ async def get_tokens_by_address(
     """
     Get comprehensive ERC20 token holdings for an address with enriched metadata and market data.
     Returns detailed token information including contract details (name, symbol, decimals), market metrics (exchange rate, market cap, volume), holders count, and actual balance (provided as is, without adjusting by decimals).
-    Supports pagination.
     Essential for portfolio analysis, wallet auditing, and DeFi position tracking.
+    **SUPPORTS PAGINATION**: If response includes 'pagination' field, use the provided next_call to get additional pages.
     """  # noqa: E501
     api_path = f"/api/v2/addresses/{address}/tokens"
     params = {"tokens": "ERC-20"}
@@ -185,6 +185,7 @@ async def nft_tokens_by_address(
     Retrieve NFT tokens (ERC-721, ERC-404, ERC-1155) owned by an address, grouped by collection.
     Provides collection details (type, address, name, symbol, total supply, holder count) and individual token instance data (ID, name, description, external URL, metadata attributes).
     Essential for a detailed overview of an address's digital collectibles and their associated collection data.
+    **SUPPORTS PAGINATION**: If response includes 'pagination' field, use the provided next_call to get additional pages.
     """  # noqa: E501
 
     api_path = f"/api/v2/addresses/{address}/nft/collections"
@@ -286,6 +287,7 @@ async def get_address_logs(
     Get comprehensive logs emitted by a specific address.
     Returns enriched logs, primarily focusing on decoded event parameters with their types and values (if event decoding is applicable).
     Essential for analyzing smart contract events emitted by specific addresses, monitoring token contract activities, tracking DeFi protocol state changes, debugging contract event emissions, and understanding address-specific event history flows.
+    **SUPPORTS PAGINATION**: If response includes 'pagination' field, use the provided next_call to get additional pages.
     """  # noqa: E501
     api_path = f"/api/v2/addresses/{address}/logs"
     params = {}

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -442,7 +442,7 @@ def build_tool_response(
         A ToolResponse instance.
     """
     # Automatically add pagination instructions when pagination is present
-    final_instructions = list(instructions) if instructions else []
+    final_instructions = list(instructions) if instructions is not None else []
 
     if pagination:
         pagination_instructions = [
@@ -451,10 +451,15 @@ def build_tool_response(
         ]
         final_instructions.extend(pagination_instructions)
 
+    # Return instructions if they were explicitly provided (even if empty) or if pagination added some
+    final_instructions_output = None
+    if instructions is not None or pagination is not None:
+        final_instructions_output = final_instructions
+
     return ToolResponse(
         data=data,
         data_description=data_description,
         notes=notes,
-        instructions=final_instructions if final_instructions else None,
+        instructions=final_instructions_output,
         pagination=pagination,
     )

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -441,10 +441,22 @@ def build_tool_response(
     Returns:
         A ToolResponse instance.
     """
+    # Automatically add pagination instructions when pagination is present
+    final_instructions = list(instructions) if instructions else []
+
+    if pagination:
+        pagination_instructions = [
+            "⚠️ PAGINATION DETECTED: This response contains only one page of a larger dataset.",
+            f"To get the next page, call the tool '{pagination.next_call.tool_name}' with these exact parameters:",
+            f"Parameters: {pagination.next_call.params}",
+            "Continue calling subsequent pages if you need comprehensive results.",
+        ]
+        final_instructions.extend(pagination_instructions)
+
     return ToolResponse(
         data=data,
         data_description=data_description,
         notes=notes,
-        instructions=instructions,
+        instructions=final_instructions if final_instructions else None,
         pagination=pagination,
     )

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -446,9 +446,7 @@ def build_tool_response(
 
     if pagination:
         pagination_instructions = [
-            "⚠️ PAGINATION DETECTED: This response contains only one page of a larger dataset.",
-            f"To get the next page, call the tool '{pagination.next_call.tool_name}' with these exact parameters:",
-            f"Parameters: {pagination.next_call.params}",
+            "⚠️ MORE DATA AVAILABLE: Use pagination.next_call to get the next page.",
             "Continue calling subsequent pages if you need comprehensive results.",
         ]
         final_instructions.extend(pagination_instructions)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -351,12 +351,11 @@ def test_build_tool_response_with_pagination_instructions():
 
     # Verify pagination instructions were added
     assert response.instructions is not None
-    assert len(response.instructions) == 5  # 1 existing + 4 pagination instructions
+    assert len(response.instructions) == 3  # 1 existing + 2 pagination instructions
     assert response.instructions[0] == "Existing instruction"
-    assert "⚠️ PAGINATION DETECTED" in response.instructions[1]
-    assert "get_tokens_by_address" in response.instructions[2]
-    assert "chain_id" in response.instructions[3]
-    assert "Continue calling subsequent pages" in response.instructions[4]
+    assert "⚠️ MORE DATA AVAILABLE" in response.instructions[1]
+    assert "Use pagination.next_call to get the next page" in response.instructions[1]
+    assert "Continue calling subsequent pages" in response.instructions[2]
 
     # Test with no existing instructions
     response_no_existing = build_tool_response(
@@ -366,8 +365,8 @@ def test_build_tool_response_with_pagination_instructions():
 
     # Verify pagination instructions were added even without existing instructions
     assert response_no_existing.instructions is not None
-    assert len(response_no_existing.instructions) == 4  # Only pagination instructions
-    assert "⚠️ PAGINATION DETECTED" in response_no_existing.instructions[0]
+    assert len(response_no_existing.instructions) == 2  # Only pagination instructions
+    assert "⚠️ MORE DATA AVAILABLE" in response_no_existing.instructions[0]
 
     # Test without pagination (should not add instructions)
     response_no_pagination = build_tool_response(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -329,3 +329,49 @@ def test_nft_collection_info_handles_none_values():
     )
     assert collection_with_values.name == "Test Collection"
     assert collection_with_values.symbol == "TEST"
+
+
+def test_build_tool_response_with_pagination_instructions():
+    """Test that build_tool_response automatically adds pagination instructions."""
+    from blockscout_mcp_server.tools.common import build_tool_response
+
+    # Create pagination info
+    pagination = PaginationInfo(
+        next_call=NextCallInfo(
+            tool_name="get_tokens_by_address", params={"chain_id": "1", "address": "0x123", "cursor": "next_page_token"}
+        )
+    )
+
+    # Test with existing instructions
+    response = build_tool_response(
+        data="test_data",
+        instructions=["Existing instruction"],
+        pagination=pagination,
+    )
+
+    # Verify pagination instructions were added
+    assert response.instructions is not None
+    assert len(response.instructions) == 5  # 1 existing + 4 pagination instructions
+    assert response.instructions[0] == "Existing instruction"
+    assert "⚠️ PAGINATION DETECTED" in response.instructions[1]
+    assert "get_tokens_by_address" in response.instructions[2]
+    assert "chain_id" in response.instructions[3]
+    assert "Continue calling subsequent pages" in response.instructions[4]
+
+    # Test with no existing instructions
+    response_no_existing = build_tool_response(
+        data="test_data",
+        pagination=pagination,
+    )
+
+    # Verify pagination instructions were added even without existing instructions
+    assert response_no_existing.instructions is not None
+    assert len(response_no_existing.instructions) == 4  # Only pagination instructions
+    assert "⚠️ PAGINATION DETECTED" in response_no_existing.instructions[0]
+
+    # Test without pagination (should not add instructions)
+    response_no_pagination = build_tool_response(
+        data="test_data",
+    )
+
+    assert response_no_pagination.instructions is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -368,9 +368,17 @@ def test_build_tool_response_with_pagination_instructions():
     assert len(response_no_existing.instructions) == 2  # Only pagination instructions
     assert "⚠️ MORE DATA AVAILABLE" in response_no_existing.instructions[0]
 
-    # Test without pagination (should not add instructions)
+    # Test without pagination and no instructions (should return None)
     response_no_pagination = build_tool_response(
         data="test_data",
     )
 
     assert response_no_pagination.instructions is None
+
+    # Test without pagination but with empty instructions (should return empty list)
+    response_empty_instructions = build_tool_response(
+        data="test_data",
+        instructions=[],
+    )
+
+    assert response_empty_instructions.instructions == []


### PR DESCRIPTION
Closes #117 

LLMs were ignoring structured `pagination` fields in tool responses, causing users to receive incomplete datasets. This PR implements a multi-layered approach to provide clear pagination guidance through enhanced general rules, automatic instruction generation, and updated tool descriptions.

The `build_tool_response()` function now automatically adds motivational instructions when pagination is present, while maintaining the structured data format. All paginated tools (`get_tokens_by_address`, `nft_tokens_by_address`, `get_address_logs`, `get_transaction_logs`) receive updated docstrings with prominent pagination notices.

This balanced approach provides both human-readable motivation ("⚠️ MORE DATA AVAILABLE") and machine-readable execution details, significantly improving the likelihood that LLMs will fetch complete datasets for users.