### PR TITLE
Refactor initialization tool name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ mcp-server/
 │       ├── __init__.py         # Initializes the tools sub-package
 │       ├── common.py           # Shared utilities and common functionality for all tools
 │       ├── decorators.py       # Logging decorators like @log_tool_invocation
-│       ├── get_instructions.py # Implements the __get_instructions__ tool
+│       ├── initialization_tools.py # Implements the __unlock_blockchain_analysis__ tool
 │       ├── ens_tools.py        # Implements ENS-related tools
 │       ├── search_tools.py     # Implements search-related tools (e.g., lookup_token_by_symbol)
 │       ├── contract_tools.py   # Implements contract-related tools (e.g., get_contract_abi)
@@ -55,7 +55,7 @@ mcp-server/
 │       ├── test_chains_tools.py      # Tests for chain-related tools (get_chains_list)
 │       ├── test_contract_tools.py    # Tests for contract-related tools (get_contract_abi)
 │       ├── test_ens_tools.py         # Tests for ENS-related tools (get_address_by_ens_name)
-│       ├── test_get_instructions.py  # Tests for instruction tool (__get_instructions__)
+│       ├── test_initialization_tools.py  # Tests for instruction tool (__unlock_blockchain_analysis__)
 │       ├── test_decorators.py       # Tests for logging decorators
 │       ├── test_search_tools.py      # Tests for search-related tools (lookup_token_by_symbol)
 │       ├── test_transaction_tools.py # Tests for transaction tools (get_transactions_by_address, transaction_summary)
@@ -171,7 +171,7 @@ mcp-server/
     * **`models.py`**:
         * Defines a standardized, structured `ToolResponse` model using Pydantic.
         * Ensures all tools return data in a consistent, machine-readable format, separating the data payload from metadata like pagination and notes.
-        * Includes specific data models for complex payloads, like the response from `__get_instructions__`.
+        * Includes specific data models for complex payloads, like the response from `__unlock_blockchain_analysis__`.
     * **`server.py`**:
         * The heart of the MCP server.
         * Initializes a `FastMCP` instance using constants from `constants.py`.
@@ -198,7 +198,7 @@ mcp-server/
         * Defines centralized constants used throughout the application, including data truncation limits.
         * Contains server instructions and other configuration strings.
         * Ensures consistency between different parts of the application.
-        * Used by both server.py and tools like get_instructions.py to maintain a single source of truth.
+        * Used by both server.py and tools like initialization_tools.py to maintain a single source of truth.
     * **`api/` (API layer)**:
         * **`helpers.py`**: Shared utilities for REST API handlers, including parameter extraction and error handling.
         * **`routes.py`**: Defines all REST API endpoints that wrap MCP tools.
@@ -226,7 +226,7 @@ mcp-server/
                 3. It processes the JSON response from Blockscout.
                 4. It transforms this response into the desired output format.
             * Examples:
-                * `get_instructions.py`: Implements `__get_instructions__`, returning special server instructions and popular chain IDs.
+                * `initialization_tools.py`: Implements `__unlock_blockchain_analysis__`, returning special server instructions and popular chain IDs.
                 * `chains_tools.py`: Implements `get_chains_list`, returning a formatted list of blockchain chains with their IDs.
                 * `ens_tools.py`: Implements `get_address_by_ens_name` (fixed BENS endpoint, no chain_id).
                 * `search_tools.py`: Implements `lookup_token_by_symbol(chain_id, symbol)`.

--- a/API.md
+++ b/API.md
@@ -91,11 +91,12 @@ curl "http://127.0.0.1:8000/v1/tools"
 
 ### General Tools
 
-#### Get Instructions (`__get_instructions__`)
+#### Unlock Blockchain Analysis (`__unlock_blockchain_analysis__`)
 
-Provides custom instructions and operational guidance for using the server.
+Provides custom instructions and operational guidance for using the server. This is a mandatory first step.
 
-`GET /v1/get_instructions`
+`GET /v1/unlock_blockchain_analysis`
+`GET /v1/get_instructions` (legacy)
 
 **Parameters**
 
@@ -103,7 +104,7 @@ Provides custom instructions and operational guidance for using the server.
 
 **Example Request**
 ```bash
-curl "http://127.0.0.1:8000/v1/get_instructions"
+curl "http://127.0.0.1:8000/v1/unlock_blockchain_analysis"
 ```
 
 #### Get Chains List (`get_chains_list`)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 
 ## Tool Descriptions
 
-1. `__get_instructions__()` - Provides custom instructions for the MCP host to use the server. This tool is required since the field `instructions` of the MCP server initialization response is not used by the MCP host so far (tested on Claude Desktop).
+1. `__unlock_blockchain_analysis__()` - Provides custom instructions for the MCP host to use the server. This is a mandatory first step before using other tools.
 2. `get_chains_list()` - Returns a list of all known chains.
 3. `get_address_by_ens_name(name)` - Converts an ENS domain name to its corresponding Ethereum address.
 4. `lookup_token_by_symbol(chain_id, symbol)` - Searches for token addresses by symbol or name, returning multiple potential matches.

--- a/TESTING.md
+++ b/TESTING.md
@@ -147,7 +147,7 @@ curl --request POST \
     "id": 1,
     "method": "tools/call",
     "params": {
-      "name": "__get_instructions__",
+      "name": "__unlock_blockchain_analysis__",
       "arguments": {}
     }
   }'

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -23,7 +23,7 @@ from blockscout_mcp_server.tools.block_tools import get_block_info, get_latest_b
 from blockscout_mcp_server.tools.chains_tools import get_chains_list
 from blockscout_mcp_server.tools.contract_tools import get_contract_abi
 from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
-from blockscout_mcp_server.tools.get_instructions import __get_instructions__
+from blockscout_mcp_server.tools.initialization_tools import __unlock_blockchain_analysis__
 from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
 from blockscout_mcp_server.tools.transaction_tools import (
     get_token_transfers_by_address,
@@ -75,8 +75,15 @@ async def main_page(_: Request) -> Response:
 
 @handle_rest_errors
 async def get_instructions_rest(_: Request) -> Response:
-    """REST wrapper for the __get_instructions__ tool."""
-    tool_response = await __get_instructions__(ctx=get_mock_context())
+    """REST wrapper for the __unlock_blockchain_analysis__ tool."""
+    tool_response = await __unlock_blockchain_analysis__(ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_rest_errors
+async def unlock_blockchain_analysis_rest(_: Request) -> Response:
+    """REST wrapper for the __unlock_blockchain_analysis__ tool."""
+    tool_response = await __unlock_blockchain_analysis__(ctx=get_mock_context())
     return JSONResponse(tool_response.model_dump())
 
 
@@ -241,6 +248,7 @@ def register_api_routes(mcp: FastMCP) -> None:
     # Version 1 of the REST API
     _add_v1_tool_route(mcp, "/tools", list_tools_rest)
     _add_v1_tool_route(mcp, "/get_instructions", get_instructions_rest)
+    _add_v1_tool_route(mcp, "/unlock_blockchain_analysis", unlock_blockchain_analysis_rest)
     _add_v1_tool_route(mcp, "/get_block_info", get_block_info_rest)
     _add_v1_tool_route(mcp, "/get_latest_block", get_latest_block_rest)
     _add_v1_tool_route(mcp, "/get_address_by_ens_name", get_address_by_ens_name_rest)

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -76,6 +76,10 @@ async def main_page(_: Request) -> Response:
 @handle_rest_errors
 async def get_instructions_rest(_: Request) -> Response:
     """REST wrapper for the __unlock_blockchain_analysis__ tool."""
+    # NOTE: This endpoint exists solely for backward compatibility. It duplicates
+    # ``unlock_blockchain_analysis_rest`` instead of delegating to it because the
+    # old route will be removed soon and another wrapper would add needless
+    # indirection.
     tool_response = await __unlock_blockchain_analysis__(ctx=get_mock_context())
     return JSONResponse(tool_response.model_dump())
 

--- a/blockscout_mcp_server/llms.txt
+++ b/blockscout_mcp_server/llms.txt
@@ -37,7 +37,7 @@ GET /v1/get_transactions_by_address?chain_id=1&address=0x...&age_from=7d
 
 All tools are available via both MCP and REST API interfaces:
 
-1. **`__get_instructions__`** - Provides custom instructions for the MCP host (MCP only)
+1. **`__unlock_blockchain_analysis__`** - Provides custom instructions for the MCP host (MCP only)
 2. **`get_chains_list`** - Returns a list of all known chains
 3. **`get_address_by_ens_name`** - Converts an ENS name to its Ethereum address
 4. **`lookup_token_by_symbol`** - Searches for tokens by symbol or name
@@ -103,7 +103,7 @@ All tools are available via both MCP and REST API interfaces:
 
 ## Best Practices for AI Agents
 
-1. **Start with Instructions:** Always call `__get_instructions__` first in MCP sessions
+1. **Start with Instructions:** Always call `__unlock_blockchain_analysis__` first in MCP sessions
 2. **Use Pagination:** Continue fetching pages for comprehensive analysis
 3. **Handle Truncation:** Check for `*_truncated` flags and fetch full data when needed
 4. **Chain Selection:** Use `get_chains_list` to understand available networks

--- a/blockscout_mcp_server/llms.txt
+++ b/blockscout_mcp_server/llms.txt
@@ -37,7 +37,7 @@ GET /v1/get_transactions_by_address?chain_id=1&address=0x...&age_from=7d
 
 All tools are available via both MCP and REST API interfaces:
 
-1. **`__unlock_blockchain_analysis__`** - Provides custom instructions for the MCP host (MCP only)
+1. **`__unlock_blockchain_analysis__`** (MCP) / `/v1/unlock_blockchain_analysis` (REST) - Provides custom instructions for the MCP host. This is a mandatory first step.
 2. **`get_chains_list`** - Returns a list of all known chains
 3. **`get_address_by_ens_name`** - Converts an ENS name to its Ethereum address
 4. **`lookup_token_by_symbol`** - Searches for tokens by symbol or name

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -32,7 +32,7 @@ class LatestBlockData(BaseModel):
     timestamp: str = Field(description="The timestamp when the block was mined (ISO format)")
 
 
-# --- Model for __get_instructions__ Data Payload ---
+# --- Model for __unlock_blockchain_analysis__ Data Payload ---
 class ChainInfo(BaseModel):
     """Represents a blockchain with its essential identifiers."""
 
@@ -40,7 +40,7 @@ class ChainInfo(BaseModel):
     chain_id: str = Field(description="The unique identifier for the chain.")
 
 
-# --- Model for __get_instructions__ Data Payload ---
+# --- Model for __unlock_blockchain_analysis__ Data Payload ---
 class ChainIdGuidance(BaseModel):
     """A structured representation of chain ID guidance combining rules and recommendations."""
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -26,7 +26,7 @@ from blockscout_mcp_server.tools.block_tools import get_block_info, get_latest_b
 from blockscout_mcp_server.tools.chains_tools import get_chains_list
 from blockscout_mcp_server.tools.contract_tools import get_contract_abi
 from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
-from blockscout_mcp_server.tools.get_instructions import __get_instructions__
+from blockscout_mcp_server.tools.initialization_tools import __unlock_blockchain_analysis__
 from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
 from blockscout_mcp_server.tools.transaction_tools import (
     get_token_transfers_by_address,
@@ -79,7 +79,7 @@ mcp = FastMCP(name=SERVER_NAME, instructions=composed_instructions)
 # The description will be taken from the function's docstring
 # The arguments (name, type, description) will be inferred from type hints
 # TODO: structured_output is disabled for all tools so far to preserve the LLM context since it adds to the `list/tools` response ~20K tokens.  # noqa: E501
-mcp.tool(structured_output=False)(__get_instructions__)
+mcp.tool(structured_output=False)(__unlock_blockchain_analysis__)
 mcp.tool(structured_output=False)(get_block_info)
 mcp.tool(structured_output=False)(get_latest_block)
 mcp.tool(structured_output=False)(get_address_by_ens_name)

--- a/blockscout_mcp_server/templates/index.html
+++ b/blockscout_mcp_server/templates/index.html
@@ -91,7 +91,7 @@
 
     <h2>Available Tools (via MCP and REST API)</h2>
     <ul>
-        <li><code>__get_instructions__</code>: Provides custom instructions for the MCP host.</li>
+        <li><code>__unlock_blockchain_analysis__</code>: Provides custom instructions for the MCP host.</li>
         <li><code>get_chains_list</code>: Returns a list of all known chains.</li>
         <li><code>get_address_by_ens_name</code>: Converts an ENS name to its Ethereum address.</li>
         <li><code>lookup_token_by_symbol</code>: Searches for tokens by symbol.</li>

--- a/blockscout_mcp_server/tools/initialization_tools.py
+++ b/blockscout_mcp_server/tools/initialization_tools.py
@@ -26,11 +26,18 @@ from blockscout_mcp_server.tools.decorators import log_tool_invocation
 # It is very important to keep the tool description in such form to force the LLM to call this tool first
 # before calling any other tool. Altering of the description could provide opportunity to LLM to skip this tool.
 @log_tool_invocation
-async def __get_instructions__(ctx: Context) -> ToolResponse[InstructionsData]:
-    """
-    This tool MUST be called BEFORE any other tool.
-    Without calling it, the MCP server will not work as expected.
-    It MUST be called once in a session.
+async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[InstructionsData]:
+    """Unlocks access to other MCP tools.
+
+    All tools remain locked with a "Session Not Initialized" error until this
+    function is successfully called. Skipping this explicit initialization step
+    will cause all subsequent tool calls to fail.
+
+    MANDATORY FOR AI AGENTS: The returned instructions contain ESSENTIAL rules
+    that MUST govern ALL blockchain data interactions. Failure to integrate these
+    rules will result in incorrect data retrieval, tool failures and invalid
+    responses. Always apply these guidelines when planning queries, processing
+    responses or recommending blockchain actions.
     """
     # Report start of operation
     await report_and_log_progress(

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -32,8 +32,8 @@
   },
   "tools": [
     {
-      "name": "__get_instructions__",
-      "description": "Provides custom instructions for the MCP host"
+      "name": "__unlock_blockchain_analysis__",
+      "description": "Provides custom instructions for the MCP host. This is a mandatory first step."
     },
     {
       "name": "get_chains_list",

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -124,13 +124,24 @@ async def test_get_block_info_missing_param(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-@patch("blockscout_mcp_server.api.routes.__get_instructions__", new_callable=AsyncMock)
+@patch("blockscout_mcp_server.api.routes.__unlock_blockchain_analysis__", new_callable=AsyncMock)
 async def test_get_instructions_success(mock_tool, client: AsyncClient):
     """Test the /get_instructions endpoint."""
     mock_tool.return_value = ToolResponse(data={"msg": "hi"})
     response = await client.get("/v1/get_instructions")
     assert response.status_code == 200
     assert response.json()["data"] == {"msg": "hi"}
+    mock_tool.assert_called_once_with(ctx=ANY)
+
+
+@pytest.mark.asyncio
+@patch("blockscout_mcp_server.api.routes.__unlock_blockchain_analysis__", new_callable=AsyncMock)
+async def test_unlock_blockchain_analysis_success(mock_tool, client: AsyncClient):
+    """Test the /unlock_blockchain_analysis endpoint."""
+    mock_tool.return_value = ToolResponse(data={"msg": "unlocked"})
+    response = await client.get("/v1/unlock_blockchain_analysis")
+    assert response.status_code == 200
+    assert response.json()["data"] == {"msg": "unlocked"}
     mock_tool.assert_called_once_with(ctx=ANY)
 
 

--- a/tests/tools/test_initialization_tools.py
+++ b/tests/tools/test_initialization_tools.py
@@ -3,12 +3,12 @@ from unittest.mock import patch
 import pytest
 
 from blockscout_mcp_server.models import InstructionsData, ToolResponse
-from blockscout_mcp_server.tools.get_instructions import __get_instructions__
+from blockscout_mcp_server.tools.initialization_tools import __unlock_blockchain_analysis__
 
 
 @pytest.mark.asyncio
-async def test_get_instructions_success(mock_ctx):
-    """Verify __get_instructions__ returns a structured ToolResponse[InstructionsData]."""
+async def test_unlock_blockchain_analysis_success(mock_ctx):
+    """Verify __unlock_blockchain_analysis__ returns a structured ToolResponse[InstructionsData]."""
     # ARRANGE
     mock_version = "1.2.3"
     mock_error_rules = "Error handling rule."
@@ -20,17 +20,17 @@ async def test_get_instructions_success(mock_ctx):
     mock_chains = [{"name": "TestChain", "chain_id": "999"}]
 
     with (
-        patch("blockscout_mcp_server.tools.get_instructions.SERVER_VERSION", mock_version),
-        patch("blockscout_mcp_server.tools.get_instructions.ERROR_HANDLING_RULES", mock_error_rules),
-        patch("blockscout_mcp_server.tools.get_instructions.CHAIN_ID_RULES", mock_chain_rules),
-        patch("blockscout_mcp_server.tools.get_instructions.PAGINATION_RULES", mock_pagination_rules),
-        patch("blockscout_mcp_server.tools.get_instructions.TIME_BASED_QUERY_RULES", mock_time_rules),
-        patch("blockscout_mcp_server.tools.get_instructions.BLOCK_TIME_ESTIMATION_RULES", mock_block_rules),
-        patch("blockscout_mcp_server.tools.get_instructions.EFFICIENCY_OPTIMIZATION_RULES", mock_efficiency_rules),
-        patch("blockscout_mcp_server.tools.get_instructions.RECOMMENDED_CHAINS", mock_chains),
+        patch("blockscout_mcp_server.tools.initialization_tools.SERVER_VERSION", mock_version),
+        patch("blockscout_mcp_server.tools.initialization_tools.ERROR_HANDLING_RULES", mock_error_rules),
+        patch("blockscout_mcp_server.tools.initialization_tools.CHAIN_ID_RULES", mock_chain_rules),
+        patch("blockscout_mcp_server.tools.initialization_tools.PAGINATION_RULES", mock_pagination_rules),
+        patch("blockscout_mcp_server.tools.initialization_tools.TIME_BASED_QUERY_RULES", mock_time_rules),
+        patch("blockscout_mcp_server.tools.initialization_tools.BLOCK_TIME_ESTIMATION_RULES", mock_block_rules),
+        patch("blockscout_mcp_server.tools.initialization_tools.EFFICIENCY_OPTIMIZATION_RULES", mock_efficiency_rules),
+        patch("blockscout_mcp_server.tools.initialization_tools.RECOMMENDED_CHAINS", mock_chains),
     ):
         # ACT
-        result = await __get_instructions__(ctx=mock_ctx)
+        result = await __unlock_blockchain_analysis__(ctx=mock_ctx)
 
         # ASSERT
         assert isinstance(result, ToolResponse)


### PR DESCRIPTION
## Summary
- rename get_instructions.py -> initialization_tools.py
- rename tool to `__unlock_blockchain_analysis__`
- add backward-compatible and new REST routes
- update tests and docs

Closes #170

------
https://chatgpt.com/codex/tasks/task_b_687ed072f5c083239c6343d03aed4dcb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new tool, `__unlock_blockchain_analysis__`, as a mandatory first step for accessing other MCP tools via both REST and MCP APIs.
  * Added a new API endpoint `/v1/unlock_blockchain_analysis`.

* **Documentation**
  * Updated all documentation to reference `__unlock_blockchain_analysis__` instead of the legacy `__get_instructions__` tool.
  * Clarified the initialization workflow and rationale in guides, API docs, and specifications.

* **Bug Fixes**
  * Ensured consistent naming and descriptions for the initialization tool across the interface and documentation.

* **Tests**
  * Updated and added tests to cover the new initialization tool and endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->