### PR TITLE
Add REST API scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 mcp-server/
 ├── blockscout_mcp_server/      # Main Python package for the server
 │   ├── __init__.py             # Makes the directory a Python package
+│   ├── api/                    # REST API implementation
+│   │   ├── __init__.py         # Initializes the api sub-package
+│   │   ├── dependencies.py     # Dependency providers for the REST API
+│   │   └── routes.py           # REST API route definitions
 │   ├── __main__.py             # Entry point for `python -m blockscout_mcp_server`
 │   ├── server.py               # Core server logic: FastMCP instance, tool registration, CLI
 │   ├── config.py               # Configuration management (e.g., API keys, timeouts, cache settings)
@@ -33,6 +37,7 @@ mcp-server/
 │   │   ├── test_ens_tools_integration.py       # Tool-level integration tests for ENS tools
 │   │   ├── test_search_tools_integration.py    # Tool-level integration tests for search tools
 │   │   └── test_transaction_tools_integration.py # Tool-level integration tests for transaction tools
+│   ├── test_server.py            # Tests for server CLI and startup logic
 │   ├── test_models.py            # Tests for Pydantic response models
 │   └── tools/                  # Unit test modules for each tool implementation
 │       ├── test_common.py            # Tests for shared utility functions

--- a/blockscout_mcp_server/api/dependencies.py
+++ b/blockscout_mcp_server/api/dependencies.py
@@ -2,15 +2,20 @@
 
 
 class MockCtx:
-    """A mock context object that provides no-op implementations for MCP context methods."""
+    """A mock context for stateless REST calls.
+
+    Tool functions require a ``ctx`` object to report progress. Since REST
+    endpoints are stateless and have no MCP session, this mock provides the
+    required ``info`` and ``report_progress`` methods as no-op async functions.
+    """
 
     async def info(self, message: str) -> None:
-        """A no-op info method."""
-        return None
+        """Simulate the ``info`` method of an MCP ``Context``."""
+        pass
 
     async def report_progress(self, *args, **kwargs) -> None:
-        """A no-op report_progress method."""
-        return None
+        """Simulate the ``report_progress`` method of an MCP ``Context``."""
+        pass
 
 
 def get_mock_context() -> MockCtx:

--- a/blockscout_mcp_server/api/dependencies.py
+++ b/blockscout_mcp_server/api/dependencies.py
@@ -1,0 +1,18 @@
+"""Dependencies for the REST API, such as mock context providers."""
+
+
+class MockCtx:
+    """A mock context object that provides no-op implementations for MCP context methods."""
+
+    async def info(self, message: str) -> None:
+        """A no-op info method."""
+        return None
+
+    async def report_progress(self, *args, **kwargs) -> None:
+        """A no-op report_progress method."""
+        return None
+
+
+def get_mock_context() -> MockCtx:
+    """Dependency provider to get a mock context for stateless REST calls."""
+    return MockCtx()

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -1,0 +1,8 @@
+"""Module for registering all REST API routes with the FastMCP server."""
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register_api_routes(mcp: FastMCP) -> None:
+    """Registers all REST API routes."""
+    pass

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -99,8 +99,7 @@ def main_command(
         asgi_app = mcp.streamable_http_app()
         uvicorn.run(asgi_app, host=http_host, port=http_port)
     elif rest:
-        print("Error: The --rest flag can only be used with the --http flag.")
-        raise typer.Exit(code=1)
+        raise typer.BadParameter("The --rest flag can only be used with the --http flag.")
     else:
         mcp.run()
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -102,6 +102,7 @@ def main_command(
     elif rest:
         raise typer.BadParameter("The --rest flag can only be used with the --http flag.")
     else:
+        # This is the original behavior: run in stdio mode
         mcp.run()
 
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -94,8 +94,9 @@ def main_command(
         else:
             print(f"Starting Blockscout MCP Server in HTTP Streamable mode on {http_host}:{http_port}")
 
-        mcp.settings.stateless_http = True
-        mcp.settings.json_response = True
+        # Configure the existing 'mcp' instance for stateless HTTP with JSON responses
+        mcp.settings.stateless_http = True  # Enable stateless mode
+        mcp.settings.json_response = True  # Enable JSON responses instead of SSE for tool calls
         asgi_app = mcp.streamable_http_app()
         uvicorn.run(asgi_app, host=http_host, port=http_port)
     elif rest:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -12,7 +13,9 @@ def test_rest_flag_without_http_fails():
 
     result = runner.invoke(cli_app, ["--rest"])
     assert result.exit_code != 0
-    assert "The --rest flag can only be used with the --http flag." in result.output
+    # Typer may add ANSI color codes to the error message; strip them for a stable assertion.
+    output_clean = re.sub(r"\x1b\[[0-9;]*[mK]", "", result.output)
+    assert "The --rest flag can only be used with the --http flag." in output_clean
 
 
 @patch("uvicorn.run")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,53 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_rest_flag_without_http_fails():
+    """Verify that using --rest without --http raises a SystemExit."""
+    from blockscout_mcp_server.server import cli_app
+
+    result = runner.invoke(cli_app, ["--rest"])
+    assert result.exit_code != 0
+    assert "The --rest flag can only be used with the --http flag." in result.stdout
+
+
+@patch("uvicorn.run")
+def test_http_and_rest_flags_call_register_routes(mock_uvicorn_run):
+    """Verify that --http and --rest together call the route registration function."""
+    mock_routes_module = MagicMock()
+    sys.modules["blockscout_mcp_server.api.routes"] = mock_routes_module
+    from blockscout_mcp_server.server import cli_app
+
+    result = runner.invoke(cli_app, ["--http", "--rest"])
+
+    assert result.exit_code == 0
+    mock_routes_module.register_api_routes.assert_called_once()
+    mock_uvicorn_run.assert_called_once()
+    del sys.modules["blockscout_mcp_server.api.routes"]
+
+
+@patch("uvicorn.run")
+@patch("blockscout_mcp_server.server.register_api_routes", create=True)
+def test_http_only_does_not_register_rest_routes(mock_register_routes, mock_uvicorn_run):
+    """Verify that --http alone does not call the route registration function."""
+    from blockscout_mcp_server.server import cli_app
+
+    result = runner.invoke(cli_app, ["--http"])
+
+    assert result.exit_code == 0
+    mock_register_routes.assert_not_called()
+    mock_uvicorn_run.assert_called_once()
+
+
+@patch("mcp.server.fastmcp.FastMCP.run")
+def test_stdio_mode_works(mock_mcp_run):
+    """Verify that the default stdio mode runs correctly."""
+    from blockscout_mcp_server.server import cli_app
+
+    result = runner.invoke(cli_app, [])
+    assert result.exit_code == 0
+    mock_mcp_run.assert_called_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,12 +7,12 @@ runner = CliRunner()
 
 
 def test_rest_flag_without_http_fails():
-    """Verify that using --rest without --http raises a SystemExit."""
+    """Verify that using --rest without --http raises a CLI error."""
     from blockscout_mcp_server.server import cli_app
 
     result = runner.invoke(cli_app, ["--rest"])
     assert result.exit_code != 0
-    assert "The --rest flag can only be used with the --http flag." in result.stdout
+    assert "The --rest flag can only be used with the --http flag." in result.output
 
 
 @patch("uvicorn.run")


### PR DESCRIPTION
## Summary
- add new `api` package with placeholder routes and dependencies
- enable `--rest` flag for server CLI
- update project layout docs in `AGENTS.md`
- test server CLI behavior

Closes #135


------
https://chatgpt.com/codex/tasks/task_b_686eeb3be8c88323a38ee9c968d21828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a REST API mode, enabled via new command-line options.
  * Added support for running the server in HTTP Streamable mode or REST API mode.

* **Documentation**
  * Updated project documentation to describe the new REST API structure.

* **Tests**
  * Added tests to verify new CLI options and server startup logic, including REST API and HTTP modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->