### PR TITLE
Add REST API endpoints and helpers

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -20,6 +20,7 @@ AI agents should consult the appropriate rule files based on the context of thei
 
 ### API Endpoints & Static Content
 
+- **Apply** `.cursor/rules/150-rest-api-implementation.mdc` when implementing REST API endpoints that wrap MCP tools
 - **Apply** `.cursor/rules/160-static-content-caching.mdc` when serving static files in API routes
 
 ### Testing & Development

--- a/.cursor/rules/150-rest-api-implementation.mdc
+++ b/.cursor/rules/150-rest-api-implementation.mdc
@@ -1,0 +1,27 @@
+---
+description: Follow these instructions when implementing REST API endpoints that wrap MCP tools.
+globs: blockscout_mcp_server/api/routes.py
+alwaysApply: false
+---
+# REST API Implementation Guidelines
+
+When exposing an MCP tool function as a REST API endpoint, follow these conventions to ensure consistency, maintainability, and robustness.
+
+## 1. Naming Convention
+
+REST handler functions in `api/routes.py` **MUST** be named after the MCP tool they wrap, with an `_rest` suffix.
+
+- **Tool function:** `get_block_info()`
+- **REST handler:** `get_block_info_rest()`
+
+## 2. Parameter Handling
+
+All request parameter extraction and validation **MUST** be handled by the `extract_and_validate_params` helper from `api/helpers.py`. This centralizes logic for required/optional parameters and type conversion.
+
+## 3. Error Handling
+
+All REST handlers **MUST** be decorated with the `@handle_validation_errors` decorator from `api/helpers.py`. This ensures that any `ValueError` raised during parameter extraction (e.g., for a missing required parameter) is automatically converted into a standardized HTTP 400 Bad Request response with a JSON error message. Do not implement `try...except` blocks for validation errors within the handlers themselves.
+
+## 4. Route Registration
+
+All REST API endpoints **MUST** be registered under the `/v1/` path prefix in `register_api_routes` to ensure proper versioning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ mcp-server/
 │   ├── api/                    # REST API implementation
 │   │   ├── __init__.py         # Initializes the api sub-package
 │   │   ├── dependencies.py     # Dependency providers for the REST API
+│   │   ├── helpers.py          # Shared utilities for REST API handlers
 │   │   └── routes.py           # REST API route definitions
 │   ├── __main__.py             # Entry point for `python -m blockscout_mcp_server`
 │   ├── server.py               # Core server logic: FastMCP instance, tool registration, CLI
@@ -181,6 +182,9 @@ mcp-server/
             * Handles API communication, chain resolution, pagination, data processing, and error handling.
             * Implements standardized patterns used across the tool ecosystem.
         * **Individual Tool Modules** (e.g., `ens_tools.py`, `transaction_tools.py`):
+            * **`api/helpers.py`**: Provides shared utilities for REST API handlers, including parameter extraction and error handling.
+            * **`api/routes.py`**: Defines all REST API endpoints, which act as thin wrappers around the MCP tool functions.
+            * **`api/dependencies.py`**: Contains dependency providers for the REST API, such as a mock context for stateless calls.
             * Each file will group logically related tools.
             * Each tool will be implemented as an `async` Python function.
             * For Blockscout API tools, functions take `chain_id` as the first parameter followed by other arguments and a `ctx: Context` parameter for progress tracking.

--- a/blockscout_mcp_server/api/helpers.py
+++ b/blockscout_mcp_server/api/helpers.py
@@ -1,0 +1,67 @@
+"""Shared utilities for REST API route handlers."""
+
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+
+def str_to_bool(val: str) -> bool:
+    """Convert a string to a boolean value."""
+    return val.lower() in ("true", "1", "t", "yes")
+
+
+# A map of parameter names to their type conversion functions.
+# All other parameters are assumed to be strings.
+PARAM_TYPES: dict[str, Callable[[str], Any]] = {
+    "include_transactions": str_to_bool,
+    "include_raw_input": str_to_bool,
+}
+
+
+def extract_and_validate_params(request: Request, required: list[str], optional: list[str]) -> dict[str, Any]:
+    """Extract and validate query parameters from a request.
+
+    Args:
+        request: The Starlette request object.
+        required: A list of required parameter names.
+        optional: A list of optional parameter names.
+
+    Returns:
+        A dictionary of validated parameters.
+
+    Raises:
+        ValueError: If a required parameter is missing.
+    """
+    params: dict[str, Any] = {}
+    query_params = request.query_params
+
+    for name in required:
+        value = query_params.get(name)
+        if value is None:
+            raise ValueError(f"Missing required query parameter: '{name}'")
+        params[name] = PARAM_TYPES.get(name, str)(value)
+
+    for name in optional:
+        value = query_params.get(name)
+        if value is not None:
+            params[name] = PARAM_TYPES.get(name, str)(value)
+
+    return params
+
+
+def handle_validation_errors(
+    func: Callable[[Request], Awaitable[Response]],
+) -> Callable[[Request], Awaitable[Response]]:
+    """Decorator to catch ValueErrors and return a 400 Bad Request response."""
+
+    @wraps(func)
+    async def wrapper(request: Request) -> Response:
+        try:
+            return await func(request)
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+
+    return wrapper

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -1,10 +1,37 @@
 """Module for registering all REST API routes with the FastMCP server."""
 
 import pathlib
+from collections.abc import Callable
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
+
+from blockscout_mcp_server.api.dependencies import get_mock_context
+from blockscout_mcp_server.api.helpers import (
+    extract_and_validate_params,
+    handle_validation_errors,
+)
+from blockscout_mcp_server.tools.address_tools import (
+    get_address_info,
+    get_address_logs,
+    get_tokens_by_address,
+    nft_tokens_by_address,
+)
+from blockscout_mcp_server.tools.block_tools import get_block_info, get_latest_block
+from blockscout_mcp_server.tools.chains_tools import get_chains_list
+from blockscout_mcp_server.tools.contract_tools import get_contract_abi
+from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
+from blockscout_mcp_server.tools.get_instructions import __get_instructions__
+from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
+from blockscout_mcp_server.tools.transaction_tools import (
+    get_token_transfers_by_address,
+    get_transaction_info,
+    get_transaction_logs,
+    get_transactions_by_address,
+    transaction_summary,
+)
 
 # Define paths to static files relative to this file's location
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
@@ -46,9 +73,182 @@ async def main_page(_: Request) -> Response:
     return HTMLResponse(INDEX_HTML_CONTENT)
 
 
+async def list_tools_rest(request: Request) -> Response:
+    """Return a list of all available tools and their schemas."""
+    mcp_instance = request.app.state.mcp_instance
+    tools_list = await mcp_instance.list_tools()
+    return JSONResponse([tool.model_dump() for tool in tools_list])
+
+
+@handle_validation_errors
+async def get_instructions_rest(_: Request) -> Response:
+    """REST wrapper for the __get_instructions__ tool."""
+    tool_response = await __get_instructions__(ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_block_info_rest(request: Request) -> Response:
+    """REST wrapper for the get_block_info tool."""
+    params = extract_and_validate_params(
+        request,
+        required=["chain_id", "number_or_hash"],
+        optional=["include_transactions"],
+    )
+    tool_response = await get_block_info(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_latest_block_rest(request: Request) -> Response:
+    """REST wrapper for the get_latest_block tool."""
+    params = extract_and_validate_params(request, required=["chain_id"], optional=[])
+    tool_response = await get_latest_block(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_address_by_ens_name_rest(request: Request) -> Response:
+    """REST wrapper for the get_address_by_ens_name tool."""
+    params = extract_and_validate_params(request, required=["name"], optional=[])
+    tool_response = await get_address_by_ens_name(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_transactions_by_address_rest(request: Request) -> Response:
+    """REST wrapper for the get_transactions_by_address tool."""
+    params = extract_and_validate_params(
+        request,
+        required=["chain_id", "address"],
+        optional=["age_from", "age_to", "methods", "cursor"],
+    )
+    tool_response = await get_transactions_by_address(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_token_transfers_by_address_rest(request: Request) -> Response:
+    """REST wrapper for the get_token_transfers_by_address tool."""
+    params = extract_and_validate_params(
+        request,
+        required=["chain_id", "address"],
+        optional=["age_from", "age_to", "token", "cursor"],
+    )
+    tool_response = await get_token_transfers_by_address(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def lookup_token_by_symbol_rest(request: Request) -> Response:
+    """REST wrapper for the lookup_token_by_symbol tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "symbol"], optional=[])
+    tool_response = await lookup_token_by_symbol(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_contract_abi_rest(request: Request) -> Response:
+    """REST wrapper for the get_contract_abi tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "address"], optional=[])
+    tool_response = await get_contract_abi(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_address_info_rest(request: Request) -> Response:
+    """REST wrapper for the get_address_info tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "address"], optional=[])
+    tool_response = await get_address_info(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_tokens_by_address_rest(request: Request) -> Response:
+    """REST wrapper for the get_tokens_by_address tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "address"], optional=["cursor"])
+    tool_response = await get_tokens_by_address(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def transaction_summary_rest(request: Request) -> Response:
+    """REST wrapper for the transaction_summary tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "transaction_hash"], optional=[])
+    tool_response = await transaction_summary(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def nft_tokens_by_address_rest(request: Request) -> Response:
+    """REST wrapper for the nft_tokens_by_address tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "address"], optional=["cursor"])
+    tool_response = await nft_tokens_by_address(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_transaction_info_rest(request: Request) -> Response:
+    """REST wrapper for the get_transaction_info tool."""
+    params = extract_and_validate_params(
+        request,
+        required=["chain_id", "transaction_hash"],
+        optional=["include_raw_input"],
+    )
+    tool_response = await get_transaction_info(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_transaction_logs_rest(request: Request) -> Response:
+    """REST wrapper for the get_transaction_logs tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "transaction_hash"], optional=["cursor"])
+    tool_response = await get_transaction_logs(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_address_logs_rest(request: Request) -> Response:
+    """REST wrapper for the get_address_logs tool."""
+    params = extract_and_validate_params(request, required=["chain_id", "address"], optional=["cursor"])
+    tool_response = await get_address_logs(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_validation_errors
+async def get_chains_list_rest(_: Request) -> Response:
+    """REST wrapper for the get_chains_list tool."""
+    tool_response = await get_chains_list(ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+def _add_v1_tool_route(mcp: FastMCP, path: str, handler: Callable[..., Any]) -> None:
+    """Register a tool route under the /v1/ prefix."""
+    mcp.custom_route(f"/v1{path}", methods=["GET"])(handler)
+
+
 def register_api_routes(mcp: FastMCP) -> None:
     """Registers all REST API routes."""
     # These routes are not part of the OpenAPI schema for tools.
     mcp.custom_route("/health", methods=["GET"], include_in_schema=False)(health_check)
     mcp.custom_route("/llms.txt", methods=["GET"], include_in_schema=False)(serve_llms_txt)
     mcp.custom_route("/", methods=["GET"], include_in_schema=False)(main_page)
+
+    # Version 1 of the REST API
+    _add_v1_tool_route(mcp, "/tools", list_tools_rest)
+    _add_v1_tool_route(mcp, "/get_instructions", get_instructions_rest)
+    _add_v1_tool_route(mcp, "/get_block_info", get_block_info_rest)
+    _add_v1_tool_route(mcp, "/get_latest_block", get_latest_block_rest)
+    _add_v1_tool_route(mcp, "/get_address_by_ens_name", get_address_by_ens_name_rest)
+    _add_v1_tool_route(mcp, "/get_transactions_by_address", get_transactions_by_address_rest)
+    _add_v1_tool_route(mcp, "/get_token_transfers_by_address", get_token_transfers_by_address_rest)
+    _add_v1_tool_route(mcp, "/lookup_token_by_symbol", lookup_token_by_symbol_rest)
+    _add_v1_tool_route(mcp, "/get_contract_abi", get_contract_abi_rest)
+    _add_v1_tool_route(mcp, "/get_address_info", get_address_info_rest)
+    _add_v1_tool_route(mcp, "/get_tokens_by_address", get_tokens_by_address_rest)
+    _add_v1_tool_route(mcp, "/transaction_summary", transaction_summary_rest)
+    _add_v1_tool_route(mcp, "/nft_tokens_by_address", nft_tokens_by_address_rest)
+    _add_v1_tool_route(mcp, "/get_transaction_info", get_transaction_info_rest)
+    _add_v1_tool_route(mcp, "/get_transaction_logs", get_transaction_logs_rest)
+    _add_v1_tool_route(mcp, "/get_address_logs", get_address_logs_rest)
+    _add_v1_tool_route(mcp, "/get_chains_list", get_chains_list_rest)

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -1,35 +1,49 @@
-"""Tests for the static REST API routes."""
+"""Tests for the REST API routes."""
+
+from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from mcp.server.fastmcp import FastMCP
 
 from blockscout_mcp_server.api.routes import register_api_routes
+from blockscout_mcp_server.models import ToolResponse
+
+
+@pytest.fixture
+def test_mcp_instance():
+    """Provides a FastMCP instance for testing."""
+    return FastMCP(name="test-server-for-routes")
+
+
+@pytest.fixture
+def client(test_mcp_instance):
+    """Provides an httpx client configured to talk to the test MCP instance."""
+    register_api_routes(test_mcp_instance)
+    asgi_app = test_mcp_instance.streamable_http_app()
+    asgi_app.state.mcp_instance = test_mcp_instance
+    return AsyncClient(transport=ASGITransport(app=asgi_app), base_url="http://test")
 
 
 @pytest.mark.asyncio
-async def test_static_routes_work_correctly():
+@patch("blockscout_mcp_server.api.routes.INDEX_HTML_CONTENT", "<h1>Blockscout MCP Server</h1>")
+@patch("blockscout_mcp_server.api.routes.LLMS_TXT_CONTENT", "# Blockscout MCP Server")
+async def test_static_routes_work_correctly(client: AsyncClient):
     """Verify that static routes return correct content and headers after registration."""
-    test_mcp = FastMCP(name="test-server-for-routes")
-    register_api_routes(test_mcp)
-    async with AsyncClient(
-        transport=ASGITransport(app=test_mcp.streamable_http_app()),
-        base_url="http://testserver",
-    ) as client:
-        response_health = await client.get("/health")
-        assert response_health.status_code == 200
-        assert response_health.json() == {"status": "ok"}
-        assert "application/json" in response_health.headers["content-type"]
+    response_health = await client.get("/health")
+    assert response_health.status_code == 200
+    assert response_health.json() == {"status": "ok"}
+    assert "application/json" in response_health.headers["content-type"]
 
-        response_main = await client.get("/")
-        assert response_main.status_code == 200
-        assert "<h1>Blockscout MCP Server</h1>" in response_main.text
-        assert "text/html" in response_main.headers["content-type"]
+    response_main = await client.get("/")
+    assert response_main.status_code == 200
+    assert "<h1>Blockscout MCP Server</h1>" in response_main.text
+    assert "text/html" in response_main.headers["content-type"]
 
-        response_llms = await client.get("/llms.txt")
-        assert response_llms.status_code == 200
-        assert "# Blockscout MCP Server" in response_llms.text
-        assert "text/plain" in response_llms.headers["content-type"]
+    response_llms = await client.get("/llms.txt")
+    assert response_llms.status_code == 200
+    assert "# Blockscout MCP Server" in response_llms.text
+    assert "text/plain" in response_llms.headers["content-type"]
 
 
 @pytest.mark.asyncio
@@ -38,8 +52,53 @@ async def test_routes_not_found_on_clean_app():
     test_mcp = FastMCP(name="test-server-clean")
     async with AsyncClient(
         transport=ASGITransport(app=test_mcp.streamable_http_app()),
-        base_url="http://testserver",
-    ) as client:
-        assert (await client.get("/health")).status_code == 404
-        assert (await client.get("/")).status_code == 404
-        assert (await client.get("/llms.txt")).status_code == 404
+        base_url="http://test",
+    ) as test_client:
+        assert (await test_client.get("/health")).status_code == 404
+        assert (await test_client.get("/")).status_code == 404
+        assert (await test_client.get("/llms.txt")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_tools_rest(client: AsyncClient, test_mcp_instance: FastMCP):
+    """Verify that the /v1/tools endpoint returns a list of tools."""
+    test_mcp_instance.list_tools = AsyncMock(return_value=[])
+    response = await client.get("/v1/tools")
+    assert response.status_code == 200
+    assert response.json() == []
+    test_mcp_instance.list_tools.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("blockscout_mcp_server.api.routes.get_latest_block", new_callable=AsyncMock)
+async def test_get_latest_block_rest_success(mock_tool, client: AsyncClient):
+    """Test the happy path for a simple REST endpoint."""
+    mock_tool.return_value = ToolResponse(data={"block_number": 123})
+    response = await client.get("/v1/get_latest_block?chain_id=1")
+    assert response.status_code == 200
+    assert response.json()["data"] == {"block_number": 123}
+    mock_tool.assert_called_once_with(chain_id="1", ctx=ANY)
+
+
+@pytest.mark.asyncio
+async def test_get_latest_block_rest_missing_param(client: AsyncClient):
+    """Test that a 400 is returned if a required parameter is missing."""
+    response = await client.get("/v1/get_latest_block")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Missing required query parameter: 'chain_id'"}
+
+
+@pytest.mark.asyncio
+@patch("blockscout_mcp_server.api.routes.get_block_info", new_callable=AsyncMock)
+async def test_get_block_info_rest_with_optional_param(mock_tool, client: AsyncClient):
+    """Test an endpoint with both required and optional boolean parameters."""
+    mock_tool.return_value = ToolResponse(data={"block_number": 456})
+    response = await client.get("/v1/get_block_info?chain_id=1&number_or_hash=latest&include_transactions=true")
+    assert response.status_code == 200
+    assert response.json()["data"] == {"block_number": 456}
+    mock_tool.assert_called_once_with(
+        chain_id="1",
+        number_or_hash="latest",
+        include_transactions=True,
+        ctx=ANY,
+    )


### PR DESCRIPTION
## Summary
- add REST API implementation guidelines for wrapping MCP tools
- add shared helper utilities
- extend API routes with tool wrappers
- add unit tests for new REST endpoints
- document new helpers in AGENTS docs

Closes #137


------
https://chatgpt.com/codex/tasks/task_b_686f43dea04c8323a9832841ff20e72d