### PR TITLE
Bump the server version to 0.4.1

### DIFF
--- a/.cursor/rules/130-version-management.mdc
+++ b/.cursor/rules/130-version-management.mdc
@@ -5,9 +5,10 @@ alwaysApply: false
 ---
 # MCP Server Version Management Rule
 
-## When updating the version of the MCP server, update the following files:
+## When updating the version of the MCP server, update the following files
 
 1. **`pyproject.toml`** - Update the `version` field in the `[project]` section:
+
    ```toml
    [project]
    name = "blockscout-mcp-server"
@@ -15,14 +16,36 @@ alwaysApply: false
    ```
 
 2. **`blockscout_mcp_server/__init__.py`** - Update the `__version__` variable:
+
    ```python
    """Blockscout MCP Server package."""
 
    __version__ = "X.Y.Z"  # <-- Update this line
    ```
 
-## Important Notes:
+## Important Notes
 
 - **Use the exact same version string** in both locations (e.g., "1.2.3")
 - **Follow semantic versioning** (MAJOR.MINOR.PATCH) when choosing version numbers
 - **Update both files simultaneously** to maintain consistency across the codebase
+
+## Why Dual-Location Approach?
+
+While modern Python packaging suggests using `importlib.metadata.version(__name__)` to make `pyproject.toml` the single source of truth, **we deliberately use the dual-location approach** for the following reasons:
+
+### **Reliability Across Environments**
+
+- **Local Development**: Works when running directly from source without installation
+- **Docker Containers**: Functions regardless of installation method
+- **Testing**: Reliable in various test environments and CI/CD pipelines
+- **Multiple Installation Methods**: Compatible with pip, uv, and other package managers
+
+### **Deployment Scenarios**
+
+For an MCP server that needs to work in various environments (local development, Docker, different installation methods), the dual-location approach ensures version information is always accessible without runtime dependencies or potential import failures.
+
+### **Trade-offs**
+
+- **Slight Maintenance Overhead**: Requires updating two files instead of one
+- **Drift Risk**: Mitigated by this rule ensuring both locations are updated simultaneously
+- **Consistency**: The version management rule ensures both locations stay in sync

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.3.1"
+version = "0.4.1"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
This pull request updates the version of the server `0.4.1`. `0.4.0` was missed by mistake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.4.1.
  * Expanded documentation on version management explaining the dual-location version string approach for improved reliability across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->