### PR TITLE
feat: expose settlement layer chain IDs

### DIFF
--- a/API.md
+++ b/API.md
@@ -127,7 +127,7 @@ curl "http://127.0.0.1:8000/v1/unlock_blockchain_analysis"
 
 #### Get Chains List (`get_chains_list`)
 
-Returns a list of all known blockchain chains, including whether each is a testnet, its native currency, and ecosystem.
+Returns a list of all known blockchain chains, including whether each is a testnet, its native currency, ecosystem, and the settlement layer chain ID when applicable.
 
 `GET /v1/get_chains_list`
 

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -66,6 +66,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "ETH",
         "ecosystem": "Ethereum",
+        "settlement_layer_chain_id": None,
     },
     {
         "name": "Polygon PoS",
@@ -73,6 +74,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "POL",
         "ecosystem": "Polygon",
+        "settlement_layer_chain_id": None,
     },
     {
         "name": "Base",
@@ -80,6 +82,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "ETH",
         "ecosystem": ["Ethereum", "Superchain"],
+        "settlement_layer_chain_id": "1",
     },
     {
         "name": "Arbitrum One Nitro",
@@ -87,6 +90,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "ETH",
         "ecosystem": "Arbitrum",
+        "settlement_layer_chain_id": "1",
     },
     {
         "name": "OP Mainnet",
@@ -94,6 +98,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "ETH",
         "ecosystem": ["Optimism", "Superchain"],
+        "settlement_layer_chain_id": "1",
     },
     {
         "name": "ZkSync Era",
@@ -101,6 +106,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "ETH",
         "ecosystem": "zkSync",
+        "settlement_layer_chain_id": "1",
     },
     {
         "name": "Gnosis",
@@ -108,6 +114,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "XDAI",
         "ecosystem": "Gnosis",
+        "settlement_layer_chain_id": None,
     },
     {
         "name": "Celo",
@@ -115,6 +122,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "CELO",
         "ecosystem": "Ethereum",
+        "settlement_layer_chain_id": None,
     },
     {
         "name": "Scroll",
@@ -122,6 +130,7 @@ RECOMMENDED_CHAINS = [
         "is_testnet": False,
         "native_currency": "ETH",
         "ecosystem": "Ethereum",
+        "settlement_layer_chain_id": "1",
     },
 ]
 

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -43,6 +43,10 @@ class ChainInfo(BaseModel):
     ecosystem: str | list[str] | None = Field(
         description="The ecosystem the chain belongs to, if applicable (e.g., 'Ethereum')."
     )
+    settlement_layer_chain_id: str | None = Field(
+        default=None,
+        description="The L1 chain ID where this rollup settles, if applicable.",
+    )
 
 
 # --- Model for __unlock_blockchain_analysis__ Data Payload ---

--- a/blockscout_mcp_server/tools/chains_tools.py
+++ b/blockscout_mcp_server/tools/chains_tools.py
@@ -61,6 +61,7 @@ async def get_chains_list(ctx: Context) -> ToolResponse[list[ChainInfo]]:
                                     is_testnet=chain.get("isTestnet", False),
                                     native_currency=chain.get("native_currency"),
                                     ecosystem=chain.get("ecosystem"),
+                                    settlement_layer_chain_id=chain.get("settlementLayerChainId"),
                                 )
                             )
 

--- a/tests/integration/test_chains_tools_integration.py
+++ b/tests/integration/test_chains_tools_integration.py
@@ -35,6 +35,7 @@ async def test_get_chains_list_integration(mock_ctx):
     assert eth_chain.is_testnet is False
     assert eth_chain.native_currency == "ETH"
     assert eth_chain.ecosystem == "Ethereum"
+    assert eth_chain.settlement_layer_chain_id is None
 
     op_chain = next((chain for chain in result.data if chain.name == "OP Mainnet"), None)
     assert op_chain is not None
@@ -42,6 +43,7 @@ async def test_get_chains_list_integration(mock_ctx):
     assert op_chain.is_testnet is False
     assert op_chain.native_currency == "ETH"
     assert op_chain.ecosystem == ["Optimism", "Superchain"]
+    assert op_chain.settlement_layer_chain_id == "1"
 
 
 @pytest.mark.integration

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,9 +104,11 @@ def test_chain_info():
         is_testnet=False,
         native_currency="ETH",
         ecosystem="Ethereum",
+        settlement_layer_chain_id=None,
     )
     assert chain.name == "Ethereum"
     assert chain.chain_id == "1"
+    assert chain.settlement_layer_chain_id is None
 
 
 def test_chain_id_guidance():
@@ -120,6 +122,7 @@ def test_chain_id_guidance():
             is_testnet=False,
             native_currency="ETH",
             ecosystem="Ethereum",
+            settlement_layer_chain_id=None,
         ),
         ChainInfo(
             name="Base",
@@ -127,6 +130,7 @@ def test_chain_id_guidance():
             is_testnet=False,
             native_currency="ETH",
             ecosystem=["Ethereum", "Superchain"],
+            settlement_layer_chain_id="1",
         ),
     ]
     guidance = ChainIdGuidance(rules="Chain ID rules here", recommended_chains=chains)
@@ -147,6 +151,7 @@ def test_instructions_data():
             is_testnet=False,
             native_currency="ETH",
             ecosystem="Ethereum",
+            settlement_layer_chain_id=None,
         ),
         ChainInfo(
             name="Polygon",
@@ -154,6 +159,7 @@ def test_instructions_data():
             is_testnet=False,
             native_currency="POL",
             ecosystem="Polygon",
+            settlement_layer_chain_id=None,
         ),
     ]
     chain_id_guidance = ChainIdGuidance(rules="Chain rules", recommended_chains=chains)

--- a/tests/tools/test_chains_tools.py
+++ b/tests/tools/test_chains_tools.py
@@ -38,6 +38,7 @@ async def test_get_chains_list_success(mock_ctx):
             "isTestnet": False,
             "native_currency": "POL",
             "ecosystem": "Polygon",
+            "settlementLayerChainId": "1",
             "explorers": [{"hostedBy": "blockscout", "url": "https://polygon"}],
         },
     }
@@ -49,6 +50,7 @@ async def test_get_chains_list_success(mock_ctx):
             is_testnet=False,
             native_currency="ETH",
             ecosystem="Ethereum",
+            settlement_layer_chain_id=None,
         ),
         ChainInfo(
             name="Polygon PoS",
@@ -56,6 +58,7 @@ async def test_get_chains_list_success(mock_ctx):
             is_testnet=False,
             native_currency="POL",
             ecosystem="Polygon",
+            settlement_layer_chain_id="1",
         ),
     ]
 
@@ -193,6 +196,7 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
             is_testnet=False,
             native_currency="ETH",
             ecosystem="Ethereum",
+            settlement_layer_chain_id=None,
         ),
         ChainInfo(
             name="Polygon PoS",
@@ -200,6 +204,7 @@ async def test_get_chains_list_chains_with_missing_fields(mock_ctx):
             is_testnet=False,
             native_currency="POL",
             ecosystem="Polygon",
+            settlement_layer_chain_id=None,
         ),
     ]
 

--- a/tests/tools/test_initialization_tools.py
+++ b/tests/tools/test_initialization_tools.py
@@ -24,6 +24,7 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
             "is_testnet": False,
             "native_currency": "TST",
             "ecosystem": "Test",
+            "settlement_layer_chain_id": "1",
         }
     ]
 
@@ -54,6 +55,7 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
         assert first_chain.is_testnet is False
         assert first_chain.native_currency == "TST"
         assert first_chain.ecosystem == "Test"
+        assert first_chain.settlement_layer_chain_id == "1"
         assert result.data.pagination_rules == mock_pagination_rules
         assert result.data.time_based_query_rules == mock_time_rules
         assert result.data.block_time_estimation_rules == mock_block_rules


### PR DESCRIPTION
## Summary
- include settlement layer chain id in ChainInfo model and chains tool
- document settlement layer chain ids in REST API and constants

## Testing
- `ruff check . --fix`
- `ruff format .`
- `ruff check .`
- `ruff format --check .`
- `pytest tests/tools/test_chains_tools.py tests/tools/test_initialization_tools.py tests/test_models.py`
- `pytest -m integration -v` *(failed: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689f890714a883239436a6612474fcca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Chains list responses now include an optional “settlement layer chain ID” for rollups, when available. Existing fields are unchanged, and the new field may be empty when not applicable. This is backward-compatible.

* Documentation
  * Updated Get Chains List endpoint description to reflect inclusion of the settlement layer chain ID alongside existing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->