### PR TITLE
Bump MCP server to v0.5.0

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.4.1"
+version = "0.5.0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- bump project version to `0.5.0`

## Testing
- `pytest`
- `pytest tests/tools/test_address_tools.py -v`
- `pytest --cov=blockscout_mcp_server --cov-report=term-missing`
- `ruff check .`
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_b_6870612e3328832380fe7327f6743f8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 0.4.1 to 0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->