### PR TITLE
Deprecate get_address_logs endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ mcp-server/
 │       ├── ens_tools.py        # Implements ENS-related tools
 │       ├── search_tools.py     # Implements search-related tools (e.g., lookup_token_by_symbol)
 │       ├── contract_tools.py   # Implements contract-related tools (e.g., get_contract_abi)
-│       ├── address_tools.py    # Implements address-related tools (e.g., get_address_info, get_tokens_by_address, get_address_logs)
+│       ├── address_tools.py    # Implements address-related tools (e.g., get_address_info, get_tokens_by_address)
 │       ├── block_tools.py      # Implements block-related tools (e.g., get_latest_block, get_block_info)
 │       ├── transaction_tools.py# Implements transaction-related tools (e.g., get_transactions_by_address, get_transaction_info)
 │       └── chains_tools.py     # Implements chain-related tools (e.g., get_chains_list)
@@ -50,7 +50,6 @@ mcp-server/
 │       ├── test_common.py            # Tests for shared utility functions
 │       ├── test_address_tools.py     # Tests for address-related tools (get_address_info, get_tokens_by_address)
 │       ├── test_address_tools_2.py   # Extended tests for nft_tokens_by_address
-│       ├── test_address_logs.py      # Tests for get_address_logs
 │       ├── test_block_tools.py       # Tests for block-related tools (get_latest_block, get_block_info)
 │       ├── test_chains_tools.py      # Tests for chain-related tools (get_chains_list)
 │       ├── test_contract_tools.py    # Tests for contract-related tools (get_contract_abi)
@@ -231,6 +230,6 @@ mcp-server/
                 * `ens_tools.py`: Implements `get_address_by_ens_name` (fixed BENS endpoint, no chain_id).
                 * `search_tools.py`: Implements `lookup_token_by_symbol(chain_id, symbol)`.
                 * `contract_tools.py`: Implements `get_contract_abi(chain_id, address)`.
-                * `address_tools.py`: Implements `get_address_info(chain_id, address)` (includes public tags), `get_tokens_by_address(chain_id, address, cursor=None)`, `nft_tokens_by_address(chain_id, address, cursor=None)`, `get_address_logs(chain_id, address, cursor=None)` with robust, cursor-based pagination.
+                * `address_tools.py`: Implements `get_address_info(chain_id, address)` (includes public tags), `get_tokens_by_address(chain_id, address, cursor=None)`, `nft_tokens_by_address(chain_id, address, cursor=None)` with robust, cursor-based pagination.
                 * `block_tools.py`: Implements `get_block_info(chain_id, number_or_hash, include_transactions=False)`, `get_latest_block(chain_id)`.
                 * `transaction_tools.py`: Implements `get_transactions_by_address(chain_id, address, age_from, age_to, methods, cursor=None)`, `get_token_transfers_by_address(chain_id, address, age_from, age_to, token, cursor=None)`, `get_transaction_info(chain_id, hash, include_raw_input=False)`, `transaction_summary(chain_id, hash)`, `get_transaction_logs(chain_id, hash, cursor=None)`, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ mcp-server/
 │       ├── test_common.py            # Tests for shared utility functions
 │       ├── test_address_tools.py     # Tests for address-related tools (get_address_info, get_tokens_by_address)
 │       ├── test_address_tools_2.py   # Extended tests for nft_tokens_by_address
+│       ├── test_address_logs.py      # Tests for get_address_logs
 │       ├── test_block_tools.py       # Tests for block-related tools (get_latest_block, get_block_info)
 │       ├── test_chains_tools.py      # Tests for chain-related tools (get_chains_list)
 │       ├── test_contract_tools.py    # Tests for contract-related tools (get_contract_abi)

--- a/API.md
+++ b/API.md
@@ -281,9 +281,9 @@ Gets comprehensive information about an address, including balance and contract 
 curl "http://127.0.0.1:8000/v1/get_address_info?chain_id=1&address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 ```
 
-#### Get Address Logs (`get_address_logs`)
+#### Get Address Logs (Deprecated) (`get_address_logs`)
 
-Gets event logs emitted by a specific address.
+This endpoint is deprecated and always returns a static notice.
 
 `GET /v1/get_address_logs`
 
@@ -297,7 +297,20 @@ Gets event logs emitted by a specific address.
 
 **Example Request**
 ```bash
-curl "http://127.0.0.1:8000/v1/get_address_logs?chain_id=1&address=0x..."
+curl "http://127.0.0.1:8000/v1/get_address_logs?chain_id=1&address=0xabc"
+```
+
+**Example Response**
+```json
+{
+  "data": {"status": "deprecated"},
+  "notes": [
+    "This endpoint is deprecated and will be removed in a future version.",
+    "Please use the recommended workflow: first, call `get_transactions_by_address` (which supports time filtering), and then use `get_transaction_logs` for each relevant transaction hash."
+  ],
+  "pagination": null,
+  "instructions": null
+}
 ```
 
 ### Token & NFT Tools

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 13. `get_block_info(chain_id, number_or_hash, include_transactions=False)` - Returns block information including timestamp, gas used, burnt fees, and transaction count. Can optionally include a list of transaction hashes.
 14. `get_transaction_info(chain_id, hash, include_raw_input=False)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
 15. `get_transaction_logs(chain_id, hash, cursor=None)` - Returns transaction logs with decoded event data.
-16. `get_address_logs(chain_id, address, cursor=None)` - Gets logs emitted by a specific address with decoded event data.
 
 ## Example Prompts for AI Agents
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -278,6 +278,21 @@ This architecture provides the flexibility of a multi-protocol server without th
 
     - **Final Tool Response (JSON):**
 
+      ```json
+      {
+        "data": [...],
+        "pagination": {
+          "next_call": {
+            "tool_name": "get_transaction_logs",
+            "params": {
+              "chain_id": "1",
+              "hash": "0x...",
+              "cursor": "eyJibG9ja19udW1iZXIiOjE4OTk5OTk5LCJpbmRleCI6NDIsIml0ZW1zX2NvdW50Ijo1MH0"
+            }
+          }
+        }
+      }
+      ```
 
     **c) Response Slicing and Context-Aware Pagination:**
     To prevent overwhelming the LLM with long lists of items (e.g., token holdings, transaction logs), the server implements a response slicing strategy. This conserves context while ensuring all data remains accessible through robust pagination.

--- a/SPEC.md
+++ b/SPEC.md
@@ -278,21 +278,6 @@ This architecture provides the flexibility of a multi-protocol server without th
 
     - **Final Tool Response (JSON):**
 
-       ```json
-       {
-         "data": [...],
-         "pagination": {
-           "next_call": {
-             "tool_name": "get_address_logs",
-             "params": {
-               "chain_id": "1",
-               "address": "0x...",
-               "cursor": "eyJibG9ja19udW1iZXIiOjE4OTk5OTk5LCJpbmRleCI6NDIsIml0ZW1zX2NvdW50Ijo1MH0"
-             }
-           }
-         }
-       }
-      ```
 
     **c) Response Slicing and Context-Aware Pagination:**
     To prevent overwhelming the LLM with long lists of items (e.g., token holdings, transaction logs), the server implements a response slicing strategy. This conserves context while ensuring all data remains accessible through robust pagination.

--- a/blockscout_mcp_server/api/helpers.py
+++ b/blockscout_mcp_server/api/helpers.py
@@ -8,6 +8,8 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
+from blockscout_mcp_server.models import ToolResponse
+
 
 def str_to_bool(val: str) -> bool:
     """Convert a string to a boolean value."""
@@ -74,3 +76,13 @@ def handle_rest_errors(
             return JSONResponse({"error": str(e)}, status_code=500)
 
     return wrapper
+
+
+def create_deprecation_response() -> Response:
+    """Creates a standardized JSON response for a deprecated tool endpoint."""
+    deprecation_notes = [
+        "This endpoint is deprecated and will be removed in a future version.",
+        "Please use the recommended workflow: first, call `get_transactions_by_address` (which supports time filtering), and then use `get_transaction_logs` for each relevant transaction hash.",  # noqa: E501
+    ]
+    tool_response = ToolResponse(data={"status": "deprecated"}, notes=deprecation_notes)
+    return JSONResponse(tool_response.model_dump(), status_code=410)

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -10,12 +10,12 @@ from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, R
 
 from blockscout_mcp_server.api.dependencies import get_mock_context
 from blockscout_mcp_server.api.helpers import (
+    create_deprecation_response,
     extract_and_validate_params,
     handle_rest_errors,
 )
 from blockscout_mcp_server.tools.address_tools import (
     get_address_info,
-    get_address_logs,
     get_tokens_by_address,
     nft_tokens_by_address,
 )
@@ -201,11 +201,9 @@ async def get_transaction_logs_rest(request: Request) -> Response:
 
 
 @handle_rest_errors
-async def get_address_logs_rest(request: Request) -> Response:
-    """REST wrapper for the get_address_logs tool."""
-    params = extract_and_validate_params(request, required=["chain_id", "address"], optional=["cursor"])
-    tool_response = await get_address_logs(**params, ctx=get_mock_context())
-    return JSONResponse(tool_response.model_dump())
+async def get_address_logs_rest(_: Request) -> Response:
+    """REST wrapper for the get_address_logs tool. This endpoint is deprecated."""
+    return create_deprecation_response()
 
 
 @handle_rest_errors

--- a/blockscout_mcp_server/llms.txt
+++ b/blockscout_mcp_server/llms.txt
@@ -52,7 +52,6 @@ All tools are available via both MCP and REST API interfaces:
 13. **`get_block_info`** - Returns detailed block information
 14. **`get_transaction_info`** - Gets comprehensive transaction information
 15. **`get_transaction_logs`** - Returns transaction logs with decoded event data
-16. **`get_address_logs`** - Gets logs emitted by a specific address
 
 ## When to Use Each Interface
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -18,7 +18,6 @@ from blockscout_mcp_server.constants import (
 )
 from blockscout_mcp_server.tools.address_tools import (
     get_address_info,
-    get_address_logs,
     get_tokens_by_address,
     nft_tokens_by_address,
 )
@@ -93,7 +92,6 @@ mcp.tool(structured_output=False)(transaction_summary)
 mcp.tool(structured_output=False)(nft_tokens_by_address)
 mcp.tool(structured_output=False)(get_transaction_info)
 mcp.tool(structured_output=False)(get_transaction_logs)
-mcp.tool(structured_output=False)(get_address_logs)
 mcp.tool(structured_output=False)(get_chains_list)
 
 # Create a Typer application for our CLI

--- a/blockscout_mcp_server/templates/index.html
+++ b/blockscout_mcp_server/templates/index.html
@@ -106,7 +106,6 @@
         <li><code>get_block_info</code>: Returns detailed block information.</li>
         <li><code>get_transaction_info</code>: Gets comprehensive transaction information.</li>
         <li><code>get_transaction_logs</code>: Returns transaction logs with decoded event data.</li>
-        <li><code>get_address_logs</code>: Gets logs emitted by a specific address.</li>
     </ul>
     <p>For more details, please refer to the project's <a href="https://github.com/blockscout/mcp-server">GitHub repository</a>.</p>
 </body>

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -292,7 +292,7 @@ async def nft_tokens_by_address(
     return build_tool_response(data=nft_holdings, pagination=pagination)
 
 
-# Note: This tool has been deprecated from the MCP interface as of v0.5.1.
+# Note: This tool has been deprecated from the MCP interface as of v0.6.0.
 # It was found to be frequently misused by LLMs, which preferred it over the
 # more efficient workflow of using `get_transactions_by_address` (with time filters)
 # followed by `get_transaction_logs`.

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -292,6 +292,15 @@ async def nft_tokens_by_address(
     return build_tool_response(data=nft_holdings, pagination=pagination)
 
 
+# Note: This tool has been deprecated from the MCP interface as of v0.5.1.
+# It was found to be frequently misused by LLMs, which preferred it over the
+# more efficient workflow of using `get_transactions_by_address` (with time filters)
+# followed by `get_transaction_logs`.
+# The implementation is preserved here for potential future use if a specific,
+# valid use case is identified. The REST endpoint /v1/get_address_logs now
+# returns a static deprecation notice.
+
+
 @log_tool_invocation
 async def get_address_logs(
     chain_id: Annotated[str, Field(description="The ID of the blockchain")],

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -90,10 +90,6 @@
     {
       "name": "get_transaction_logs",
       "description": "Returns transaction logs with decoded event data"
-    },
-    {
-      "name": "get_address_logs",
-      "description": "Gets logs emitted by a specific address"
     }
   ],
   "keywords": [

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -442,9 +442,16 @@ async def test_get_transaction_logs_missing_param(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_get_address_logs_returns_deprecation_notice(client: AsyncClient):
-    """Test that the deprecated /get_address_logs endpoint returns a 410 Gone status and a deprecation notice."""
-    response = await client.get("/v1/get_address_logs?chain_id=1&address=0xabc")
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/v1/get_address_logs",
+        "/v1/get_address_logs?chain_id=1&address=0xabc",
+    ],
+)
+async def test_get_address_logs_returns_deprecation_notice(client: AsyncClient, url: str):
+    """Deprecated /get_address_logs always returns a static 410 response."""
+    response = await client.get(url)
     assert response.status_code == 410
     json_response = response.json()
     assert json_response["data"] == {"status": "deprecated"}

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -442,33 +442,13 @@ async def test_get_transaction_logs_missing_param(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-@patch("blockscout_mcp_server.api.routes.get_address_logs", new_callable=AsyncMock)
-async def test_get_address_logs_success(mock_tool, client: AsyncClient):
-    """Test /get_address_logs endpoint."""
-    mock_tool.return_value = ToolResponse(data=[])
-    response = await client.get("/v1/get_address_logs?chain_id=1&address=0xabc&cursor=foo")
-    assert response.status_code == 200
-    assert response.json()["data"] == []
-    mock_tool.assert_called_once_with(chain_id="1", address="0xabc", cursor="foo", ctx=ANY)
-
-
-@pytest.mark.asyncio
-@patch("blockscout_mcp_server.api.routes.get_address_logs", new_callable=AsyncMock)
-async def test_get_address_logs_no_cursor(mock_tool, client: AsyncClient):
-    """Works without optional cursor."""
-    mock_tool.return_value = ToolResponse(data=[])
+async def test_get_address_logs_returns_deprecation_notice(client: AsyncClient):
+    """Test that the deprecated /get_address_logs endpoint returns a 410 Gone status and a deprecation notice."""
     response = await client.get("/v1/get_address_logs?chain_id=1&address=0xabc")
-    assert response.status_code == 200
-    assert response.json()["data"] == []
-    mock_tool.assert_called_once_with(chain_id="1", address="0xabc", ctx=ANY)
-
-
-@pytest.mark.asyncio
-async def test_get_address_logs_missing_param(client: AsyncClient):
-    """Missing chain_id."""
-    response = await client.get("/v1/get_address_logs?address=0xabc")
-    assert response.status_code == 400
-    assert response.json() == {"error": "Missing required query parameter: 'chain_id'"}
+    assert response.status_code == 410
+    json_response = response.json()
+    assert json_response["data"] == {"status": "deprecated"}
+    assert "This endpoint is deprecated" in json_response["notes"][0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- deprecate REST endpoint for `get_address_logs`
- remove tool registration from server
- document deprecation and clean references
- update llms.txt, index page, DXT manifest
- add deprecation test and helper

Closes #168


------
https://chatgpt.com/codex/tasks/task_b_687ec2ea40e88323b9185cfcd8d5689a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The API now returns a clear deprecation notice for requests to the `/v1/get_address_logs` endpoint, including guidance on alternative workflows.

* **Documentation**
  * Updated documentation and user guides to mark `get_address_logs` as deprecated and removed references to it across all docs and help pages.

* **Chores**
  * Removed `get_address_logs` from tool lists, manifests, server registration, and UI tool listings.
  * Updated tests to verify deprecation behavior for the affected endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->