### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.6.1"
+version = "0.6.2"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- bump `blockscout-mcp-server` version to 0.6.2

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68884a24577c8323af5c3e19fecb22ba