### PR TITLE
feat: track index page views

### DIFF
--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -9,6 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 
+from blockscout_mcp_server.analytics import track_event
 from blockscout_mcp_server.api.dependencies import get_mock_context
 from blockscout_mcp_server.api.helpers import (
     create_deprecation_response,
@@ -70,8 +71,9 @@ async def serve_llms_txt(_: Request) -> Response:
     return PlainTextResponse(LLMS_TXT_CONTENT)
 
 
-async def main_page(_: Request) -> Response:
+async def main_page(request: Request) -> Response:
     """Serve the main landing page."""
+    track_event(request, "PageView", {"path": "/"})
     if INDEX_HTML_CONTENT is None:
         message = "Landing page content is not available."
         return PlainTextResponse(message, status_code=500)

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -26,9 +26,10 @@ def client(test_mcp_instance):
 
 
 @pytest.mark.asyncio
+@patch("blockscout_mcp_server.api.routes.track_event")
 @patch("blockscout_mcp_server.api.routes.INDEX_HTML_CONTENT", "<h1>Blockscout MCP Server</h1>")
 @patch("blockscout_mcp_server.api.routes.LLMS_TXT_CONTENT", "# Blockscout MCP Server")
-async def test_static_routes_work_correctly(client: AsyncClient):
+async def test_static_routes_work_correctly(mock_track_event, client: AsyncClient):
     """Verify that static routes return correct content and headers after registration."""
     response_health = await client.get("/health")
     assert response_health.status_code == 200
@@ -39,6 +40,7 @@ async def test_static_routes_work_correctly(client: AsyncClient):
     assert response_main.status_code == 200
     assert "<h1>Blockscout MCP Server</h1>" in response_main.text
     assert "text/html" in response_main.headers["content-type"]
+    mock_track_event.assert_called_once_with(ANY, "PageView", {"path": "/"})
 
     response_llms = await client.get("/llms.txt")
     assert response_llms.status_code == 200


### PR DESCRIPTION
## Summary
- add generic Mixpanel event tracker
- log landing page views
- cover event tracking with tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

Closes #212

------
https://chatgpt.com/codex/tasks/task_b_68ae32599f34832392db1b9e6cf6dfb0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added anonymous page-view tracking for the home page when running in HTTP mode, capturing basic client metadata (IP and user agent) for analytics. No impact on app behavior.

- Tests
  - Added tests for analytics behavior, including verification that a page-view event is emitted on “/” and that tracking is disabled when analytics is turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->