### PR TITLE
Implement fine-grained ChainCache locking

### DIFF
--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -49,7 +49,7 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
                             filtered[chain_id] = chain
                             url_map[chain_id] = url
 
-                    chain_cache.bulk_set(url_map)
+                    await chain_cache.bulk_set(url_map)
 
                     for chain_id, chain in filtered.items():
                         if chain.get("name"):

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -85,7 +85,7 @@ async def get_blockscout_base_url(chain_id: str) -> str:
                 )
             return cached_url
         else:
-            chain_cache.invalidate(chain_id)  # Cache expired
+            await chain_cache.invalidate(chain_id)  # Cache expired
 
     chain_api_url = f"{config.chainscout_url}/api/chains/{chain_id}"
 
@@ -101,18 +101,18 @@ async def get_blockscout_base_url(chain_id: str) -> str:
         chain_data = response.json()
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
-            chain_cache.set_failure(chain_id)
+            await chain_cache.set_failure(chain_id)
             raise ChainNotFoundError(f"Chain with ID '{chain_id}' not found on Chainscout.") from e
         raise ChainNotFoundError(f"Error fetching data for chain ID '{chain_id}' from Chainscout: {e}") from e
     except (httpx.RequestError, json.JSONDecodeError) as e:
         raise ChainNotFoundError(f"Could not retrieve or parse data for chain ID '{chain_id}' from Chainscout.") from e
 
     if not chain_data or "explorers" not in chain_data:
-        chain_cache.set_failure(chain_id)
+        await chain_cache.set_failure(chain_id)
         raise ChainNotFoundError(f"No explorer data found for chain ID '{chain_id}' on Chainscout.")
 
     blockscout_url = find_blockscout_url(chain_data)
-    chain_cache.set(chain_id, blockscout_url)
+    await chain_cache.set(chain_id, blockscout_url)
 
     if blockscout_url:
         return blockscout_url

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from blockscout_mcp_server.cache import ChainCache
 from blockscout_mcp_server.config import config
 from blockscout_mcp_server.tools.common import find_blockscout_url
@@ -20,36 +22,40 @@ def test_find_blockscout_url_no_match():
     assert find_blockscout_url(chain_data) is None
 
 
-def test_chain_cache_basic_flow():
+@pytest.mark.asyncio
+async def test_chain_cache_basic_flow():
     cache = ChainCache()
     with patch("time.time", return_value=1000):
-        cache.set("1", "https://a")
+        await cache.set("1", "https://a")
     assert cache.get("1") == ("https://a", 1000 + config.chain_cache_ttl_seconds)
 
 
-def test_chain_cache_set_failure():
+@pytest.mark.asyncio
+async def test_chain_cache_set_failure():
     cache = ChainCache()
     with patch("time.time", return_value=2000):
-        cache.set_failure("2")
+        await cache.set_failure("2")
     assert cache.get("2") == (None, 2000 + config.chain_cache_ttl_seconds)
 
 
-def test_chain_cache_bulk_set():
+@pytest.mark.asyncio
+async def test_chain_cache_bulk_set():
     cache = ChainCache()
     chain_urls = {
         "1": "https://a",
         "2": "https://b",
     }
     with patch("time.time", return_value=3000):
-        cache.bulk_set(chain_urls)
+        await cache.bulk_set(chain_urls)
     assert cache.get("1") == ("https://a", 3000 + config.chain_cache_ttl_seconds)
     assert cache.get("2") == ("https://b", 3000 + config.chain_cache_ttl_seconds)
 
 
-def test_chain_cache_invalidate():
+@pytest.mark.asyncio
+async def test_chain_cache_invalidate():
     cache = ChainCache()
     with patch("time.time", return_value=4000):
-        cache.set("1", "https://a")
+        await cache.set("1", "https://a")
     assert cache.get("1") == ("https://a", 4000 + config.chain_cache_ttl_seconds)
-    cache.invalidate("1")
+    await cache.invalidate("1")
     assert cache.get("1") is None

--- a/tests/tools/test_chains_tools.py
+++ b/tests/tools/test_chains_tools.py
@@ -96,10 +96,11 @@ async def test_get_chains_list_caches_filtered_chains(mock_ctx):
     ) as mock_request:
         with patch("blockscout_mcp_server.tools.chains_tools.chain_cache") as mock_cache:
             mock_request.return_value = mock_api_response
+            mock_cache.bulk_set = AsyncMock()
 
             await get_chains_list(ctx=mock_ctx)
 
-            mock_cache.bulk_set.assert_called_once()
+            mock_cache.bulk_set.assert_awaited_once()
             cached = mock_cache.bulk_set.call_args.args[0]
             assert cached == {"1": "https://eth"}
 


### PR DESCRIPTION
## Summary
- add per-chain async locks in ChainCache and convert write operations to async
- await ChainCache writes in common and chains tools
- update cache-related tests for async API

## Testing
- `pytest`
- `pytest --cov=blockscout_mcp_server --cov-report=term-missing`
- `pytest -m integration`

Closes #192

------
https://chatgpt.com/codex/tasks/task_b_68964d3ab81883238659476bc2b50324