### PR TITLE
Implement chain data caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ mcp-server/
 │   ├── config.py               # Configuration management (e.g., API keys, timeouts, cache settings)
 │   ├── constants.py            # Centralized constants used throughout the application, including data truncation limits
 │   ├── logging_utils.py        # Logging utilities for production-ready log formatting
+│   ├── cache.py               # Simple in-memory cache for chain data
 │   ├── models.py               # Defines standardized Pydantic models for all tool responses
 │   └── tools/                  # Sub-package for tool implementations
 │       ├── __init__.py         # Initializes the tools sub-package
@@ -203,6 +204,8 @@ mcp-server/
     * **`logging_utils.py`**:
         * Provides utilities for configuring production-ready logging.
         * Contains the `replace_rich_handlers_with_standard()` function that eliminates multi-line Rich formatting from MCP SDK logs.
+    * **`cache.py`**:
+        * Encapsulates in-memory caching of chain data with TTL management.
     * **`api/` (API layer)**:
         * **`helpers.py`**: Shared utilities for REST API handlers, including parameter extraction and error handling.
         * **`routes.py`**: Defines all REST API endpoints that wrap MCP tools.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ mcp-server/
 │   ├── config.py               # Configuration management (e.g., API keys, timeouts, cache settings)
 │   ├── constants.py            # Centralized constants used throughout the application, including data truncation limits
 │   ├── logging_utils.py        # Logging utilities for production-ready log formatting
-│   ├── cache.py               # Simple in-memory cache for chain data
+│   ├── cache.py                # Simple in-memory cache for chain data
 │   ├── models.py               # Defines standardized Pydantic models for all tool responses
 │   └── tools/                  # Sub-package for tool implementations
 │       ├── __init__.py         # Initializes the tools sub-package

--- a/API.md
+++ b/API.md
@@ -127,7 +127,7 @@ curl "http://127.0.0.1:8000/v1/unlock_blockchain_analysis"
 
 #### Get Chains List (`get_chains_list`)
 
-Returns a list of all known blockchain chains and their IDs.
+Returns a list of all known blockchain chains, including whether each is a testnet, its native currency, and ecosystem.
 
 `GET /v1/get_chains_list`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -238,7 +238,14 @@ This architecture provides the flexibility of a multi-protocol server without th
       }
       ```
 
-4. **Response Processing and Context Optimization**:
+4. **Blockscout-Hosted Chain Filtering**:
+
+   The `get_chains_list` tool intentionally returns only chains that are hosted
+   by the Blockscout team. This ensures a consistent feature set, stable service
+   levels, and the ability to authenticate requests from the MCP server. Chains
+   without an official Blockscout instance are omitted.
+
+5. **Response Processing and Context Optimization**:
 
    The server employs a comprehensive strategy to **conserve LLM context** by intelligently processing API responses before forwarding them to the MCP Host. This prevents overwhelming the LLM context window with excessive blockchain data, ensuring efficient tool selection and reasoning.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -56,6 +56,7 @@ sequenceDiagram
     AI->>MCP: get_chains_list
     MCP->>CS: Request available chains
     CS-->>MCP: List of chains
+    MCP->>MCP: Cache chain metadata
     MCP-->>AI: Formatted chains list
 
     Note over AI: Host selects chain_id as per the user's initial prompt
@@ -124,7 +125,7 @@ This architecture provides the flexibility of a multi-protocol server without th
 
 3. **Chain Selection**:
    - MCP Host requests available chains via `get_chains_list`
-   - MCP Server retrieves chain data from Chainscout
+   - MCP Server retrieves chain data from Chainscout and stores it in the `ChainCache`
    - MCP Host selects appropriate chain based on user needs
 
 4. **Optimized Data Retrieval with Concurrent API Calls**:

--- a/blockscout_mcp_server/cache.py
+++ b/blockscout_mcp_server/cache.py
@@ -1,3 +1,5 @@
+"""Simple in-memory cache for chain metadata."""
+
 import time
 
 from blockscout_mcp_server.config import config
@@ -6,6 +8,10 @@ from blockscout_mcp_server.config import config
 class ChainCache:
     def __init__(self) -> None:
         # Cache: chain_id -> (blockscout_url_or_none, expiry_timestamp)
+        # Note: this simple dict is not thread-safe when multiple threads try
+        # to write the same new key concurrently. For the HTTP server in
+        # streamable mode we run a single-thread event loop, so the risk is low.
+        # TODO: implement a thread-safe cache for official deployments.
         self._cache: dict[str, tuple[str | None, float]] = {}
 
     def get(self, chain_id: str) -> tuple[str | None, float] | None:

--- a/blockscout_mcp_server/cache.py
+++ b/blockscout_mcp_server/cache.py
@@ -1,0 +1,45 @@
+import time
+from typing import Any
+
+from blockscout_mcp_server.config import config
+
+
+def find_blockscout_url(chain_data: dict) -> str | None:
+    """Iterates through explorers to find the one hosted by Blockscout."""
+    for explorer in chain_data.get("explorers", []):
+        if isinstance(explorer, dict) and explorer.get("hostedBy") == "blockscout":
+            url = explorer.get("url")
+            if url:
+                return url.rstrip("/")
+    return None
+
+
+class ChainCache:
+    def __init__(self) -> None:
+        # Cache: chain_id -> (blockscout_url_or_none, expiry_timestamp)
+        self._cache: dict[str, tuple[str | None, float]] = {}
+
+    def get(self, chain_id: str) -> tuple[str | None, float] | None:
+        """Retrieves an entry from the cache."""
+        return self._cache.get(chain_id)
+
+    def set(self, chain_id: str, chain_data: dict[str, Any]) -> None:
+        """Processes and caches a single chain's data."""
+        blockscout_url = find_blockscout_url(chain_data)
+        expiry = time.time() + config.chain_cache_ttl_seconds
+        self._cache[chain_id] = (blockscout_url, expiry)
+
+    def set_failure(self, chain_id: str) -> None:
+        """Caches a failure to find a chain."""
+        expiry = time.time() + config.chain_cache_ttl_seconds
+        self._cache[chain_id] = (None, expiry)
+
+    def bulk_set(self, chains_data: dict[str, Any]) -> None:
+        """Caches the data from a bulk /api/chains response."""
+        for chain_id, chain_data in chains_data.items():
+            if isinstance(chain_data, dict):
+                self.set(chain_id, chain_data)
+
+    def invalidate(self, chain_id: str) -> None:
+        """Remove an entry from the cache if present."""
+        self._cache.pop(chain_id, None)

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -60,16 +60,69 @@ as you learn
 """
 
 RECOMMENDED_CHAINS = [
-    {"name": "Ethereum", "chain_id": "1"},
-    {"name": "Polygon PoS", "chain_id": "137"},
-    {"name": "Base", "chain_id": "8453"},
-    {"name": "Arbitrum One", "chain_id": "42161"},
-    {"name": "OP Mainnet", "chain_id": "10"},
-    {"name": "ZkSync Era", "chain_id": "324"},
-    {"name": "Polygon zkEVM", "chain_id": "1101"},
-    {"name": "Gnosis", "chain_id": "100"},
-    {"name": "Celo", "chain_id": "42220"},
-    {"name": "Scroll", "chain_id": "534352"},
+    {
+        "name": "Ethereum",
+        "chain_id": "1",
+        "is_testnet": False,
+        "native_currency": "ETH",
+        "ecosystem": "Ethereum",
+    },
+    {
+        "name": "Polygon PoS",
+        "chain_id": "137",
+        "is_testnet": False,
+        "native_currency": "POL",
+        "ecosystem": "Polygon",
+    },
+    {
+        "name": "Base",
+        "chain_id": "8453",
+        "is_testnet": False,
+        "native_currency": "ETH",
+        "ecosystem": ["Ethereum", "Superchain"],
+    },
+    {
+        "name": "Arbitrum One Nitro",
+        "chain_id": "42161",
+        "is_testnet": False,
+        "native_currency": "ETH",
+        "ecosystem": "Arbitrum",
+    },
+    {
+        "name": "OP Mainnet",
+        "chain_id": "10",
+        "is_testnet": False,
+        "native_currency": "ETH",
+        "ecosystem": ["Optimism", "Superchain"],
+    },
+    {
+        "name": "ZkSync Era",
+        "chain_id": "324",
+        "is_testnet": False,
+        "native_currency": "ETH",
+        "ecosystem": "zkSync",
+    },
+    {
+        "name": "Gnosis",
+        "chain_id": "100",
+        "is_testnet": False,
+        "native_currency": "XDAI",
+        "ecosystem": "Gnosis",
+    },
+    {
+        "name": "Celo",
+        "chain_id": "42220",
+        "is_testnet": False,
+        "native_currency": "CELO",
+        "ecosystem": "Ethereum",
+    },
+    {
+        "name": "Scroll",
+        "chain_id": "534352",
+        "is_testnet": False,
+        "native_currency": "ETH",
+        "ecosystem": "Ethereum",
+    },
 ]
 
 SERVER_NAME = "blockscout-mcp-server"

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -38,6 +38,11 @@ class ChainInfo(BaseModel):
 
     name: str = Field(description="The common name of the blockchain (e.g., 'Ethereum').")
     chain_id: str = Field(description="The unique identifier for the chain.")
+    is_testnet: bool = Field(description="Indicates if the chain is a testnet.")
+    native_currency: str | None = Field(description="The native currency symbol of the chain (e.g., 'ETH').")
+    ecosystem: str | list[str] | None = Field(
+        description="The ecosystem the chain belongs to, if applicable (e.g., 'Ethereum')."
+    )
 
 
 # --- Model for __unlock_blockchain_analysis__ Data Payload ---

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -52,6 +52,8 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
                     ChainInfo(
                         name=chain["name"],
                         chain_id=chain_id,
+                        # Chainscout /api/chains uses camelCase field names;
+                        # map them defensively in case of schema changes.
                         is_testnet=chain.get("isTestnet", False),
                         native_currency=chain.get("nativeCurrency"),
                         ecosystem=chain.get("ecosystem"),

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -1,10 +1,10 @@
 from mcp.server.fastmcp import Context
 
-from blockscout_mcp_server.cache import find_blockscout_url
 from blockscout_mcp_server.models import ChainInfo, ToolResponse
 from blockscout_mcp_server.tools.common import (
     build_tool_response,
     chain_cache,
+    find_blockscout_url,
     make_chainscout_request,
     report_and_log_progress,
 )
@@ -38,13 +38,16 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
     chains: list[ChainInfo] = []
     if isinstance(response_data, dict):
         filtered: dict[str, dict] = {}
+        url_map: dict[str, str] = {}
         for chain_id, chain in response_data.items():
             if not isinstance(chain, dict):
                 continue
-            if find_blockscout_url(chain):
+            url = find_blockscout_url(chain)
+            if url:
                 filtered[chain_id] = chain
+                url_map[chain_id] = url
 
-        chain_cache.bulk_set(filtered)
+        chain_cache.bulk_set(url_map)
 
         for chain_id, chain in filtered.items():
             if chain.get("name"):

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -55,9 +55,9 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
                     ChainInfo(
                         name=chain["name"],
                         chain_id=chain_id,
-                        # Map fields defensively to handle different naming styles.
-                        is_testnet=chain.get("isTestnet", chain.get("is_testnet", False)),
-                        native_currency=chain.get("nativeCurrency") or chain.get("native_currency"),
+                        # Fields follow the Chainscout API schema (isTestnet, native_currency)
+                        is_testnet=chain.get("isTestnet", False),
+                        native_currency=chain.get("native_currency"),
                         ecosystem=chain.get("ecosystem"),
                     )
                 )

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -55,10 +55,9 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
                     ChainInfo(
                         name=chain["name"],
                         chain_id=chain_id,
-                        # Chainscout /api/chains uses camelCase field names;
-                        # map them defensively in case of schema changes.
-                        is_testnet=chain.get("isTestnet", False),
-                        native_currency=chain.get("nativeCurrency"),
+                        # Map fields defensively to handle different naming styles.
+                        is_testnet=chain.get("isTestnet", chain.get("is_testnet", False)),
+                        native_currency=chain.get("nativeCurrency") or chain.get("native_currency"),
                         ecosystem=chain.get("ecosystem"),
                     )
                 )

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -1,8 +1,10 @@
 from mcp.server.fastmcp import Context
 
+from blockscout_mcp_server.cache import find_blockscout_url
 from blockscout_mcp_server.models import ChainInfo, ToolResponse
 from blockscout_mcp_server.tools.common import (
     build_tool_response,
+    chain_cache,
     make_chainscout_request,
     report_and_log_progress,
 )
@@ -15,7 +17,7 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
     Get the list of known blockchain chains with their IDs.
     Useful for getting a chain ID when the chain name is known. This information can be used in other tools that require a chain ID to request information.
     """  # noqa: E501
-    api_path = "/api/chains/list"
+    api_path = "/api/chains"
 
     await report_and_log_progress(
         ctx,
@@ -34,13 +36,26 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
     )
 
     chains: list[ChainInfo] = []
-    if isinstance(response_data, list):
-        # 1. No need to sort the chains as per the nature of Chainscout: most popular chains are at the top
-        # 2. The chain ID can be either numeric or string, so we don't need to convert it to int
-        chains.extend(
-            ChainInfo(name=item["name"], chain_id=item["chainid"])
-            for item in response_data
-            if item.get("name") and item.get("chainid")
-        )
+    if isinstance(response_data, dict):
+        filtered: dict[str, dict] = {}
+        for chain_id, chain in response_data.items():
+            if not isinstance(chain, dict):
+                continue
+            if find_blockscout_url(chain):
+                filtered[chain_id] = chain
+
+        chain_cache.bulk_set(filtered)
+
+        for chain_id, chain in filtered.items():
+            if chain.get("name"):
+                chains.append(
+                    ChainInfo(
+                        name=chain["name"],
+                        chain_id=chain_id,
+                        is_testnet=chain.get("isTestnet", False),
+                        native_currency=chain.get("nativeCurrency"),
+                        ecosystem=chain.get("ecosystem"),
+                    )
+                )
 
     return build_tool_response(data=chains)

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "get_chains_list",
-      "description": "Returns a list of all known blockchain chains"
+      "description": "Lists available chains with testnet flag, native currency, and ecosystem"
     },
     {
       "name": "get_address_by_ens_name",

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "get_chains_list",
-      "description": "Lists available chains with testnet flag, native currency, and ecosystem"
+      "description": "Returns a list of all known blockchain chains"
     },
     {
       "name": "get_address_by_ens_name",

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -24,12 +24,12 @@ async def test_get_chains_list_integration(mock_ctx):
     assert eth_chain.native_currency == "ETH"
     assert eth_chain.ecosystem == "Ethereum"
 
-    polygon_chain = next((chain for chain in result.data if chain.name == "Polygon PoS"), None)
-    assert polygon_chain is not None
-    assert polygon_chain.chain_id == "137"
-    assert polygon_chain.is_testnet is False
-    assert polygon_chain.native_currency == "POL"
-    assert polygon_chain.ecosystem == "Polygon"
+    op_chain = next((chain for chain in result.data if chain.name == "OP Mainnet"), None)
+    assert op_chain is not None
+    assert op_chain.chain_id == "10"
+    assert op_chain.is_testnet is False
+    assert op_chain.native_currency == "ETH"
+    assert op_chain.ecosystem == ["Optimism", "Superchain"]
 
 
 @pytest.mark.integration

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -1,7 +1,10 @@
+import time
+
 import pytest
 
 from blockscout_mcp_server.models import ToolResponse
 from blockscout_mcp_server.tools.chains_tools import get_chains_list
+from blockscout_mcp_server.tools.common import chain_cache, get_blockscout_base_url
 
 
 @pytest.mark.integration
@@ -17,7 +20,27 @@ async def test_get_chains_list_integration(mock_ctx):
     eth_chain = next((chain for chain in result.data if chain.name == "Ethereum"), None)
     assert eth_chain is not None
     assert eth_chain.chain_id == "1"
+    assert eth_chain.is_testnet is False
+    assert eth_chain.native_currency == "ETH"
+    assert eth_chain.ecosystem == "Ethereum"
 
     polygon_chain = next((chain for chain in result.data if chain.name == "Polygon PoS"), None)
     assert polygon_chain is not None
     assert polygon_chain.chain_id == "137"
+    assert polygon_chain.is_testnet is False
+    assert polygon_chain.native_currency == "POL"
+    assert polygon_chain.ecosystem == "Polygon"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_chains_list_warms_cache(mock_ctx):
+    """Ensure calling get_chains_list populates the chain cache."""
+    await get_chains_list(ctx=mock_ctx)
+
+    cached_entry = chain_cache.get("1")
+    assert cached_entry is not None
+    cached_url, expiry = cached_entry
+    expected_url = await get_blockscout_base_url("1")
+    assert cached_url == expected_url
+    assert expiry > time.time()

--- a/tests/integration/test_common_helpers.py
+++ b/tests/integration/test_common_helpers.py
@@ -19,7 +19,7 @@ async def test_make_chainscout_request_for_chains_list():
     """
     # 1. ARRANGE
     # The only arrangement needed is to define the API path we want to test.
-    api_path = "/api/chains/list"
+    api_path = "/api/chains"
 
     # 2. ACT
     # This will make a REAL network request.
@@ -27,15 +27,13 @@ async def test_make_chainscout_request_for_chains_list():
 
     # 3. ASSERT
     # We can't know the exact chains, but we can check the response structure.
-    assert isinstance(response_data, list)
-    assert len(response_data) > 0  # We expect at least one chain
+    assert isinstance(response_data, dict)
+    assert len(response_data) > 0
 
-    # Check the structure of the first chain in the list.
-    first_chain = response_data[0]
+    first_key = next(iter(response_data))
+    first_chain = response_data[first_key]
     assert "name" in first_chain
-    assert "chainid" in first_chain
     assert isinstance(first_chain["name"], str)
-    assert isinstance(first_chain["chainid"], str)  # Chainscout returns chainid as a string
 
 
 @pytest.mark.integration
@@ -77,7 +75,7 @@ async def test_make_bens_request_for_ens_lookup():
     [
         ("1", "https://eth.blockscout.com"),
         ("137", "https://polygon.blockscout.com"),
-        ("10", "https://optimism.blockscout.com"),
+        ("10", "https://explorer.optimism.io"),
         ("8453", "https://base.blockscout.com"),
     ],
 )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+from blockscout_mcp_server.cache import ChainCache, find_blockscout_url
+from blockscout_mcp_server.config import config
+
+
+def test_find_blockscout_url_success():
+    chain_data = {
+        "explorers": [
+            {"hostedBy": "blockscout", "url": "https://example.blockscout.com"},
+            {"hostedBy": "other", "url": "https://other.com"},
+        ]
+    }
+    assert find_blockscout_url(chain_data) == "https://example.blockscout.com"
+
+
+def test_find_blockscout_url_no_match():
+    chain_data = {"explorers": [{"hostedBy": "other", "url": "https://x"}]}
+    assert find_blockscout_url(chain_data) is None
+
+
+def test_chain_cache_basic_flow():
+    cache = ChainCache()
+    with patch("time.time", return_value=1000):
+        cache.set("1", {"explorers": [{"hostedBy": "blockscout", "url": "https://a"}]})
+    assert cache.get("1") == ("https://a", 1000 + config.chain_cache_ttl_seconds)
+
+
+def test_chain_cache_set_failure():
+    cache = ChainCache()
+    with patch("time.time", return_value=2000):
+        cache.set_failure("2")
+    assert cache.get("2") == (None, 2000 + config.chain_cache_ttl_seconds)
+
+
+def test_chain_cache_bulk_set():
+    cache = ChainCache()
+    chains = {
+        "1": {"explorers": [{"hostedBy": "blockscout", "url": "https://a"}]},
+        "2": {"explorers": [{"hostedBy": "blockscout", "url": "https://b"}]},
+    }
+    with patch("time.time", return_value=3000):
+        cache.bulk_set(chains)
+    assert cache.get("1") == ("https://a", 3000 + config.chain_cache_ttl_seconds)
+    assert cache.get("2") == ("https://b", 3000 + config.chain_cache_ttl_seconds)
+
+
+def test_chain_cache_invalidate():
+    cache = ChainCache()
+    with patch("time.time", return_value=4000):
+        cache.set("1", {"explorers": [{"hostedBy": "blockscout", "url": "https://a"}]})
+    assert cache.get("1") == ("https://a", 4000 + config.chain_cache_ttl_seconds)
+    cache.invalidate("1")
+    assert cache.get("1") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,8 @@
 from unittest.mock import patch
 
-from blockscout_mcp_server.cache import ChainCache, find_blockscout_url
+from blockscout_mcp_server.cache import ChainCache
 from blockscout_mcp_server.config import config
+from blockscout_mcp_server.tools.common import find_blockscout_url
 
 
 def test_find_blockscout_url_success():
@@ -22,7 +23,7 @@ def test_find_blockscout_url_no_match():
 def test_chain_cache_basic_flow():
     cache = ChainCache()
     with patch("time.time", return_value=1000):
-        cache.set("1", {"explorers": [{"hostedBy": "blockscout", "url": "https://a"}]})
+        cache.set("1", "https://a")
     assert cache.get("1") == ("https://a", 1000 + config.chain_cache_ttl_seconds)
 
 
@@ -35,12 +36,12 @@ def test_chain_cache_set_failure():
 
 def test_chain_cache_bulk_set():
     cache = ChainCache()
-    chains = {
-        "1": {"explorers": [{"hostedBy": "blockscout", "url": "https://a"}]},
-        "2": {"explorers": [{"hostedBy": "blockscout", "url": "https://b"}]},
+    chain_urls = {
+        "1": "https://a",
+        "2": "https://b",
     }
     with patch("time.time", return_value=3000):
-        cache.bulk_set(chains)
+        cache.bulk_set(chain_urls)
     assert cache.get("1") == ("https://a", 3000 + config.chain_cache_ttl_seconds)
     assert cache.get("2") == ("https://b", 3000 + config.chain_cache_ttl_seconds)
 
@@ -48,7 +49,7 @@ def test_chain_cache_bulk_set():
 def test_chain_cache_invalidate():
     cache = ChainCache()
     with patch("time.time", return_value=4000):
-        cache.set("1", {"explorers": [{"hostedBy": "blockscout", "url": "https://a"}]})
+        cache.set("1", "https://a")
     assert cache.get("1") == ("https://a", 4000 + config.chain_cache_ttl_seconds)
     cache.invalidate("1")
     assert cache.get("1") is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,7 +38,15 @@ def test_tool_response_complex_data():
 
     chain_id_guidance = ChainIdGuidance(
         rules="Chain ID rule",
-        recommended_chains=[ChainInfo(name="TestChain", chain_id="123")],
+        recommended_chains=[
+            ChainInfo(
+                name="TestChain",
+                chain_id="123",
+                is_testnet=False,
+                native_currency="TST",
+                ecosystem="Test",
+            )
+        ],
     )
     instructions_data = InstructionsData(
         version="1.0.0",
@@ -90,7 +98,13 @@ def test_pagination_info():
 
 def test_chain_info():
     """Test ChainInfo model."""
-    chain = ChainInfo(name="Ethereum", chain_id="1")
+    chain = ChainInfo(
+        name="Ethereum",
+        chain_id="1",
+        is_testnet=False,
+        native_currency="ETH",
+        ecosystem="Ethereum",
+    )
     assert chain.name == "Ethereum"
     assert chain.chain_id == "1"
 
@@ -99,7 +113,22 @@ def test_chain_id_guidance():
     """Test ChainIdGuidance model."""
     from blockscout_mcp_server.models import ChainIdGuidance
 
-    chains = [ChainInfo(name="Ethereum", chain_id="1"), ChainInfo(name="Base", chain_id="8453")]
+    chains = [
+        ChainInfo(
+            name="Ethereum",
+            chain_id="1",
+            is_testnet=False,
+            native_currency="ETH",
+            ecosystem="Ethereum",
+        ),
+        ChainInfo(
+            name="Base",
+            chain_id="8453",
+            is_testnet=False,
+            native_currency="ETH",
+            ecosystem=["Ethereum", "Superchain"],
+        ),
+    ]
     guidance = ChainIdGuidance(rules="Chain ID rules here", recommended_chains=chains)
     assert guidance.rules == "Chain ID rules here"
     assert len(guidance.recommended_chains) == 2
@@ -111,7 +140,22 @@ def test_instructions_data():
     """Test InstructionsData model."""
     from blockscout_mcp_server.models import ChainIdGuidance
 
-    chains = [ChainInfo(name="Ethereum", chain_id="1"), ChainInfo(name="Polygon", chain_id="137")]
+    chains = [
+        ChainInfo(
+            name="Ethereum",
+            chain_id="1",
+            is_testnet=False,
+            native_currency="ETH",
+            ecosystem="Ethereum",
+        ),
+        ChainInfo(
+            name="Polygon",
+            chain_id="137",
+            is_testnet=False,
+            native_currency="POL",
+            ecosystem="Polygon",
+        ),
+    ]
     chain_id_guidance = ChainIdGuidance(rules="Chain rules", recommended_chains=chains)
     instructions = InstructionsData(
         version="2.0.0",

--- a/tests/tools/test_chains_tools.py
+++ b/tests/tools/test_chains_tools.py
@@ -91,8 +91,7 @@ async def test_get_chains_list_caches_filtered_chains(mock_ctx):
 
             mock_cache.bulk_set.assert_called_once()
             cached = mock_cache.bulk_set.call_args.args[0]
-            assert "1" in cached
-            assert "999" not in cached
+            assert cached == {"1": "https://eth"}
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_chains_tools.py
+++ b/tests/tools/test_chains_tools.py
@@ -19,14 +19,14 @@ async def test_get_chains_list_success(mock_ctx):
         "1": {
             "name": "Ethereum",
             "isTestnet": False,
-            "nativeCurrency": "ETH",
+            "native_currency": "ETH",
             "ecosystem": "Ethereum",
             "explorers": [{"hostedBy": "blockscout", "url": "https://eth"}],
         },
         "137": {
             "name": "Polygon PoS",
             "isTestnet": False,
-            "nativeCurrency": "POL",
+            "native_currency": "POL",
             "ecosystem": "Polygon",
             "explorers": [{"hostedBy": "blockscout", "url": "https://polygon"}],
         },
@@ -160,7 +160,7 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
         "1": {
             "name": "Ethereum",
             "isTestnet": False,
-            "nativeCurrency": "ETH",
+            "native_currency": "ETH",
             "ecosystem": "Ethereum",
             "explorers": [{"hostedBy": "blockscout", "url": "https://eth"}],
         },
@@ -168,7 +168,7 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
         "137": {
             "name": "Polygon PoS",
             "isTestnet": False,
-            "nativeCurrency": "POL",
+            "native_currency": "POL",
             "ecosystem": "Polygon",
             "explorers": [{"hostedBy": "blockscout", "url": "https://polygon"}],
         },

--- a/tests/tools/test_chains_tools.py
+++ b/tests/tools/test_chains_tools.py
@@ -15,14 +15,38 @@ async def test_get_chains_list_success(mock_ctx):
     # 1. ARRANGE: Set up our mocks and test data.
 
     # This is the fake JSON data we want our mocked API call to return.
-    mock_api_response = [
-        {"name": "Ethereum", "chainid": "1"},
-        {"name": "Polygon PoS", "chainid": "137"},
-    ]
+    mock_api_response = {
+        "1": {
+            "name": "Ethereum",
+            "isTestnet": False,
+            "nativeCurrency": "ETH",
+            "ecosystem": "Ethereum",
+            "explorers": [{"hostedBy": "blockscout", "url": "https://eth"}],
+        },
+        "137": {
+            "name": "Polygon PoS",
+            "isTestnet": False,
+            "nativeCurrency": "POL",
+            "ecosystem": "Polygon",
+            "explorers": [{"hostedBy": "blockscout", "url": "https://polygon"}],
+        },
+    }
 
     expected_data = [
-        ChainInfo(name="Ethereum", chain_id="1"),
-        ChainInfo(name="Polygon PoS", chain_id="137"),
+        ChainInfo(
+            name="Ethereum",
+            chain_id="1",
+            is_testnet=False,
+            native_currency="ETH",
+            ecosystem="Ethereum",
+        ),
+        ChainInfo(
+            name="Polygon PoS",
+            chain_id="137",
+            is_testnet=False,
+            native_currency="POL",
+            ecosystem="Polygon",
+        ),
     ]
 
     # Use `patch` to replace the real `make_chainscout_request` with our mock.
@@ -39,7 +63,7 @@ async def test_get_chains_list_success(mock_ctx):
         # 3. ASSERT: Check if the function behaved as expected.
 
         # Was the API helper called correctly?
-        mock_request.assert_called_once_with(api_path="/api/chains/list")
+        mock_request.assert_called_once_with(api_path="/api/chains")
 
         assert isinstance(result, ToolResponse)
         assert result.data == expected_data
@@ -57,7 +81,7 @@ async def test_get_chains_list_empty_response(mock_ctx):
     # ARRANGE
 
     # Empty response
-    mock_api_response = []
+    mock_api_response = {}
     expected_data: list[ChainInfo] = []
 
     with patch(
@@ -69,7 +93,7 @@ async def test_get_chains_list_empty_response(mock_ctx):
         result = await get_chains_list(ctx=mock_ctx)
 
         # ASSERT
-        mock_request.assert_called_once_with(api_path="/api/chains/list")
+        mock_request.assert_called_once_with(api_path="/api/chains")
         assert isinstance(result, ToolResponse)
         assert result.data == expected_data
         assert mock_ctx.report_progress.call_count == 2
@@ -96,7 +120,7 @@ async def test_get_chains_list_invalid_response_format(mock_ctx):
         result = await get_chains_list(ctx=mock_ctx)
 
         # ASSERT
-        mock_request.assert_called_once_with(api_path="/api/chains/list")
+        mock_request.assert_called_once_with(api_path="/api/chains")
         assert isinstance(result, ToolResponse)
         assert result.data == expected_data
         assert mock_ctx.report_progress.call_count == 2
@@ -111,18 +135,40 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
     # ARRANGE
 
     # Mix of valid and invalid chain entries
-    mock_api_response = [
-        {"name": "Ethereum", "chainid": "1"},  # Valid
-        {"name": "Incomplete Chain"},  # Missing chainid
-        {"chainid": "137"},  # Missing name
-        {"name": "Polygon PoS", "chainid": "137"},  # Valid
-        {},  # Empty entry
-    ]
+    mock_api_response = {
+        "1": {
+            "name": "Ethereum",
+            "isTestnet": False,
+            "nativeCurrency": "ETH",
+            "ecosystem": "Ethereum",
+            "explorers": [{"hostedBy": "blockscout", "url": "https://eth"}],
+        },
+        "invalid": {"name": "Incomplete Chain"},
+        "137": {
+            "name": "Polygon PoS",
+            "isTestnet": False,
+            "nativeCurrency": "POL",
+            "ecosystem": "Polygon",
+            "explorers": [{"hostedBy": "blockscout", "url": "https://polygon"}],
+        },
+        "empty": {},
+    }
 
-    # Only valid entries should appear in output
     expected_data = [
-        ChainInfo(name="Ethereum", chain_id="1"),
-        ChainInfo(name="Polygon PoS", chain_id="137"),
+        ChainInfo(
+            name="Ethereum",
+            chain_id="1",
+            is_testnet=False,
+            native_currency="ETH",
+            ecosystem="Ethereum",
+        ),
+        ChainInfo(
+            name="Polygon PoS",
+            chain_id="137",
+            is_testnet=False,
+            native_currency="POL",
+            ecosystem="Polygon",
+        ),
     ]
 
     with patch(
@@ -134,7 +180,7 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
         result = await get_chains_list(ctx=mock_ctx)
 
         # ASSERT
-        mock_request.assert_called_once_with(api_path="/api/chains/list")
+        mock_request.assert_called_once_with(api_path="/api/chains")
         assert isinstance(result, ToolResponse)
         assert result.data == expected_data
         assert mock_ctx.report_progress.call_count == 2
@@ -163,7 +209,7 @@ async def test_get_chains_list_api_error(mock_ctx):
             await get_chains_list(ctx=mock_ctx)
 
         # Verify mock was called as expected before the exception
-        mock_request.assert_called_once_with(api_path="/api/chains/list")
+        mock_request.assert_called_once_with(api_path="/api/chains")
         # Progress should have been reported once (at start) before the error
         assert mock_ctx.report_progress.call_count == 1
         assert mock_ctx.info.call_count == 1

--- a/tests/tools/test_initialization_tools.py
+++ b/tests/tools/test_initialization_tools.py
@@ -17,7 +17,15 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
     mock_time_rules = "Time-based query rule."
     mock_block_rules = "Block time estimation rule."
     mock_efficiency_rules = "Efficiency optimization rule."
-    mock_chains = [{"name": "TestChain", "chain_id": "999"}]
+    mock_chains = [
+        {
+            "name": "TestChain",
+            "chain_id": "999",
+            "is_testnet": False,
+            "native_currency": "TST",
+            "ecosystem": "Test",
+        }
+    ]
 
     with (
         patch("blockscout_mcp_server.tools.initialization_tools.SERVER_VERSION", mock_version),

--- a/tests/tools/test_initialization_tools.py
+++ b/tests/tools/test_initialization_tools.py
@@ -48,8 +48,12 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
         assert result.data.error_handling_rules == mock_error_rules
         assert result.data.chain_id_guidance.rules == mock_chain_rules
         assert len(result.data.chain_id_guidance.recommended_chains) == 1
-        assert result.data.chain_id_guidance.recommended_chains[0].name == "TestChain"
-        assert result.data.chain_id_guidance.recommended_chains[0].chain_id == "999"
+        first_chain = result.data.chain_id_guidance.recommended_chains[0]
+        assert first_chain.name == "TestChain"
+        assert first_chain.chain_id == "999"
+        assert first_chain.is_testnet is False
+        assert first_chain.native_currency == "TST"
+        assert first_chain.ecosystem == "Test"
         assert result.data.pagination_rules == mock_pagination_rules
         assert result.data.time_based_query_rules == mock_time_rules
         assert result.data.block_time_estimation_rules == mock_block_rules


### PR DESCRIPTION
## Summary
- add ChainCache.invalidate() to safely remove cache entries
- update get_blockscout_base_url to use invalidate instead of touching internal cache
- test the new cache invalidation behavior

Closes #184

------
https://chatgpt.com/codex/tasks/task_b_6887d0033e248323800e2a3ac7effe23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an in-memory caching mechanism for chain data with time-to-live management.
  * Chains are now listed with additional details: testnet flag, native currency, and ecosystem.

* **Bug Fixes**
  * Updated API interactions to handle new response formats and endpoints for chain data retrieval.

* **Documentation**
  * Enhanced documentation to reflect caching behavior and richer chain metadata in API responses.

* **Tests**
  * Added and updated tests to cover new cache logic and expanded chain metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->