### PR TITLE
feat: add read_contract MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ mcp-server/
 │   ├── constants.py            # Centralized constants used throughout the application, including data truncation limits
 │   ├── logging_utils.py        # Logging utilities for production-ready log formatting
 │   ├── cache.py                # Simple in-memory cache for chain data
+│   ├── web3_pool.py            # Async Web3 connection pool manager
 │   ├── models.py               # Defines standardized Pydantic models for all tool responses
 │   └── tools/                  # Sub-package for tool implementations
 │       ├── __init__.py         # Initializes the tools sub-package
@@ -207,6 +208,9 @@ mcp-server/
         * Contains the `replace_rich_handlers_with_standard()` function that eliminates multi-line Rich formatting from MCP SDK logs.
     * **`cache.py`**:
         * Encapsulates in-memory caching of chain data with TTL management.
+    * **`web3_pool.py`**:
+        * Manages pooled `AsyncWeb3` instances with shared `aiohttp` sessions.
+        * Provides a custom provider to ensure Blockscout RPC compatibility and connection reuse.
     * **`api/` (API layer)**:
         * **`helpers.py`**: Shared utilities for REST API handlers, including parameter extraction and error handling.
         * **`routes.py`**: Defines all REST API endpoints that wrap MCP tools.

--- a/API.md
+++ b/API.md
@@ -444,3 +444,26 @@ Converts an ENS (Ethereum Name Service) name to its corresponding Ethereum addre
 ```bash
 curl "http://127.0.0.1:8000/v1/get_address_by_ens_name?name=vitalik.eth"
 ```
+
+### Read Contract (`read_contract`)
+
+Executes a read-only smart contract function and returns its result.
+
+`GET /v1/read_contract`
+
+**Parameters**
+
+| Name           | Type     | Required | Description                                     |
+| -------------- | -------- | -------- | ----------------------------------------------- |
+| `chain_id`     | `string` | Yes      | The ID of the blockchain.                       |
+| `address`      | `string` | Yes      | Smart contract address.                         |
+| `abi`          | `string` | Yes      | JSON-encoded ABI of the contract.               |
+| `function_name`| `string` | Yes      | Name of the function to call.                   |
+| `args`         | `string` | No       | JSON-encoded array of function arguments.       |
+| `block`        | `string` | No       | Block identifier or number (`latest` by default). |
+
+**Example Request**
+
+```bash
+curl "http://127.0.0.1:8000/v1/read_contract?chain_id=1&address=0xdAC17F958D2ee523a2206206994597C13D831ec7&function_name=balanceOf&abi=%5B%7B%22constant%22%3Atrue%2C%22inputs%22%3A%5B%7B%22name%22%3A%22_owner%22%2C%22type%22%3A%22address%22%7D%5D%2C%22name%22%3A%22balanceOf%22%2C%22outputs%22%3A%5B%7B%22name%22%3A%22balance%22%2C%22type%22%3A%22uint256%22%7D%5D%2C%22payable%22%3Afalse%2C%22stateMutability%22%3A%22view%22%2C%22type%22%3A%22function%22%7D%5D&args=%5B%220xF977814e90dA44bFA03b6295A0616a897441aceC%22%5D"
+```

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 13. `get_block_info(chain_id, number_or_hash, include_transactions=False)` - Returns block information including timestamp, gas used, burnt fees, and transaction count. Can optionally include a list of transaction hashes.
 14. `get_transaction_info(chain_id, hash, include_raw_input=False)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
 15. `get_transaction_logs(chain_id, hash, cursor=None)` - Returns transaction logs with decoded event data.
+16. `read_contract(chain_id, address, abi, function_name, args=None, block='latest')` - Executes a read-only smart contract function and returns its result.
 
 ## Example Prompts for AI Agents
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -238,8 +238,14 @@ This architecture provides the flexibility of a multi-protocol server without th
           }
         }
       }
-      }
-      ```
+    }
+    ```
+
+4. **Async Web3 Connection Pool**:
+   - The server uses a custom `AsyncHTTPProviderBlockscout` and `Web3Pool` to interact with Blockscout's JSON-RPC interface.
+   - Connection pooling reuses TCP connections, reducing latency and resource usage.
+   - The provider ensures request IDs never start at zero and normalizes parameters to lists for Blockscout compatibility.
+   - A shared `aiohttp` session enforces global and per-host connection limits to prevent overload.
 
 4. **Blockscout-Hosted Chain Filtering**:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -214,6 +214,11 @@ This request is missing the `number_or_hash` parameter and should return a 400 e
 curl -i "http://127.0.0.1:8000/v1/get_block_info?chain_id=1"
 ```
 
+#### 5. Read Contract
+```bash
+curl "http://127.0.0.1:8000/v1/read_contract?chain_id=1&address=0xdAC17F958D2ee523a2206206994597C13D831ec7&function_name=balanceOf&abi=%5B%7B%22constant%22%3Atrue%2C%22inputs%22%3A%5B%7B%22name%22%3A%22_owner%22%2C%22type%22%3A%22address%22%7D%5D%2C%22name%22%3A%22balanceOf%22%2C%22outputs%22%3A%5B%7B%22name%22%3A%22balance%22%2C%22type%22%3A%22uint256%22%7D%5D%2C%22payable%22%3Afalse%2C%22stateMutability%22%3A%22view%22%2C%22type%22%3A%22function%22%7D%5D&args=%5B%220xF977814e90dA44bFA03b6295A0616a897441aceC%22%5D"
+```
+
 
 #### Expected REST API Response Format
 

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -1,5 +1,6 @@
 """Module for registering all REST API routes with the FastMCP server."""
 
+import json
 import pathlib
 from collections.abc import Callable
 from typing import Any
@@ -21,7 +22,7 @@ from blockscout_mcp_server.tools.address_tools import (
 )
 from blockscout_mcp_server.tools.block_tools import get_block_info, get_latest_block
 from blockscout_mcp_server.tools.chains_tools import get_chains_list
-from blockscout_mcp_server.tools.contract_tools import get_contract_abi
+from blockscout_mcp_server.tools.contract_tools import get_contract_abi, read_contract
 from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
 from blockscout_mcp_server.tools.initialization_tools import __unlock_blockchain_analysis__
 from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
@@ -160,6 +161,29 @@ async def get_contract_abi_rest(request: Request) -> Response:
 
 
 @handle_rest_errors
+async def read_contract_rest(request: Request) -> Response:
+    """REST wrapper for the read_contract tool."""
+    params = extract_and_validate_params(
+        request,
+        required=["chain_id", "address", "abi", "function_name"],
+        optional=["args", "block"],
+    )
+    try:
+        params["abi"] = json.loads(params["abi"])
+    except json.JSONDecodeError as e:
+        raise ValueError("Invalid JSON for 'abi'") from e
+    if "args" in params:
+        try:
+            params["args"] = json.loads(params["args"])
+        except json.JSONDecodeError as e:
+            raise ValueError("Invalid JSON for 'args'") from e
+    if "block" in params and params["block"].isdigit():
+        params["block"] = int(params["block"])
+    tool_response = await read_contract(**params, ctx=get_mock_context())
+    return JSONResponse(tool_response.model_dump())
+
+
+@handle_rest_errors
 async def get_address_info_rest(request: Request) -> Response:
     """REST wrapper for the get_address_info tool."""
     params = extract_and_validate_params(request, required=["chain_id", "address"], optional=[])
@@ -258,6 +282,7 @@ def register_api_routes(mcp: FastMCP) -> None:
     _add_v1_tool_route(mcp, "/get_token_transfers_by_address", get_token_transfers_by_address_rest)
     _add_v1_tool_route(mcp, "/lookup_token_by_symbol", lookup_token_by_symbol_rest)
     _add_v1_tool_route(mcp, "/get_contract_abi", get_contract_abi_rest)
+    _add_v1_tool_route(mcp, "/read_contract", read_contract_rest)
     _add_v1_tool_route(mcp, "/get_address_info", get_address_info_rest)
     _add_v1_tool_route(mcp, "/get_tokens_by_address", get_tokens_by_address_rest)
     _add_v1_tool_route(mcp, "/transaction_summary", transaction_summary_rest)

--- a/blockscout_mcp_server/llms.txt
+++ b/blockscout_mcp_server/llms.txt
@@ -53,6 +53,7 @@ All tools are available via both MCP and REST API interfaces:
 13. **`get_block_info`** - Returns detailed block information
 14. **`get_transaction_info`** - Gets comprehensive transaction information
 15. **`get_transaction_logs`** - Returns transaction logs with decoded event data
+16. **`read_contract`** - Executes a read-only smart contract function
 
 ## When to Use Each Interface
 

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -74,6 +74,12 @@ class ContractAbiData(BaseModel):
     abi: list | None = Field(description="The Application Binary Interface (ABI) of the smart contract.")
 
 
+class ContractReadData(BaseModel):
+    """Result of a read-only smart contract function call."""
+
+    result: Any = Field(description="Return value from the contract function call.")
+
+
 # --- Model for lookup_token_by_symbol Data Payload ---
 class TokenSearchResult(BaseModel):
     """Represents a single token found by a search query."""

--- a/blockscout_mcp_server/templates/index.html
+++ b/blockscout_mcp_server/templates/index.html
@@ -129,6 +129,7 @@
         <li><code>get_block_info</code>: Returns detailed block information.</li>
         <li><code>get_transaction_info</code>: Gets comprehensive transaction information.</li>
         <li><code>get_transaction_logs</code>: Returns transaction logs with decoded event data.</li>
+        <li><code>read_contract</code>: Executes a read-only smart contract function.</li>
     </ul>
     <p>For more details, please refer to the project's <a href="https://github.com/blockscout/mcp-server">GitHub repository</a>.</p>
 </body>

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -1,9 +1,11 @@
-from typing import Annotated
+from typing import Annotated, Any
 
+from eth_utils import to_checksum_address
 from mcp.server.fastmcp import Context
 from pydantic import Field
+from web3.exceptions import ContractLogicError
 
-from blockscout_mcp_server.models import ContractAbiData, ToolResponse
+from blockscout_mcp_server.models import ContractAbiData, ContractReadData, ToolResponse
 from blockscout_mcp_server.tools.common import (
     build_tool_response,
     get_blockscout_base_url,
@@ -11,6 +13,7 @@ from blockscout_mcp_server.tools.common import (
     report_and_log_progress,
 )
 from blockscout_mcp_server.tools.decorators import log_tool_invocation
+from blockscout_mcp_server.web3_pool import WEB3_POOL
 
 # The contracts sources are not returned by MCP tools as they consume too much context.
 # More elegant solution needs to be found.
@@ -60,3 +63,62 @@ async def get_contract_abi(
     abi_data = ContractAbiData(abi=response_data.get("abi"))
 
     return build_tool_response(data=abi_data)
+
+
+def _convert_json_args(args: list[Any]) -> list[Any]:
+    out: list[Any] = []
+    for a in args:
+        if isinstance(a, list):
+            out.append(_convert_json_args(a))
+        elif isinstance(a, str):
+            if a.startswith(("0x", "0X")):
+                out.append(a)
+            elif a.isdigit():
+                out.append(int(a))
+            else:
+                out.append(a)
+        else:
+            out.append(a)
+    return out
+
+
+@log_tool_invocation
+async def read_contract(
+    chain_id: Annotated[str, Field(description="The ID of the blockchain")],
+    address: Annotated[str, Field(description="Smart contract address")],
+    abi: Annotated[list, Field(description="ABI of the contract")],
+    function_name: Annotated[str, Field(description="Name of the function to call")],
+    ctx: Context,
+    args: Annotated[list[Any] | None, Field(description="Function arguments", default=None)] = None,
+    block: Annotated[str | int, Field(description="Block identifier", default="latest")] = "latest",
+) -> ToolResponse[ContractReadData]:
+    """Execute a read-only smart contract function and return its result."""
+    await report_and_log_progress(
+        ctx,
+        progress=0.0,
+        total=2.0,
+        message=f"Preparing contract call {function_name} on {address}...",
+    )
+    w3 = await WEB3_POOL.get(chain_id)
+    await report_and_log_progress(
+        ctx,
+        progress=1.0,
+        total=2.0,
+        message="Connected. Executing function call...",
+    )
+    contract = w3.eth.contract(address=to_checksum_address(address), abi=abi)
+    fn = contract.get_function_by_name(function_name)
+    if isinstance(fn, list):
+        raise ValueError(f"Function name '{function_name}' is overloaded; use get_function_by_signature(...) instead.")
+    py_args = _convert_json_args(args or [])
+    try:
+        result = await fn(*py_args).call(block_identifier=block)
+    except ContractLogicError as e:
+        raise RuntimeError(f"Contract call failed: {e}") from e
+    await report_and_log_progress(
+        ctx,
+        progress=2.0,
+        total=2.0,
+        message="Contract call successful.",
+    )
+    return build_tool_response(data=ContractReadData(result=result))

--- a/blockscout_mcp_server/web3_pool.py
+++ b/blockscout_mcp_server/web3_pool.py
@@ -1,0 +1,109 @@
+"""Async Web3 connection pool optimized for Blockscout RPC."""
+
+from __future__ import annotations
+
+from itertools import count
+from typing import Any
+
+import aiohttp
+from web3 import AsyncWeb3
+from web3.providers.rpc import AsyncHTTPProvider
+
+from blockscout_mcp_server.tools.common import get_blockscout_base_url
+
+DEFAULT_HEADERS = {"User-Agent": "Blockscout MCP/0.1"}
+REQUEST_TIMEOUT_SECONDS = 60
+POOL_TOTAL_CONN = 200
+POOL_PER_HOST = 50
+
+
+class AsyncHTTPProviderBlockscout(AsyncHTTPProvider):
+    """Custom provider with Blockscout-specific adaptations."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.request_counter = count(1)
+        self.pooled_session: aiohttp.ClientSession | None = None
+
+    def set_pooled_session(self, session: aiohttp.ClientSession) -> None:
+        self.pooled_session = session
+
+    async def _make_http_request(self, session: aiohttp.ClientSession, rpc_dict: dict[str, Any]) -> dict[str, Any]:
+        async with session.post(
+            self.endpoint_uri,
+            json=rpc_dict,
+            headers={"Content-Type": "application/json"},
+            timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS),
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    async def make_request(self, method: str, params: Any) -> dict[str, Any]:  # type: ignore[override]
+        if not isinstance(params, list):
+            if hasattr(params, "__iter__") and not isinstance(params, str | bytes | dict):
+                params = list(params)
+            else:
+                params = [params] if params is not None else []
+
+        rpc_dict = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": next(self.request_counter),
+        }
+
+        if self.pooled_session and not self.pooled_session.closed:
+            return await self._make_http_request(self.pooled_session, rpc_dict)
+
+        async with aiohttp.ClientSession() as session:
+            return await self._make_http_request(session, rpc_dict)
+
+
+class Web3Pool:
+    """Manage pooled AsyncWeb3 instances with shared sessions."""
+
+    def __init__(self) -> None:
+        self._pool: dict[tuple[str, tuple[tuple[str, str], ...]], AsyncWeb3] = {}
+        self._sessions: dict[tuple[str, tuple[tuple[str, str], ...]], aiohttp.ClientSession] = {}
+
+    async def get(self, chain_id: str, headers: dict[str, str] | None = None) -> AsyncWeb3:
+        hdr_items = tuple(sorted((headers or DEFAULT_HEADERS).items()))
+        key = (chain_id, hdr_items)
+        if key in self._pool:
+            return self._pool[key]
+
+        base_url = await get_blockscout_base_url(chain_id)
+        endpoint = f"{base_url}/api/eth-rpc"
+
+        provider = AsyncHTTPProviderBlockscout(
+            endpoint_uri=endpoint,
+            request_kwargs={"headers": dict(hdr_items), "timeout": REQUEST_TIMEOUT_SECONDS},
+        )
+        w3 = AsyncWeb3(provider)
+
+        session = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(limit=POOL_TOTAL_CONN, limit_per_host=POOL_PER_HOST)
+        )
+        provider.set_pooled_session(session)
+
+        self._pool[key] = w3
+        self._sessions[key] = session
+        return w3
+
+    async def close(self) -> None:
+        for w3 in list(self._pool.values()):
+            try:
+                await w3.provider.disconnect()
+            except Exception:
+                pass
+        for sess in list(self._sessions.values()):
+            if not sess.closed:
+                try:
+                    await sess.close()
+                except Exception:
+                    pass
+        self._pool.clear()
+        self._sessions.clear()
+
+
+WEB3_POOL = Web3Pool()

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -90,6 +90,10 @@
     {
       "name": "get_transaction_logs",
       "description": "Returns transaction logs with decoded event data"
+    },
+    {
+      "name": "read_contract",
+      "description": "Executes a read-only smart contract function"
     }
   ],
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.0",
     "anyio>=4.0.0",  # For async task management and progress reporting,
     "uvicorn>=0.23.1",  # For HTTP Streamable mode
+    "web3[async]==7.13.0",
 ]
 
 [project.scripts]

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -289,6 +289,43 @@ async def test_get_contract_abi_missing_param(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+@patch("blockscout_mcp_server.api.routes.read_contract", new_callable=AsyncMock)
+async def test_read_contract_success(mock_tool, client: AsyncClient):
+    mock_tool.return_value = ToolResponse(data={"result": 1})
+    url = "/v1/read_contract?chain_id=1&address=0xabc&abi=%5B%5D&function_name=foo"
+    response = await client.get(url)
+    assert response.status_code == 200
+    assert response.json()["data"] == {"result": 1}
+    mock_tool.assert_called_once_with(chain_id="1", address="0xabc", abi=[], function_name="foo", ctx=ANY)
+
+
+@pytest.mark.asyncio
+@patch("blockscout_mcp_server.api.routes.read_contract", new_callable=AsyncMock)
+async def test_read_contract_with_optional(mock_tool, client: AsyncClient):
+    mock_tool.return_value = ToolResponse(data={"result": 2})
+    url = "/v1/read_contract?chain_id=1&address=0xabc&abi=%5B%5D&function_name=foo&args=%5B1%5D&block=5"
+    response = await client.get(url)
+    assert response.status_code == 200
+    assert response.json()["data"] == {"result": 2}
+    mock_tool.assert_called_once_with(
+        chain_id="1",
+        address="0xabc",
+        abi=[],
+        function_name="foo",
+        args=[1],
+        block=5,
+        ctx=ANY,
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_contract_missing_param(client: AsyncClient):
+    response = await client.get("/v1/read_contract?chain_id=1&address=0xabc&function_name=foo")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Missing required query parameter: 'abi'"}
+
+
+@pytest.mark.asyncio
 @patch("blockscout_mcp_server.api.routes.get_address_info", new_callable=AsyncMock)
 async def test_get_address_info_success(mock_tool, client: AsyncClient):
     """Test /get_address_info endpoint."""

--- a/tests/integration/test_contract_tools_integration.py
+++ b/tests/integration/test_contract_tools_integration.py
@@ -1,7 +1,9 @@
+import aiohttp
+import httpx
 import pytest
 
-from blockscout_mcp_server.models import ContractAbiData, ToolResponse
-from blockscout_mcp_server.tools.contract_tools import get_contract_abi
+from blockscout_mcp_server.models import ContractAbiData, ContractReadData, ToolResponse
+from blockscout_mcp_server.tools.contract_tools import get_contract_abi, read_contract
 
 
 @pytest.mark.integration
@@ -15,3 +17,35 @@ async def test_get_contract_abi_integration(mock_ctx):
     assert isinstance(result.data, ContractAbiData)
     assert isinstance(result.data.abi, list)
     assert len(result.data.abi) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_read_contract_integration(mock_ctx):
+    address = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    abi = [
+        {
+            "constant": True,
+            "inputs": [{"name": "_owner", "type": "address"}],
+            "name": "balanceOf",
+            "outputs": [{"name": "balance", "type": "uint256"}],
+            "payable": False,
+            "stateMutability": "view",
+            "type": "function",
+        }
+    ]
+    owner = "0xF977814e90dA44bFA03b6295A0616a897441aceC"
+    try:
+        result = await read_contract(
+            chain_id="1",
+            address=address,
+            abi=abi,
+            function_name="balanceOf",
+            args=[owner],
+            ctx=mock_ctx,
+        )
+    except (aiohttp.ClientError, httpx.HTTPError, OSError) as e:
+        pytest.skip(f"Network connectivity issue: {e}")
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, ContractReadData)
+    assert isinstance(result.data.result, int)

--- a/tests/test_web3_pool.py
+++ b/tests/test_web3_pool.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from blockscout_mcp_server.web3_pool import (
+    AsyncHTTPProviderBlockscout,
+    Web3Pool,
+)
+
+
+@pytest.mark.asyncio
+async def test_web3_pool_reuses_instances():
+    pool = Web3Pool()
+    mock_session = MagicMock()
+    mock_session.closed = False
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.get_blockscout_base_url",
+            new_callable=AsyncMock,
+            return_value="https://example.org",
+        ) as mock_get_url,
+        patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", return_value=mock_session) as mock_session_cls,
+    ):
+        w3_first = await pool.get("1")
+        w3_second = await pool.get("1")
+    assert w3_first is w3_second
+    mock_get_url.assert_called_once_with("1")
+    mock_session_cls.assert_called_once()
+    assert w3_first.provider.endpoint_uri == "https://example.org/api/eth-rpc"
+
+
+@pytest.mark.asyncio
+async def test_provider_formats_request():
+    provider = AsyncHTTPProviderBlockscout(endpoint_uri="http://rpc", request_kwargs={})
+    session_mock = MagicMock()
+    session_mock.closed = False
+    provider.set_pooled_session(session_mock)
+    with patch.object(provider, "_make_http_request", new_callable=AsyncMock, return_value={}) as mock_http:
+        await provider.make_request("eth_method", ("0xabc",))
+        await provider.make_request("eth_method", ["0xdef", "latest"])
+    first_rpc = mock_http.await_args_list[0].args[1]
+    second_rpc = mock_http.await_args_list[1].args[1]
+    assert first_rpc["params"] == ["0xabc"]
+    assert first_rpc["id"] == 1
+    assert second_rpc["params"] == ["0xdef", "latest"]
+    assert second_rpc["id"] == 2

--- a/tests/tools/test_contract_tools.py
+++ b/tests/tools/test_contract_tools.py
@@ -3,9 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from web3.exceptions import ContractLogicError
 
 from blockscout_mcp_server.models import ContractAbiData, ToolResponse
-from blockscout_mcp_server.tools.contract_tools import get_contract_abi
+from blockscout_mcp_server.tools.common import ChainNotFoundError
+from blockscout_mcp_server.tools.contract_tools import get_contract_abi, read_contract
 
 
 def assert_contract_abi_response(result: ToolResponse, expected_abi) -> None:
@@ -283,3 +285,117 @@ async def test_get_contract_abi_complex_abi(mock_ctx):
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=f"/api/v2/smart-contracts/{address}")
         assert_contract_abi_response(result, mock_abi_list)
         assert mock_ctx.report_progress.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_read_contract_success(mock_ctx):
+    chain_id = "1"
+    address = "0x0000000000000000000000000000000000000abc"
+    abi: list = []
+    function_name = "balanceOf"
+    expected = 123
+
+    fn_result = MagicMock()
+    fn_result.call = AsyncMock(return_value=expected)
+    fn_mock = MagicMock(return_value=fn_result)
+    contract_mock = MagicMock()
+    contract_mock.get_function_by_name.return_value = fn_mock
+    w3_mock = MagicMock()
+    w3_mock.eth.contract.return_value = contract_mock
+
+    with patch(
+        "blockscout_mcp_server.tools.contract_tools.WEB3_POOL.get",
+        new_callable=AsyncMock,
+        return_value=w3_mock,
+    ) as mock_get:
+        result = await read_contract(
+            chain_id=chain_id,
+            address=address,
+            abi=abi,
+            function_name=function_name,
+            args=["1"],
+            block="latest",
+            ctx=mock_ctx,
+        )
+
+    mock_get.assert_called_once_with(chain_id)
+    contract_mock.get_function_by_name.assert_called_once_with(function_name)
+    fn_mock.assert_called_once_with(1)
+    fn_result.call.assert_awaited_once_with(block_identifier="latest")
+    assert result.data.result == expected
+    assert mock_ctx.report_progress.call_count == 3
+    assert mock_ctx.info.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_read_contract_chain_not_found(mock_ctx):
+    chain_id = "999"
+    with patch(
+        "blockscout_mcp_server.tools.contract_tools.WEB3_POOL.get",
+        new_callable=AsyncMock,
+        side_effect=ChainNotFoundError("not found"),
+    ) as mock_get:
+        with pytest.raises(ChainNotFoundError):
+            await read_contract(
+                chain_id=chain_id,
+                address="0x0000000000000000000000000000000000000abc",
+                abi=[],
+                function_name="foo",
+                ctx=mock_ctx,
+            )
+    mock_get.assert_called_once_with(chain_id)
+    assert mock_ctx.report_progress.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_read_contract_contract_error(mock_ctx):
+    fn_result = MagicMock()
+    fn_result.call = AsyncMock(side_effect=ContractLogicError("boom"))
+    fn_mock = MagicMock(return_value=fn_result)
+    contract_mock = MagicMock()
+    contract_mock.get_function_by_name.return_value = fn_mock
+    w3_mock = MagicMock()
+    w3_mock.eth.contract.return_value = contract_mock
+
+    with patch(
+        "blockscout_mcp_server.tools.contract_tools.WEB3_POOL.get",
+        new_callable=AsyncMock,
+        return_value=w3_mock,
+    ):
+        with pytest.raises(RuntimeError):
+            await read_contract(
+                chain_id="1",
+                address="0x0000000000000000000000000000000000000abc",
+                abi=[],
+                function_name="foo",
+                ctx=mock_ctx,
+            )
+    assert mock_ctx.report_progress.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_read_contract_default_args(mock_ctx):
+    fn_result = MagicMock()
+    fn_result.call = AsyncMock(return_value=0)
+    fn_mock = MagicMock(return_value=fn_result)
+    contract_mock = MagicMock()
+    contract_mock.get_function_by_name.return_value = fn_mock
+    w3_mock = MagicMock()
+    w3_mock.eth.contract.return_value = contract_mock
+
+    with patch(
+        "blockscout_mcp_server.tools.contract_tools.WEB3_POOL.get",
+        new_callable=AsyncMock,
+        return_value=w3_mock,
+    ):
+        await read_contract(
+            chain_id="1",
+            address="0x0000000000000000000000000000000000000abc",
+            abi=[],
+            function_name="foo",
+            ctx=mock_ctx,
+        )
+
+    fn_mock.assert_called_once_with()
+    fn_result.call.assert_awaited_once_with(block_identifier="latest")
+    assert mock_ctx.report_progress.call_count == 3


### PR DESCRIPTION
## Summary
- add async Web3 connection pool with Blockscout-compatible provider
- implement `read_contract` MCP tool and REST endpoint
- document and test contract execution helper

## Testing
- `pytest`
- `pytest -m integration tests/integration/test_contract_tools_integration.py -v`

Closes #190

------
https://chatgpt.com/codex/tasks/task_b_68957802ca108323808b435bcd4b2c43