### PR TITLE
Replace Cursor MCP deeplink with working web link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ _Note: Docker is required for this setup_
 
 **Cursor Setup:**
 
-Use [this deeplink](cursor://anysphere.cursor-deeplink/mcp/install?name=blockscout&config=eyJ1cmwiOiJodHRwczovL21jcC5ibG9ja3Njb3V0LmNvbS9tY3AvIiwidGltZW91dCI6MTgwMDAwfQ%3D%3D) to install the Blockscout MCP server in Cursor.
+Use [this deeplink](https://cursor.com/en/install-mcp?name=blockscout&config=eyJ1cmwiOiJodHRwczovL21jcC5ibG9ja3Njb3V0LmNvbS9tY3AvIiwidGltZW91dCI6MTgwMDAwLCJoZWFkZXJzIjp7fX0%3D) to install the Blockscout MCP server in Cursor.
 
 **Gemini CLI Setup:**
 


### PR DESCRIPTION
# Summary

GitHub suppresses `cursor://…` deeplinks in rendered Markdown, which made our one-click Cursor MCP setup unusable from the README. Cursor’s site now generates working **web links**, so this PR updates the README to use a web link that restores the Blockscout MCP configuration in Cursor.

# Details

* **Background**

  * Deeplinks were originally used because web links generated by Cursor did not restore the MCP server configuration correctly.
  * Since GitHub removes `cursor://` links in rendered Markdown, the deeplink in `README.md` was effectively hidden.
  * A recent check shows Cursor now produces **functional web links** from its documentation portal: [https://docs.cursor.com/en/tools/developers](https://docs.cursor.com/en/tools/developers)

* **Change**

  * Replace the deeplink in `README.md` with a **web link** that automates the Blockscout MCP configuration in Cursor.

* **Why**

  * Works reliably in GitHub’s UI.
  * Preserves one-click setup for users.

## Reference

**Blockscout MCP config JSON used to generate the link**

```json
{
  "blockscout": {
    "url": "https://mcp.blockscout.com/mcp/",
    "timeout": 180000,
    "headers": {}
  }
}
```

**Link formats**

* Deeplink pattern (previous, suppressed by GitHub): `cursor://anysphere.cursor-deeplink/mcp/install?…`
* Web link pattern (now used): `https://cursor.com/en/install-mcp?…`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated Cursor installation instructions to use a standard web URL instead of a Cursor-specific deeplink, improving accessibility across environments.
  * Synchronized the example configuration payload with the new URL to ensure a smooth setup.
  * No functional changes to the product.
  * Simplifies onboarding by providing a direct, browser-accessible installation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->