### PR TITLE
Remove unsupported limit parameter from direct API pagination tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ mcp-server/
 │   │   ├── test_chains_tools_integration.py    # Tool-level integration tests for chains tools
 │   │   ├── test_common_helpers.py              # Helper-level integration tests for API helpers
 │   │   ├── test_contract_tools_integration.py  # Tool-level integration tests for contract tools
+│   │   ├── test_direct_api_tools_integration.py   # Tool-level integration tests for direct API tool
 │   │   ├── test_ens_tools_integration.py       # Tool-level integration tests for ENS tools
 │   │   ├── test_search_tools_integration.py    # Tool-level integration tests for search tools
 │   │   └── test_transaction_tools_integration.py # Tool-level integration tests for transaction tools

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ mcp-server/
 │       ├── address_tools.py    # Implements address-related tools (e.g., get_address_info, get_tokens_by_address)
 │       ├── block_tools.py      # Implements block-related tools (e.g., get_latest_block, get_block_info)
 │       ├── transaction_tools.py# Implements transaction-related tools (e.g., get_transactions_by_address, get_transaction_info)
+│       ├── direct_api_tools.py   # Implements generic direct API tool (direct_api_call)
 │       └── chains_tools.py     # Implements chain-related tools (e.g., get_chains_list)
 ├── tests/                      # Test suite for all MCP tools
 │   ├── integration/            # Integration tests that make real network calls
@@ -281,4 +282,5 @@ mcp-server/
                 * `contract_tools.py`: Implements `get_contract_abi(chain_id, address)` and `inspect_contract_code(chain_id, address, file_name=None)`.
                 * `address_tools.py`: Implements `get_address_info(chain_id, address)` (includes public tags), `get_tokens_by_address(chain_id, address, cursor=None)`, `nft_tokens_by_address(chain_id, address, cursor=None)` with robust, cursor-based pagination.
                 * `block_tools.py`: Implements `get_block_info(chain_id, number_or_hash, include_transactions=False)`, `get_latest_block(chain_id)`.
-                * `transaction_tools.py`: Implements `get_transactions_by_address(chain_id, address, age_from, age_to, methods, cursor=None)`, `get_token_transfers_by_address(chain_id, address, age_from, age_to, token, cursor=None)`, `get_transaction_info(chain_id, hash, include_raw_input=False)`, `transaction_summary(chain_id, hash)`, `get_transaction_logs(chain_id, hash, cursor=None)`, etc.
+            * `transaction_tools.py`: Implements `get_transactions_by_address(chain_id, address, age_from, age_to, methods, cursor=None)`, `get_token_transfers_by_address(chain_id, address, age_from, age_to, token, cursor=None)`, `get_transaction_info(chain_id, hash, include_raw_input=False)`, `transaction_summary(chain_id, hash)`, `get_transaction_logs(chain_id, hash, cursor=None)`, etc.
+            * `direct_api_tools.py`: Implements `direct_api_call(chain_id, endpoint_path, query_params=None, cursor=None)`.

--- a/API.md
+++ b/API.md
@@ -487,3 +487,25 @@ Executes a read-only smart contract function and returns its result.
 ```bash
 curl "http://127.0.0.1:8000/v1/read_contract?chain_id=1&address=0xdAC17F958D2ee523a2206206994597C13D831ec7&function_name=balanceOf&abi=%7B%22constant%22%3Atrue%2C%22inputs%22%3A%5B%7B%22name%22%3A%22_owner%22%2C%22type%22%3A%22address%22%7D%5D%2C%22name%22%3A%22balanceOf%22%2C%22outputs%22%3A%5B%7B%22name%22%3A%22balance%22%2C%22type%22%3A%22uint256%22%7D%5D%2C%22payable%22%3Afalse%2C%22stateMutability%22%3A%22view%22%2C%22type%22%3A%22function%22%7D&args=%5B%220xF977814e90dA44bFA03b6295A0616a897441aceC%22%5D"
 ```
+
+### Direct API Call (`direct_api_call`)
+
+Allows calling a curated raw Blockscout API endpoint for advanced or chain-specific data.
+
+`GET /v1/direct_api_call`
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |
+| `chain_id` | `string` | Yes | The ID of the blockchain. |
+| `endpoint_path` | `string` | Yes | The Blockscout API path to call (e.g., `/api/v2/stats`). |
+| `cursor` | `string` | No | The cursor for pagination from a previous response. |
+
+Any additional query parameters appended to the URL are forwarded directly to the Blockscout API.
+
+**Example Request**
+
+```bash
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats"
+```

--- a/API.md
+++ b/API.md
@@ -500,12 +500,11 @@ Allows calling a curated raw Blockscout API endpoint for advanced or chain-speci
 | ---- | ---- | -------- | ----------- |
 | `chain_id` | `string` | Yes | The ID of the blockchain. |
 | `endpoint_path` | `string` | Yes | The Blockscout API path to call (e.g., `/api/v2/stats`). |
+| `query_params` | `object` | No | Additional query parameters forwarded to the Blockscout API. |
 | `cursor` | `string` | No | The cursor for pagination from a previous response. |
-
-Any additional query parameters appended to the URL are forwarded directly to the Blockscout API.
 
 **Example Request**
 
 ```bash
-curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats"
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats&query_params[page]=1"
 ```

--- a/API.md
+++ b/API.md
@@ -500,7 +500,7 @@ Allows calling a curated raw Blockscout API endpoint for advanced or chain-speci
 | ---- | ---- | -------- | ----------- |
 | `chain_id` | `string` | Yes | The ID of the blockchain. |
 | `endpoint_path` | `string` | Yes | The Blockscout API path to call (e.g., `/api/v2/stats`). |
-| `query_params` | `object` | No | Additional query parameters forwarded to the Blockscout API. |
+| `query_params` | `object` | No | Additional query parameters forwarded to the Blockscout API. Use bracket syntax in the query string, e.g., `query_params[page]=1`. |
 | `cursor` | `string` | No | The cursor for pagination from a previous response. |
 
 **Example Request**

--- a/API.md
+++ b/API.md
@@ -506,5 +506,5 @@ Allows calling a curated raw Blockscout API endpoint for advanced or chain-speci
 **Example Request**
 
 ```bash
-curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats&query_params[page]=1"
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=137&endpoint_path=/api/v2/proxy/account-abstraction/operations&query_params[sender]=0x91f51371D33e4E50e838057E8045265372f8d448"
 ```

--- a/API.md
+++ b/API.md
@@ -506,5 +506,5 @@ Allows calling a curated raw Blockscout API endpoint for advanced or chain-speci
 **Example Request**
 
 ```bash
-curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=137&endpoint_path=/api/v2/proxy/account-abstraction/operations&query_params[sender]=0x91f51371D33e4E50e838057E8045265372f8d448"
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/proxy/account-abstraction/operations&query_params[sender]=0x91f51371D33e4E50e838057E8045265372f8d448"
 ```

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 15. `get_transaction_info(chain_id, hash, include_raw_input=False)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
 16. `get_transaction_logs(chain_id, hash, cursor=None)` - Returns transaction logs with decoded event data.
 17. `read_contract(chain_id, address, abi, function_name, args=None, block='latest')` - Executes a read-only smart contract function and returns its result. The `abi` argument is a JSON object describing the specific function's signature.
+18. `direct_api_call(chain_id, endpoint_path, query_params=None, cursor=None)` - Calls a curated raw Blockscout API endpoint for specialized or chain-specific data.
 
 ## Example Prompts for AI Agents
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -581,3 +581,30 @@ This server exposes a tool for on-chain smart contract read-only state access. I
 - Write operations are not supported; `eth_call` does not change state.
 - No caller context (`from`) or gas simulation tuning is provided.
 - Multi-function ABI arrays are not accepted for `read_contract`; provide exactly the ABI item for the intended function signature.
+
+### Direct API Call Tool (`direct_api_call`)
+
+To enhance the flexibility and extensibility of the Blockscout MCP Server, a new generic tool, `direct_api_call`, has been introduced. This tool allows AI agents to access a curated set of Blockscout API endpoints that are not covered by existing, more specialized MCP tools.
+
+**Rationale for Introduction:**
+
+While the existing MCP tools provide high-level, optimized access to common blockchain data, they do not cover every possible endpoint or chain-specific functionality offered by Blockscout. Introducing a dedicated tool for every niche endpoint would lead to "tool sprawl," overwhelming the LLM's context and making tool selection difficult. The `direct_api_call` tool addresses this by providing a controlled mechanism to access specialized data without proliferating the core toolset. It is specifically designed for:
+
+*   Accessing chain-specific data (e.g., rollup batch information, validator lists for PoS chains).
+*   Retrieving data from less frequently used or experimental Blockscout API endpoints.
+*   Providing a flexible interface for future Blockscout API additions without requiring server code changes.
+
+**Architectural Integration and Curation Strategy:**
+
+The `direct_api_call` tool is integrated into the server with careful consideration for LLM usability and context optimization:
+
+1.  **Functional Uniqueness:** The endpoints exposed via `direct_api_call` are strictly curated to *not* duplicate functionality already provided by existing, specific MCP tools. This eliminates "tool selection confusion" for the AI, ensuring that `direct_api_call` serves a complementary role.
+2.  **Endpoint Discovery:**
+    *   A primary, curated list of general and chain-specific endpoints is provided to the AI through the `__unlock_blockchain_analysis__` tool's response. This ensures the AI is aware of the tool's capabilities from the outset.
+    *   Additionally, context-relevant endpoints are suggested in the `instructions` field of responses from other specific tools (e.g., `get_address_info`). This allows the AI to "dig deeper" into related data only when it's contextually relevant, optimizing LLM token usage.
+3.  **Input Simplicity:** The curated endpoints are chosen to have relatively simple input parameters, making it easier for the AI to construct valid calls. The AI is responsible for substituting any path parameters (e.g., `{account_address}`) directly into the `endpoint_path` string.
+4.  **Output Conciseness:** Endpoints that return excessively large or complex raw data payloads are generally excluded from the curated list. This prevents overwhelming the LLM's context window with unmanageable information, aligning with the server's overall "Response Processing and Context Optimization" strategy.
+
+**High-Level Implementation Details:**
+
+The `direct_api_call` tool functions as a thin wrapper around the core `make_blockscout_request` helper. It accepts a `chain_id`, the full `endpoint_path` (including any necessary API prefixes like `/api/v2/` or `/stats-service/api/v1/`), optional `query_params`, and an optional `cursor` for pagination. For pagination in the response, it directly encodes the raw `next_page_params` from the Blockscout API into an opaque cursor, as the structure of these parameters can vary across arbitrary endpoints. It leverages the existing `ToolResponse` model for consistent output and integrates with the server's robust HTTP request handling and error propagation mechanisms.

--- a/TESTING.md
+++ b/TESTING.md
@@ -227,6 +227,12 @@ curl -i "http://127.0.0.1:8000/v1/get_block_info?chain_id=1"
 curl "http://127.0.0.1:8000/v1/read_contract?chain_id=1&address=0xdAC17F958D2ee523a2206206994597C13D831ec7&function_name=balanceOf&abi=%7B%22constant%22%3Atrue%2C%22inputs%22%3A%5B%7B%22name%22%3A%22_owner%22%2C%22type%22%3A%22address%22%7D%5D%2C%22name%22%3A%22balanceOf%22%2C%22outputs%22%3A%5B%7B%22name%22%3A%22balance%22%2C%22type%22%3A%22uint256%22%7D%5D%2C%22payable%22%3Afalse%2C%22stateMutability%22%3A%22view%22%2C%22type%22%3A%22function%22%7D&args=%5B%220xF977814e90dA44bFA03b6295A0616a897441aceC%22%5D"
 ```
 
+#### 6. Direct API Call
+
+```bash
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats"
+```
+
 #### Expected REST API Response Format
 
 All successful REST API responses return a `200 OK` status with a JSON body that follows the standard `ToolResponse` structure:

--- a/TESTING.md
+++ b/TESTING.md
@@ -230,7 +230,7 @@ curl "http://127.0.0.1:8000/v1/read_contract?chain_id=1&address=0xdAC17F958D2ee5
 #### 6. Direct API Call
 
 ```bash
-curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats&query_params[page]=1"
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=137&endpoint_path=/api/v2/proxy/account-abstraction/operations&query_params[sender]=0x91f51371D33e4E50e838057E8045265372f8d448"
 ```
 
 #### Expected REST API Response Format

--- a/TESTING.md
+++ b/TESTING.md
@@ -230,7 +230,7 @@ curl "http://127.0.0.1:8000/v1/read_contract?chain_id=1&address=0xdAC17F958D2ee5
 #### 6. Direct API Call
 
 ```bash
-curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats"
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats&query_params[page]=1"
 ```
 
 #### Expected REST API Response Format

--- a/TESTING.md
+++ b/TESTING.md
@@ -230,7 +230,7 @@ curl "http://127.0.0.1:8000/v1/read_contract?chain_id=1&address=0xdAC17F958D2ee5
 #### 6. Direct API Call
 
 ```bash
-curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=137&endpoint_path=/api/v2/proxy/account-abstraction/operations&query_params[sender]=0x91f51371D33e4E50e838057E8045265372f8d448"
+curl "http://127.0.0.1:8000/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/proxy/account-abstraction/operations&query_params[sender]=0x91f51371D33e4E50e838057E8045265372f8d448"
 ```
 
 #### Expected REST API Response Format

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.10.0.dev0"
+__version__ = "0.10.0.dev1"

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -121,14 +121,14 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
     ],
     "specific": [
         {
-            "chains_family": "Ethereum Mainnet and Gnosis",
+            "chain_family": "Ethereum Mainnet and Gnosis",
             "endpoints": [
                 {
                     "path": "/api/v2/addresses/{account_address}/beacon/deposits",
                     "description": "Get Beacon Chain deposits for a specific address.",
                 },
                 {
-                    "path": "/api/v2/block/{block_number}/beacon/deposits",
+                    "path": "/api/v2/blocks/{block_number}/beacon/deposits",
                     "description": "Get Beacon Chain deposits for a specific block.",
                 },
                 {
@@ -142,7 +142,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "Arbitrum",
+            "chain_family": "Arbitrum",
             "endpoints": [
                 {
                     "path": "/api/v2/main-page/arbitrum/batches/latest-number",
@@ -161,13 +161,13 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
                     "description": "Get L2 to L1 messages for Arbitrum.",
                 },
                 {
-                    "path": "/api/v2/arbitrum/messages/withdrawals/{transactions_hash}",
+                    "path": "/api/v2/arbitrum/messages/withdrawals/{transaction_hash}",
                     "description": "Get L2 to L1 messages for a specific transaction hash on Arbitrum.",
                 },
             ],
         },
         {
-            "chains_family": "Optimism",
+            "chain_family": "Optimism",
             "endpoints": [
                 {
                     "path": "/api/v2/optimism/batches",
@@ -192,7 +192,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "Celo",
+            "chain_family": "Celo",
             "endpoints": [
                 {
                     "path": "/api/v2/celo/epochs",
@@ -217,7 +217,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "zkSync",
+            "chain_family": "zkSync",
             "endpoints": [
                 {
                     "path": "/api/v2/main-page/zksync/batches/latest-number",
@@ -230,7 +230,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "zkEVM",
+            "chain_family": "zkEVM",
             "endpoints": [
                 {
                     "path": "/api/v2/zkevm/batches/confirmed",
@@ -251,7 +251,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "Scroll",
+            "chain_family": "Scroll",
             "endpoints": [
                 {
                     "path": "/api/v2/scroll/batches",
@@ -276,7 +276,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "Shibarium",
+            "chain_family": "Shibarium",
             "endpoints": [
                 {
                     "path": "/api/v2/shibarium/deposits",
@@ -289,7 +289,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "Stability",
+            "chain_family": "Stability",
             "endpoints": [
                 {
                     "path": "/api/v2/validators/stability",
@@ -298,7 +298,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "Zilliqa",
+            "chain_family": "Zilliqa",
             "endpoints": [
                 {
                     "path": "/api/v2/validators/zilliqa",
@@ -311,7 +311,7 @@ DIRECT_API_CALL_ENDPOINT_LIST = {
             ],
         },
         {
-            "chains_family": "Redstone",
+            "chain_family": "Redstone",
             "endpoints": [
                 {
                     "path": "/api/v2/mud/worlds",

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -59,6 +59,281 @@ as you learn
 6. Combine approaches - use estimation to get close, then fine-tune with iteration, always learning from each step
 """
 
+DIRECT_API_CALL_RULES = """
+ADVANCED API USAGE: For specialized or chain-specific data not covered by other tools,
+you can use `direct_api_call`. This tool can call a curated list of raw Blockscout API endpoints.
+"""
+
+# Curated list of endpoints for the direct_api_call tool
+DIRECT_API_CALL_ENDPOINT_LIST = {
+    "common": [
+        {
+            "group": "Stats",
+            "endpoints": [
+                {
+                    "path": "/stats-service/api/v1/counters",
+                    "description": (
+                        "Get consolidated historical and recent-window counters—totals and 24h/30m rollups for "
+                        "blockchain activity (transactions, accounts, contracts, verified contracts, ERC-4337 "
+                        "user ops), plus average block time and fee aggregates"
+                    ),
+                },
+                {
+                    "path": "/api/v2/stats",
+                    "description": (
+                        "Get real-time network status and market context—current gas price tiers with last-update "
+                        "and next-update timing, network utilization, today's transactions, average block time "
+                        "'now', and coin price/market cap."
+                    ),
+                },
+            ],
+        },
+        {
+            "group": "User Operations",
+            "endpoints": [
+                {
+                    "path": "/api/v2/proxy/account-abstraction/operations/{user_operation_hash}",
+                    "description": "Get details for a specific User Operation by its hash.",
+                }
+            ],
+        },
+        {
+            "group": "Tokens & NFTs",
+            "endpoints": [
+                {
+                    "path": "/api/v2/tokens/{token_contract_address}/instances",
+                    "description": "Get all NFT instances for a given token contract address.",
+                },
+                {
+                    "path": "/api/v2/tokens/{token_contract_address}/holders",
+                    "description": "Get a list of holders for a given token.",
+                },
+                {
+                    "path": "/api/v2/tokens/{token_contract_address}/instances/{instance_id}",
+                    "description": "Get details for a specific NFT instance.",
+                },
+                {
+                    "path": "/api/v2/tokens/{token_contract_address}/instances/{instance_id}/transfers",
+                    "description": "Get transfer history for a specific NFT instance.",
+                },
+            ],
+        },
+    ],
+    "specific": [
+        {
+            "chains_family": "Ethereum Mainnet and Gnosis",
+            "endpoints": [
+                {
+                    "path": "/api/v2/addresses/{account_address}/beacon/deposits",
+                    "description": "Get Beacon Chain deposits for a specific address.",
+                },
+                {
+                    "path": "/api/v2/block/{block_number}/beacon/deposits",
+                    "description": "Get Beacon Chain deposits for a specific block.",
+                },
+                {
+                    "path": "/api/v2/addresses/{account_address}/withdrawals",
+                    "description": "Get Beacon Chain withdrawals for a specific address.",
+                },
+                {
+                    "path": "/api/v2/blocks/{block_number}/withdrawals",
+                    "description": "Get Beacon Chain withdrawals for a specific block.",
+                },
+            ],
+        },
+        {
+            "chains_family": "Arbitrum",
+            "endpoints": [
+                {
+                    "path": "/api/v2/main-page/arbitrum/batches/latest-number",
+                    "description": "Get the latest committed batch number for Arbitrum.",
+                },
+                {
+                    "path": "/api/v2/arbitrum/batches/{batch_number}",
+                    "description": "Get information for a specific Arbitrum batch.",
+                },
+                {
+                    "path": "/api/v2/arbitrum/messages/to-rollup",
+                    "description": "Get L1 to L2 messages for Arbitrum.",
+                },
+                {
+                    "path": "/api/v2/arbitrum/messages/from-rollup",
+                    "description": "Get L2 to L1 messages for Arbitrum.",
+                },
+                {
+                    "path": "/api/v2/arbitrum/messages/withdrawals/{transactions_hash}",
+                    "description": "Get L2 to L1 messages for a specific transaction hash on Arbitrum.",
+                },
+            ],
+        },
+        {
+            "chains_family": "Optimism",
+            "endpoints": [
+                {
+                    "path": "/api/v2/optimism/batches",
+                    "description": "Get the latest committed batches for Optimism.",
+                },
+                {
+                    "path": "/api/v2/optimism/batches/{batch_number}",
+                    "description": "Get information for a specific Optimism batch.",
+                },
+                {
+                    "path": "/api/v2/optimism/games",
+                    "description": "Get dispute games for Optimism.",
+                },
+                {
+                    "path": "/api/v2/optimism/deposits",
+                    "description": "Get L1 to L2 messages (deposits) for Optimism.",
+                },
+                {
+                    "path": "/api/v2/optimism/withdrawals",
+                    "description": "Get L2 to L1 messages (withdrawals) for Optimism.",
+                },
+            ],
+        },
+        {
+            "chains_family": "Celo",
+            "endpoints": [
+                {
+                    "path": "/api/v2/celo/epochs",
+                    "description": "Get the latest finalized epochs for Celo.",
+                },
+                {
+                    "path": "/api/v2/celo/epochs/{epoch_number}",
+                    "description": "Get information for a specific Celo epoch.",
+                },
+                {
+                    "path": "/api/v2/celo/epochs/{epoch_number}/election-rewards/group",
+                    "description": "Get validator group rewards for a specific Celo epoch.",
+                },
+                {
+                    "path": "/api/v2/celo/epochs/{epoch_number}/election-rewards/validator",
+                    "description": "Get validator rewards for a specific Celo epoch.",
+                },
+                {
+                    "path": "/api/v2/celo/epochs/{epoch_number}/election-rewards/voter",
+                    "description": "Get voter rewards for a specific Celo epoch.",
+                },
+            ],
+        },
+        {
+            "chains_family": "zkSync",
+            "endpoints": [
+                {
+                    "path": "/api/v2/main-page/zksync/batches/latest-number",
+                    "description": "Get the latest committed batch number for zkSync.",
+                },
+                {
+                    "path": "/api/v2/zksync/batches/{batch_number}",
+                    "description": "Get information for a specific zkSync batch.",
+                },
+            ],
+        },
+        {
+            "chains_family": "zkEVM",
+            "endpoints": [
+                {
+                    "path": "/api/v2/zkevm/batches/confirmed",
+                    "description": "Get the latest confirmed batches for zkEVM.",
+                },
+                {
+                    "path": "/api/v2/zkevm/batches/{batch_number}",
+                    "description": "Get information for a specific zkEVM batch.",
+                },
+                {
+                    "path": "/api/v2/zkevm/deposits",
+                    "description": "Get deposits for zkEVM.",
+                },
+                {
+                    "path": "/api/v2/zkevm/withdrawals",
+                    "description": "Get withdrawals for zkEVM.",
+                },
+            ],
+        },
+        {
+            "chains_family": "Scroll",
+            "endpoints": [
+                {
+                    "path": "/api/v2/scroll/batches",
+                    "description": "Get the latest committed batches for Scroll.",
+                },
+                {
+                    "path": "/api/v2/scroll/batches/{batch_number}",
+                    "description": "Get information for a specific Scroll batch.",
+                },
+                {
+                    "path": "/api/v2/blocks/scroll-batch/{batch_number}",
+                    "description": "Get blocks for a specific Scroll batch.",
+                },
+                {
+                    "path": "/api/v2/scroll/deposits",
+                    "description": "Get L1 to L2 messages (deposits) for Scroll.",
+                },
+                {
+                    "path": "/api/v2/scroll/withdrawals",
+                    "description": "Get L2 to L1 messages (withdrawals) for Scroll.",
+                },
+            ],
+        },
+        {
+            "chains_family": "Shibarium",
+            "endpoints": [
+                {
+                    "path": "/api/v2/shibarium/deposits",
+                    "description": "Get L1 to L2 messages (deposits) for Shibarium.",
+                },
+                {
+                    "path": "/api/v2/shibarium/withdrawals",
+                    "description": "Get L2 to L1 messages (withdrawals) for Shibarium.",
+                },
+            ],
+        },
+        {
+            "chains_family": "Stability",
+            "endpoints": [
+                {
+                    "path": "/api/v2/validators/stability",
+                    "description": "Get the list of validators for Stability.",
+                }
+            ],
+        },
+        {
+            "chains_family": "Zilliqa",
+            "endpoints": [
+                {
+                    "path": "/api/v2/validators/zilliqa",
+                    "description": "Get the list of validators for Zilliqa.",
+                },
+                {
+                    "path": "/api/v2/validators/zilliqa/{validator_public_key}",
+                    "description": "Get information for a specific Zilliqa validator.",
+                },
+            ],
+        },
+        {
+            "chains_family": "Redstone",
+            "endpoints": [
+                {
+                    "path": "/api/v2/mud/worlds",
+                    "description": "Get a list of MUD worlds for Redstone.",
+                },
+                {
+                    "path": "/api/v2/mud/worlds/{contract_address}/tables",
+                    "description": "Get tables for a specific MUD world on Redstone.",
+                },
+                {
+                    "path": "/api/v2/mud/worlds/{contract_address}/tables/{table_id}/records",
+                    "description": "Get records for a specific MUD world table on Redstone.",
+                },
+                {
+                    "path": "/api/v2/mud/worlds/{contract_address}/tables/{table_id}/records/{record_id}",
+                    "description": "Get a specific record from a MUD world table on Redstone.",
+                },
+            ],
+        },
+    ],
+}
+
 RECOMMENDED_CHAINS = [
     {
         "name": "Ethereum",

--- a/blockscout_mcp_server/llms.txt
+++ b/blockscout_mcp_server/llms.txt
@@ -59,6 +59,7 @@ All tools are available via both MCP and REST API interfaces:
 15. **`get_transaction_info`** - Gets comprehensive transaction information
 16. **`get_transaction_logs`** - Returns transaction logs with decoded event data
 17. **`read_contract`** - Executes a read-only smart contract function
+18. **`direct_api_call`** - Calls a curated raw Blockscout API endpoint
 
 ## When to Use Each Interface
 

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -59,6 +59,34 @@ class ChainIdGuidance(BaseModel):
     )
 
 
+class DirectApiEndpoint(BaseModel):
+    """Represents a single direct API endpoint."""
+
+    path: str = Field(description="The API endpoint path (e.g., '/api/v2/stats').")
+    description: str = Field(description="A description of what this endpoint returns.")
+
+
+class DirectApiCommonGroup(BaseModel):
+    """Represents a group of common endpoints available on all chains."""
+
+    group: str = Field(description="The functional group name (e.g., 'Stats', 'Tokens & NFTs').")
+    endpoints: list[DirectApiEndpoint] = Field(description="List of endpoints in this group.")
+
+
+class DirectApiSpecificGroup(BaseModel):
+    """Represents a group of endpoints specific to certain chain families."""
+
+    chains_family: str = Field(description="The chain family this group applies to (e.g., 'Arbitrum', 'Optimism').")
+    endpoints: list[DirectApiEndpoint] = Field(description="List of chain-specific endpoints.")
+
+
+class DirectApiEndpointList(BaseModel):
+    """Contains the complete curated list of endpoints for direct_api_call tool."""
+
+    common: list[DirectApiCommonGroup] = Field(description="Endpoint groups available on all supported chains.")
+    specific: list[DirectApiSpecificGroup] = Field(description="Endpoint groups specific to certain chain families.")
+
+
 class InstructionsData(BaseModel):
     """A structured representation of the server's operational instructions."""
 
@@ -69,6 +97,10 @@ class InstructionsData(BaseModel):
     time_based_query_rules: str = Field(description="Rules for executing time-based blockchain queries efficiently.")
     block_time_estimation_rules: str = Field(description="Rules for mathematical block time estimation and navigation.")
     efficiency_optimization_rules: str = Field(description="Rules for optimizing query strategies and performance.")
+    direct_api_call_rules: str = Field(description="Rules and guidance for using the direct_api_call tool.")
+    direct_api_endpoints: "DirectApiEndpointList" = Field(
+        description="Curated list of endpoints available for direct API calls."
+    )
 
 
 # --- Model for inspect_contract_code Metadata Payload ---

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -59,6 +59,12 @@ class ChainIdGuidance(BaseModel):
     )
 
 
+class DirectApiData(BaseModel):
+    """Generic container for direct API responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+
 class DirectApiEndpoint(BaseModel):
     """Represents a single direct API endpoint."""
 
@@ -76,7 +82,7 @@ class DirectApiCommonGroup(BaseModel):
 class DirectApiSpecificGroup(BaseModel):
     """Represents a group of endpoints specific to certain chain families."""
 
-    chains_family: str = Field(description="The chain family this group applies to (e.g., 'Arbitrum', 'Optimism').")
+    chain_family: str = Field(description="The chain family this group applies to (e.g., 'Arbitrum', 'Optimism').")
     endpoints: list[DirectApiEndpoint] = Field(description="List of chain-specific endpoints.")
 
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -55,10 +55,10 @@ def format_endpoint_groups(groups):
             formatted.append(f'<group name="{group["group"]}">')
             formatted.extend(f'"{endpoint["path"]}" - "{endpoint["description"]}"' for endpoint in group["endpoints"])
             formatted.append("</group>")
-        elif "chains_family" in group:
-            formatted.append(f'<chains_family name="{group["chains_family"]}">')
+        elif "chain_family" in group:
+            formatted.append(f'<chain_family name="{group["chain_family"]}">')
             formatted.extend(f'"{endpoint["path"]}" - "{endpoint["description"]}"' for endpoint in group["endpoints"])
-            formatted.append("</chains_family>")
+            formatted.append("</chain_family>")
     return "\n".join(formatted)
 
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -8,6 +8,8 @@ from blockscout_mcp_server import analytics
 from blockscout_mcp_server.constants import (
     BLOCK_TIME_ESTIMATION_RULES,
     CHAIN_ID_RULES,
+    DIRECT_API_CALL_ENDPOINT_LIST,
+    DIRECT_API_CALL_RULES,
     EFFICIENCY_OPTIMIZATION_RULES,
     ERROR_HANDLING_RULES,
     PAGINATION_RULES,
@@ -29,6 +31,7 @@ from blockscout_mcp_server.tools.contract_tools import (
     inspect_contract_code,
     read_contract,
 )
+from blockscout_mcp_server.tools.direct_api_tools import direct_api_call
 from blockscout_mcp_server.tools.ens_tools import get_address_by_ens_name
 from blockscout_mcp_server.tools.initialization_tools import __unlock_blockchain_analysis__
 from blockscout_mcp_server.tools.search_tools import lookup_token_by_symbol
@@ -43,6 +46,24 @@ from blockscout_mcp_server.web3_pool import WEB3_POOL
 
 # Compose the instructions string for the MCP server constructor
 chains_list_str = "\n".join([f"  * {chain['name']}: {chain['chain_id']}" for chain in RECOMMENDED_CHAINS])
+
+
+def format_endpoint_groups(groups):
+    formatted = []
+    for group in groups:
+        if "group" in group:
+            formatted.append(f'<group name="{group["group"]}">')
+            formatted.extend(f'"{endpoint["path"]}" - "{endpoint["description"]}"' for endpoint in group["endpoints"])
+            formatted.append("</group>")
+        elif "chains_family" in group:
+            formatted.append(f'<chains_family name="{group["chains_family"]}">')
+            formatted.extend(f'"{endpoint["path"]}" - "{endpoint["description"]}"' for endpoint in group["endpoints"])
+            formatted.append("</chains_family>")
+    return "\n".join(formatted)
+
+
+common_endpoints = format_endpoint_groups(DIRECT_API_CALL_ENDPOINT_LIST["common"])
+specific_endpoints = format_endpoint_groups(DIRECT_API_CALL_ENDPOINT_LIST["specific"])
 composed_instructions = f"""
 Blockscout MCP server version: {SERVER_VERSION}
 
@@ -75,6 +96,18 @@ Here is the list of IDs of most popular chains:
 <efficiency_optimization_rules>
 {EFFICIENCY_OPTIMIZATION_RULES.strip()}
 </efficiency_optimization_rules>
+
+<direct_call_endpoint_list>
+{DIRECT_API_CALL_RULES.strip()}
+
+<common>
+{common_endpoints}
+</common>
+
+<specific>
+{specific_endpoints}
+</specific>
+</direct_call_endpoint_list>
 """
 
 mcp = FastMCP(name=SERVER_NAME, instructions=composed_instructions)
@@ -102,6 +135,7 @@ mcp.tool(structured_output=False)(nft_tokens_by_address)
 mcp.tool(structured_output=False)(get_transaction_info)
 mcp.tool(structured_output=False)(get_transaction_logs)
 mcp.tool(structured_output=False)(get_chains_list)
+mcp.tool(structured_output=False)(direct_api_call)
 
 
 # Initialize logging and override the rich formatter defined in the FastMCP

--- a/blockscout_mcp_server/templates/index.html
+++ b/blockscout_mcp_server/templates/index.html
@@ -143,6 +143,7 @@
         <li><code>get_transaction_info</code>: Gets comprehensive transaction information.</li>
         <li><code>get_transaction_logs</code>: Returns transaction logs with decoded event data.</li>
         <li><code>read_contract</code>: Executes a read-only smart contract function.</li>
+        <li><code>direct_api_call</code>: Calls a curated raw Blockscout API endpoint.</li>
     </ul>
     <p>For more details, please refer to the project's <a href="https://github.com/blockscout/mcp-server">GitHub repository</a>.</p>
 </body>

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -94,7 +94,7 @@ async def get_address_info(
             "to get daily native coin balance history."
         ),
         (
-            f"Use `direct_api_call` with endpoint `/addresses/{address}/coin-balance-history` "
+            f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history` "
             "to get native coin balance history."
         ),
         (
@@ -106,8 +106,8 @@ async def get_address_info(
             "to get Account Abstraction info."
         ),
         (
-            f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/operations?sender={address}` "
-            "to get User Operations sent by this Address."
+            f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/operations` "
+            f"and query_params={{'sender': '{address}'}} to get User Operations sent by this Address."
         ),
     ]
 

--- a/blockscout_mcp_server/tools/address_tools.py
+++ b/blockscout_mcp_server/tools/address_tools.py
@@ -87,8 +87,31 @@ async def get_address_info(
     address_data = AddressInfoData(basic_info=address_info_result, metadata=metadata_data)
 
     await report_and_log_progress(ctx, progress=3.0, total=3.0, message="Successfully fetched all address data.")
+    instructions = [
+        (f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs` to get Logs Emitted by Address."),
+        (
+            f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history-by-day` "
+            "to get daily native coin balance history."
+        ),
+        (
+            f"Use `direct_api_call` with endpoint `/addresses/{address}/coin-balance-history` "
+            "to get native coin balance history."
+        ),
+        (
+            f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/blocks-validated` "
+            "to get Blocks Validated by this Address."
+        ),
+        (
+            f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/accounts/{address}` "
+            "to get Account Abstraction info."
+        ),
+        (
+            f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/operations?sender={address}` "
+            "to get User Operations sent by this Address."
+        ),
+    ]
 
-    return build_tool_response(data=address_data, notes=notes)
+    return build_tool_response(data=address_data, notes=notes, instructions=instructions)
 
 
 @log_tool_invocation

--- a/blockscout_mcp_server/tools/direct_api_tools.py
+++ b/blockscout_mcp_server/tools/direct_api_tools.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
-from blockscout_mcp_server.models import NextCallInfo, PaginationInfo, ToolResponse
+from blockscout_mcp_server.models import DirectApiData, NextCallInfo, PaginationInfo, ToolResponse
 from blockscout_mcp_server.tools.common import (
     apply_cursor_to_params,
     build_tool_response,
@@ -28,8 +28,12 @@ async def direct_api_call(
         str | None,
         Field(description="The pagination cursor from a previous response to get the next page of results."),
     ] = None,
-) -> ToolResponse[dict[str, Any]]:
-    """Call a raw Blockscout API endpoint for advanced or chain-specific data."""
+) -> ToolResponse[DirectApiData]:
+    """Call a raw Blockscout API endpoint for advanced or chain-specific data.
+
+    **SUPPORTS PAGINATION**: If response includes 'pagination' field,
+    use the provided next_call to get additional pages.
+    """
     await report_and_log_progress(
         ctx,
         progress=0.0,
@@ -69,4 +73,5 @@ async def direct_api_call(
         message="Successfully fetched data.",
     )
 
-    return build_tool_response(data=response_json, pagination=pagination)
+    data = DirectApiData.model_validate(response_json)
+    return build_tool_response(data=data, pagination=pagination)

--- a/blockscout_mcp_server/tools/direct_api_tools.py
+++ b/blockscout_mcp_server/tools/direct_api_tools.py
@@ -5,8 +5,8 @@ from pydantic import Field
 
 from blockscout_mcp_server.models import NextCallInfo, PaginationInfo, ToolResponse
 from blockscout_mcp_server.tools.common import (
+    apply_cursor_to_params,
     build_tool_response,
-    decode_cursor,
     encode_cursor,
     get_blockscout_base_url,
     make_blockscout_request,
@@ -39,8 +39,7 @@ async def direct_api_call(
     base_url = await get_blockscout_base_url(chain_id)
 
     params = dict(query_params) if query_params else {}
-    if cursor:
-        params.update(decode_cursor(cursor))
+    apply_cursor_to_params(cursor, params)
 
     await report_and_log_progress(
         ctx,

--- a/blockscout_mcp_server/tools/direct_api_tools.py
+++ b/blockscout_mcp_server/tools/direct_api_tools.py
@@ -1,0 +1,73 @@
+from typing import Annotated, Any
+
+from mcp.server.fastmcp import Context
+from pydantic import Field
+
+from blockscout_mcp_server.models import NextCallInfo, PaginationInfo, ToolResponse
+from blockscout_mcp_server.tools.common import (
+    build_tool_response,
+    decode_cursor,
+    encode_cursor,
+    get_blockscout_base_url,
+    make_blockscout_request,
+    report_and_log_progress,
+)
+from blockscout_mcp_server.tools.decorators import log_tool_invocation
+
+
+@log_tool_invocation
+async def direct_api_call(
+    chain_id: Annotated[str, Field(description="The ID of the blockchain")],
+    endpoint_path: Annotated[str, Field(description="The Blockscout API path to call (e.g., '/api/v2/stats')")],
+    ctx: Context,
+    query_params: Annotated[
+        dict[str, Any] | None,
+        Field(description="Optional query parameters forwarded to the Blockscout API."),
+    ] = None,
+    cursor: Annotated[
+        str | None,
+        Field(description="The pagination cursor from a previous response to get the next page of results."),
+    ] = None,
+) -> ToolResponse[dict[str, Any]]:
+    """Call a raw Blockscout API endpoint for advanced or chain-specific data."""
+    await report_and_log_progress(
+        ctx,
+        progress=0.0,
+        total=2.0,
+        message=f"Resolving Blockscout URL for chain {chain_id}...",
+    )
+    base_url = await get_blockscout_base_url(chain_id)
+
+    params = dict(query_params) if query_params else {}
+    if cursor:
+        params.update(decode_cursor(cursor))
+
+    await report_and_log_progress(
+        ctx,
+        progress=1.0,
+        total=2.0,
+        message="Fetching data from Blockscout API...",
+    )
+    response_json = await make_blockscout_request(base_url=base_url, api_path=endpoint_path, params=params)
+
+    pagination = None
+    next_page_params = response_json.get("next_page_params")
+    if next_page_params:
+        next_cursor = encode_cursor(next_page_params)
+        next_call_params = {
+            "chain_id": chain_id,
+            "endpoint_path": endpoint_path,
+            "cursor": next_cursor,
+        }
+        if query_params:
+            next_call_params["query_params"] = query_params
+        pagination = PaginationInfo(next_call=NextCallInfo(tool_name="direct_api_call", params=next_call_params))
+
+    await report_and_log_progress(
+        ctx,
+        progress=2.0,
+        total=2.0,
+        message="Successfully fetched data.",
+    )
+
+    return build_tool_response(data=response_json, pagination=pagination)

--- a/blockscout_mcp_server/tools/initialization_tools.py
+++ b/blockscout_mcp_server/tools/initialization_tools.py
@@ -67,7 +67,7 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
     specific_groups = []
     for group_data in DIRECT_API_CALL_ENDPOINT_LIST["specific"]:
         endpoints = [DirectApiEndpoint(**endpoint) for endpoint in group_data["endpoints"]]
-        specific_groups.append(DirectApiSpecificGroup(chains_family=group_data["chains_family"], endpoints=endpoints))
+        specific_groups.append(DirectApiSpecificGroup(chain_family=group_data["chain_family"], endpoints=endpoints))
 
     direct_api_endpoints = DirectApiEndpointList(common=common_groups, specific=specific_groups)
 

--- a/blockscout_mcp_server/tools/initialization_tools.py
+++ b/blockscout_mcp_server/tools/initialization_tools.py
@@ -3,6 +3,8 @@ from mcp.server.fastmcp import Context
 from blockscout_mcp_server.constants import (
     BLOCK_TIME_ESTIMATION_RULES,
     CHAIN_ID_RULES,
+    DIRECT_API_CALL_ENDPOINT_LIST,
+    DIRECT_API_CALL_RULES,
     EFFICIENCY_OPTIMIZATION_RULES,
     ERROR_HANDLING_RULES,
     PAGINATION_RULES,
@@ -13,6 +15,10 @@ from blockscout_mcp_server.constants import (
 from blockscout_mcp_server.models import (
     ChainIdGuidance,
     ChainInfo,
+    DirectApiCommonGroup,
+    DirectApiEndpoint,
+    DirectApiEndpointList,
+    DirectApiSpecificGroup,
     InstructionsData,
     ToolResponse,
 )
@@ -53,6 +59,18 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
         recommended_chains=[ChainInfo(**chain) for chain in RECOMMENDED_CHAINS],
     )
 
+    common_groups = []
+    for group_data in DIRECT_API_CALL_ENDPOINT_LIST["common"]:
+        endpoints = [DirectApiEndpoint(**endpoint) for endpoint in group_data["endpoints"]]
+        common_groups.append(DirectApiCommonGroup(group=group_data["group"], endpoints=endpoints))
+
+    specific_groups = []
+    for group_data in DIRECT_API_CALL_ENDPOINT_LIST["specific"]:
+        endpoints = [DirectApiEndpoint(**endpoint) for endpoint in group_data["endpoints"]]
+        specific_groups.append(DirectApiSpecificGroup(chains_family=group_data["chains_family"], endpoints=endpoints))
+
+    direct_api_endpoints = DirectApiEndpointList(common=common_groups, specific=specific_groups)
+
     instructions_data = InstructionsData(
         version=SERVER_VERSION,
         error_handling_rules=ERROR_HANDLING_RULES,
@@ -61,6 +79,8 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
         time_based_query_rules=TIME_BASED_QUERY_RULES,
         block_time_estimation_rules=BLOCK_TIME_ESTIMATION_RULES,
         efficiency_optimization_rules=EFFICIENCY_OPTIMIZATION_RULES,
+        direct_api_call_rules=DIRECT_API_CALL_RULES,
+        direct_api_endpoints=direct_api_endpoints,
     )
 
     # Report completion

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -545,7 +545,14 @@ async def get_transaction_info(
             ),
         ]
 
-    return build_tool_response(data=transaction_data, notes=notes)
+    instructions = [
+        (
+            "Use `direct_api_call` with endpoint "
+            f"`/api/v2/proxy/account-abstraction/operations?transaction_hash={transaction_hash}` "
+            "to get User Operations for this transaction."
+        )
+    ]
+    return build_tool_response(data=transaction_data, notes=notes, instructions=instructions)
 
 
 @log_tool_invocation

--- a/blockscout_mcp_server/tools/transaction_tools.py
+++ b/blockscout_mcp_server/tools/transaction_tools.py
@@ -547,9 +547,9 @@ async def get_transaction_info(
 
     instructions = [
         (
-            "Use `direct_api_call` with endpoint "
-            f"`/api/v2/proxy/account-abstraction/operations?transaction_hash={transaction_hash}` "
-            "to get User Operations for this transaction."
+            "To check for ERC-4337 User Operations related to this tx, call "
+            f"`direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/operations` "
+            f"with query_params={{'transaction_hash': '{transaction_hash}'}}."
         )
     ]
     return build_tool_response(data=transaction_data, notes=notes, instructions=instructions)

--- a/dxt/manifest-dev.json
+++ b/dxt/manifest-dev.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "name": "blockscout-mcp-dev",
   "display_name": "Blockscout (dev)",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Contextual blockchain activity analysis via Blockscout APIs",
   "long_description": "This extension enables contextual blockchain activity analysis with multi-chain support, intelligent context optimization, smart response slicing, and seamless pagination. The server exposes blockchain data including balances, tokens, NFTs, contract metadata, transactions, and logs via MCP for comprehensive blockchain analysis. This extension acts as a proxy to the official Blockscout MCP server.",
   "author": {
@@ -109,6 +109,11 @@
     {
       "name": "read_contract",
       "description": "Executes a read-only smart contract function"
+    }
+    ,
+    {
+      "name": "direct_api_call",
+      "description": "Calls a curated raw Blockscout API endpoint"
     }
   ],
   "keywords": [

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "name": "blockscout-mcp",
   "display_name": "Blockscout",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Contextual blockchain activity analysis via Blockscout APIs",
   "long_description": "This extension enables contextual blockchain activity analysis with multi-chain support, intelligent context optimization, smart response slicing, and seamless pagination. The server exposes blockchain data including balances, tokens, NFTs, contract metadata, transactions, and logs via MCP for comprehensive blockchain analysis. This extension acts as a proxy to the official Blockscout MCP server.",
   "author": {
@@ -99,6 +99,11 @@
     {
       "name": "read_contract",
       "description": "Executes a read-only smart contract function"
+    }
+    ,
+    {
+      "name": "direct_api_call",
+      "description": "Calls a curated raw Blockscout API endpoint"
     }
   ],
   "keywords": [

--- a/gpt/action_tool_descriptions.md
+++ b/gpt/action_tool_descriptions.md
@@ -127,3 +127,7 @@ Unlike standard eth_getLogs, this tool returns enriched logs, primarily focusing
 Essential for analyzing smart contract events, tracking token transfers, monitoring DeFi protocol interactions, debugging event emissions, and understanding complex multi-contract transaction flows.
 **SUPPORTS PAGINATION**: If response includes 'pagination' field, use the provided next_call to get additional pages.
 </get_transaction_logs>
+
+<direct_api_call>
+Call a curated raw Blockscout API endpoint for specialized or chain-specific data not covered by other tools. Supports pagination via `cursor` when the API response includes `next_page_params`.
+</direct_api_call>

--- a/gpt/instructions.md
+++ b/gpt/instructions.md
@@ -56,3 +56,86 @@ When direct tools don't exist for your query, be creative and strategic:
 5. Detect pattern changes - if your estimates become less accurate, recalibrate using more recent data segments
 6. Combine approaches - use estimation to get close, then fine-tune with iteration, always learning from each step
 </efficiency_optimization_rules>
+<direct_call_endpoint_list>
+ADVANCED API USAGE: For specialized or chain-specific data not covered by other tools, you can use `direct_api_call`. This tool can call a curated list of raw Blockscout API endpoints.
+
+<common>
+<group name="Stats">
+"/stats-service/api/v1/counters" - "Get consolidated historical and recent-window counters—totals and 24h/30m rollups for blockchain activity (transactions, accounts, contracts, verified contracts, ERC-4337 user ops), plus average block time and fee aggregates"
+"/api/v2/stats" - "Get real-time network status and market context—current gas price tiers with last-update and next-update timing, network utilization, today's transactions, average block time 'now', and coin price/market cap."
+</group>
+<group name="User Operations">
+"/api/v2/proxy/account-abstraction/operations/{user_operation_hash}" - "Get details for a specific User Operation by its hash."
+</group>
+<group name="Tokens & NFTs">
+"/api/v2/tokens/{token_contract_address}/instances" - "Get all NFT instances for a given token contract address."
+"/api/v2/tokens/{token_contract_address}/holders" - "Get a list of holders for a given token."
+"/api/v2/tokens/{token_contract_address}/instances/{instance_id}" - "Get details for a specific NFT instance."
+"/api/v2/tokens/{token_contract_address}/instances/{instance_id}/transfers" - "Get transfer history for a specific NFT instance."
+</group>
+</common>
+
+<specific>
+<chains_family name="Ethereum Mainnet and Gnosis">
+"/api/v2/addresses/{account_address}/beacon/deposits" - "Get Beacon Chain deposits for a specific address."
+"/api/v2/block/{block_number}/beacon/deposits" - "Get Beacon Chain deposits for a specific block."
+"/api/v2/addresses/{account_address}/withdrawals" - "Get Beacon Chain withdrawals for a specific address."
+"/api/v2/blocks/{block_number}/withdrawals" - "Get Beacon Chain withdrawals for a specific block."
+</chains_family>
+<chains_family name="Arbitrum">
+"/api/v2/main-page/arbitrum/batches/latest-number" - "Get the latest committed batch number for Arbitrum."
+"/api/v2/arbitrum/batches/{batch_number}" - "Get information for a specific Arbitrum batch."
+"/api/v2/arbitrum/messages/to-rollup" - "Get L1 to L2 messages for Arbitrum."
+"/api/v2/arbitrum/messages/from-rollup" - "Get L2 to L1 messages for Arbitrum."
+"/api/v2/arbitrum/messages/withdrawals/{transactions_hash}" - "Get L2 to L1 messages for a specific transaction hash on Arbitrum."
+</chains_family>
+<chains_family name="Optimism">
+"/api/v2/optimism/batches" - "Get the latest committed batches for Optimism."
+"/api/v2/optimism/batches/{batch_number}" - "Get information for a specific Optimism batch."
+"/api/v2/optimism/games" - "Get dispute games for Optimism."
+"/api/v2/optimism/deposits" - "Get L1 to L2 messages (deposits) for Optimism."
+"/api/v2/optimism/withdrawals" - "Get L2 to L1 messages (withdrawals) for Optimism."
+</chains_family>
+<chains_family name="Celo">
+"/api/v2/celo/epochs" - "Get the latest finalized epochs for Celo."
+"/api/v2/celo/epochs/{epoch_number}" - "Get information for a specific Celo epoch."
+"/api/v2/celo/epochs/{epoch_number}/election-rewards/group" - "Get validator group rewards for a specific Celo epoch."
+"/api/v2/celo/epochs/{epoch_number}/election-rewards/validator" - "Get validator rewards for a specific Celo epoch."
+"/api/v2/celo/epochs/{epoch_number}/election-rewards/voter" - "Get voter rewards for a specific Celo epoch."
+</chains_family>
+<chains_family name="zkSync">
+"/api/v2/main-page/zksync/batches/latest-number" - "Get the latest committed batch number for zkSync."
+"/api/v2/zksync/batches/{batch_number}" - "Get information for a specific zkSync batch."
+</chains_family>
+<chains_family name="zkEVM">
+"/api/v2/zkevm/batches/confirmed" - "Get the latest confirmed batches for zkEVM."
+"/api/v2/zkevm/batches/{batch_number}" - "Get information for a specific zkEVM batch."
+"/api/v2/zkevm/deposits" - "Get deposits for zkEVM."
+"/api/v2/zkevm/withdrawals" - "Get withdrawals for zkEVM."
+</chains_family>
+<chains_family name="Scroll">
+"/api/v2/scroll/batches" - "Get the latest committed batches for Scroll."
+"/api/v2/scroll/batches/{batch_number}" - "Get information for a specific Scroll batch."
+"/api/v2/blocks/scroll-batch/{batch_number}" - "Get blocks for a specific Scroll batch."
+"/api/v2/scroll/deposits" - "Get L1 to L2 messages (deposits) for Scroll."
+"/api/v2/scroll/withdrawals" - "Get L2 to L1 messages (withdrawals) for Scroll."
+</chains_family>
+<chains_family name="Shibarium">
+"/api/v2/shibarium/deposits" - "Get L1 to L2 messages (deposits) for Shibarium."
+"/api/v2/shibarium/withdrawals" - "Get L2 to L1 messages (withdrawals) for Shibarium."
+</chains_family>
+<chains_family name="Stability">
+"/api/v2/validators/stability" - "Get the list of validators for Stability."
+</chains_family>
+<chains_family name="Zilliqa">
+"/api/v2/validators/zilliqa" - "Get the list of validators for Zilliqa."
+"/api/v2/validators/zilliqa/{validator_public_key}" - "Get information for a specific Zilliqa validator."
+</chains_family>
+<chains_family name="Redstone">
+"/api/v2/mud/worlds" - "Get a list of MUD worlds for Redstone."
+"/api/v2/mud/worlds/{contract_address}/tables" - "Get tables for a specific MUD world on Redstone."
+"/api/v2/mud/worlds/{contract_address}/tables/{table_id}/records" - "Get records for a specific MUD world table on Redstone."
+"/api/v2/mud/worlds/{contract_address}/tables/{table_id}/records/{record_id}" - "Get a specific record from a MUD world table on Redstone."
+</chains_family>
+</specific>
+</direct_call_endpoint_list>

--- a/gpt/instructions.md
+++ b/gpt/instructions.md
@@ -76,66 +76,66 @@ ADVANCED API USAGE: For specialized or chain-specific data not covered by other 
 </common>
 
 <specific>
-<chains_family name="Ethereum Mainnet and Gnosis">
+<chain_family name="Ethereum Mainnet and Gnosis">
 "/api/v2/addresses/{account_address}/beacon/deposits" - "Get Beacon Chain deposits for a specific address."
-"/api/v2/block/{block_number}/beacon/deposits" - "Get Beacon Chain deposits for a specific block."
+"/api/v2/blocks/{block_number}/beacon/deposits" - "Get Beacon Chain deposits for a specific block."
 "/api/v2/addresses/{account_address}/withdrawals" - "Get Beacon Chain withdrawals for a specific address."
 "/api/v2/blocks/{block_number}/withdrawals" - "Get Beacon Chain withdrawals for a specific block."
-</chains_family>
-<chains_family name="Arbitrum">
+</chain_family>
+<chain_family name="Arbitrum">
 "/api/v2/main-page/arbitrum/batches/latest-number" - "Get the latest committed batch number for Arbitrum."
 "/api/v2/arbitrum/batches/{batch_number}" - "Get information for a specific Arbitrum batch."
 "/api/v2/arbitrum/messages/to-rollup" - "Get L1 to L2 messages for Arbitrum."
 "/api/v2/arbitrum/messages/from-rollup" - "Get L2 to L1 messages for Arbitrum."
-"/api/v2/arbitrum/messages/withdrawals/{transactions_hash}" - "Get L2 to L1 messages for a specific transaction hash on Arbitrum."
-</chains_family>
-<chains_family name="Optimism">
+"/api/v2/arbitrum/messages/withdrawals/{transaction_hash}" - "Get L2 to L1 messages for a specific transaction hash on Arbitrum."
+</chain_family>
+<chain_family name="Optimism">
 "/api/v2/optimism/batches" - "Get the latest committed batches for Optimism."
 "/api/v2/optimism/batches/{batch_number}" - "Get information for a specific Optimism batch."
 "/api/v2/optimism/games" - "Get dispute games for Optimism."
 "/api/v2/optimism/deposits" - "Get L1 to L2 messages (deposits) for Optimism."
 "/api/v2/optimism/withdrawals" - "Get L2 to L1 messages (withdrawals) for Optimism."
-</chains_family>
-<chains_family name="Celo">
+</chain_family>
+<chain_family name="Celo">
 "/api/v2/celo/epochs" - "Get the latest finalized epochs for Celo."
 "/api/v2/celo/epochs/{epoch_number}" - "Get information for a specific Celo epoch."
 "/api/v2/celo/epochs/{epoch_number}/election-rewards/group" - "Get validator group rewards for a specific Celo epoch."
 "/api/v2/celo/epochs/{epoch_number}/election-rewards/validator" - "Get validator rewards for a specific Celo epoch."
 "/api/v2/celo/epochs/{epoch_number}/election-rewards/voter" - "Get voter rewards for a specific Celo epoch."
-</chains_family>
-<chains_family name="zkSync">
+</chain_family>
+<chain_family name="zkSync">
 "/api/v2/main-page/zksync/batches/latest-number" - "Get the latest committed batch number for zkSync."
 "/api/v2/zksync/batches/{batch_number}" - "Get information for a specific zkSync batch."
-</chains_family>
-<chains_family name="zkEVM">
+</chain_family>
+<chain_family name="zkEVM">
 "/api/v2/zkevm/batches/confirmed" - "Get the latest confirmed batches for zkEVM."
 "/api/v2/zkevm/batches/{batch_number}" - "Get information for a specific zkEVM batch."
 "/api/v2/zkevm/deposits" - "Get deposits for zkEVM."
 "/api/v2/zkevm/withdrawals" - "Get withdrawals for zkEVM."
-</chains_family>
-<chains_family name="Scroll">
+</chain_family>
+<chain_family name="Scroll">
 "/api/v2/scroll/batches" - "Get the latest committed batches for Scroll."
 "/api/v2/scroll/batches/{batch_number}" - "Get information for a specific Scroll batch."
 "/api/v2/blocks/scroll-batch/{batch_number}" - "Get blocks for a specific Scroll batch."
 "/api/v2/scroll/deposits" - "Get L1 to L2 messages (deposits) for Scroll."
 "/api/v2/scroll/withdrawals" - "Get L2 to L1 messages (withdrawals) for Scroll."
-</chains_family>
-<chains_family name="Shibarium">
+</chain_family>
+<chain_family name="Shibarium">
 "/api/v2/shibarium/deposits" - "Get L1 to L2 messages (deposits) for Shibarium."
 "/api/v2/shibarium/withdrawals" - "Get L2 to L1 messages (withdrawals) for Shibarium."
-</chains_family>
-<chains_family name="Stability">
+</chain_family>
+<chain_family name="Stability">
 "/api/v2/validators/stability" - "Get the list of validators for Stability."
-</chains_family>
-<chains_family name="Zilliqa">
+</chain_family>
+<chain_family name="Zilliqa">
 "/api/v2/validators/zilliqa" - "Get the list of validators for Zilliqa."
 "/api/v2/validators/zilliqa/{validator_public_key}" - "Get information for a specific Zilliqa validator."
-</chains_family>
-<chains_family name="Redstone">
+</chain_family>
+<chain_family name="Redstone">
 "/api/v2/mud/worlds" - "Get a list of MUD worlds for Redstone."
 "/api/v2/mud/worlds/{contract_address}/tables" - "Get tables for a specific MUD world on Redstone."
 "/api/v2/mud/worlds/{contract_address}/tables/{table_id}/records" - "Get records for a specific MUD world table on Redstone."
 "/api/v2/mud/worlds/{contract_address}/tables/{table_id}/records/{record_id}" - "Get a specific record from a MUD world table on Redstone."
-</chains_family>
+</chain_family>
 </specific>
 </direct_call_endpoint_list>

--- a/gpt/openapi.yaml
+++ b/gpt/openapi.yaml
@@ -35,6 +35,45 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /direct_api_call:
+    get:
+      summary: Direct API call
+      description: |
+        Perform a raw request to a curated Blockscout API endpoint for advanced or chain-specific data.
+      operationId: directApiCall
+      tags:
+        - General
+      parameters:
+        - name: chain_id
+          in: query
+          required: true
+          description: The ID of the blockchain
+          schema:
+            type: string
+        - name: endpoint_path
+          in: query
+          required: true
+          description: The Blockscout API path to call (e.g., '/api/v2/stats')
+          schema:
+            type: string
+        - name: cursor
+          in: query
+          required: false
+          description: Pagination cursor from a previous response
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Raw Blockscout API response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   # Block tools
   /get_latest_block:
     get:

--- a/gpt/openapi.yaml
+++ b/gpt/openapi.yaml
@@ -50,7 +50,7 @@ paths:
           description: The ID of the blockchain
           schema:
             type: string
-          example: "ethereum-mainnet"
+          example: "1"
         - name: endpoint_path
           in: query
           required: true
@@ -68,6 +68,9 @@ paths:
             type: object
             additionalProperties:
               type: string
+          example:
+            sender: "0x91f51371D33e4E50e838057E8045265372f8d448"
+            page: "1"
         - name: cursor
           in: query
           required: false

--- a/gpt/openapi.yaml
+++ b/gpt/openapi.yaml
@@ -50,12 +50,24 @@ paths:
           description: The ID of the blockchain
           schema:
             type: string
+          example: "ethereum-mainnet"
         - name: endpoint_path
           in: query
           required: true
           description: The Blockscout API path to call (e.g., '/api/v2/stats')
           schema:
             type: string
+          example: "/api/v2/stats"
+        - name: query_params
+          in: query
+          required: false
+          description: Optional query parameters forwarded to the Blockscout API
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
         - name: cursor
           in: query
           required: false
@@ -73,6 +85,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
 
   # Block tools
   /get_latest_block:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.10.0.dev0"
+version = "0.10.0.dev1"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -559,7 +559,7 @@ async def test_get_chains_list_success(mock_tool, client: AsyncClient):
 @patch("blockscout_mcp_server.api.routes.direct_api_call", new_callable=AsyncMock)
 async def test_direct_api_call_success(mock_tool, client: AsyncClient):
     mock_tool.return_value = ToolResponse(data={"ok": True})
-    url = "/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats&limit=1"
+    url = "/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats&query_params[limit]=1"
     response = await client.get(url)
     assert response.status_code == 200
     assert response.json()["data"] == {"ok": True}

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -557,17 +557,12 @@ async def test_get_chains_list_success(mock_tool, client: AsyncClient):
 
 @pytest.mark.asyncio
 @patch("blockscout_mcp_server.api.routes.direct_api_call", new_callable=AsyncMock)
-async def test_direct_api_call_success(mock_tool, client: AsyncClient):
+async def test_direct_api_call_required_only(mock_tool, client: AsyncClient):
     mock_tool.return_value = ToolResponse(data={"ok": True})
-    url = "/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats"
-    response = await client.get(url)
+    response = await client.get("/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats")
     assert response.status_code == 200
     assert response.json()["data"] == {"ok": True}
-    mock_tool.assert_called_once_with(
-        chain_id="1",
-        endpoint_path="/api/v2/stats",
-        ctx=ANY,
-    )
+    mock_tool.assert_called_once_with(chain_id="1", endpoint_path="/api/v2/stats", ctx=ANY)
 
 
 @pytest.mark.asyncio
@@ -588,7 +583,7 @@ async def test_direct_api_call_success_with_cursor_and_query_params(mock_tool, c
 
 
 @pytest.mark.asyncio
-async def test_direct_api_call_missing_param(client: AsyncClient):
+async def test_direct_api_call_missing_endpoint_path(client: AsyncClient):
     response = await client.get("/v1/direct_api_call?chain_id=1")
     assert response.status_code == 400
     assert response.json() == {"error": "Missing required query parameter: 'endpoint_path'"}

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -556,6 +556,29 @@ async def test_get_chains_list_success(mock_tool, client: AsyncClient):
 
 
 @pytest.mark.asyncio
+@patch("blockscout_mcp_server.api.routes.direct_api_call", new_callable=AsyncMock)
+async def test_direct_api_call_success(mock_tool, client: AsyncClient):
+    mock_tool.return_value = ToolResponse(data={"ok": True})
+    url = "/v1/direct_api_call?chain_id=1&endpoint_path=/api/v2/stats&limit=1"
+    response = await client.get(url)
+    assert response.status_code == 200
+    assert response.json()["data"] == {"ok": True}
+    mock_tool.assert_called_once_with(
+        chain_id="1",
+        endpoint_path="/api/v2/stats",
+        query_params={"limit": "1"},
+        ctx=ANY,
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_api_call_missing_param(client: AsyncClient):
+    response = await client.get("/v1/direct_api_call?chain_id=1")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Missing required query parameter: 'endpoint_path'"}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "side_effect, status",
     [

--- a/tests/integration/test_direct_api_tools_integration.py
+++ b/tests/integration/test_direct_api_tools_integration.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from blockscout_mcp_server.models import DirectApiData
@@ -32,5 +33,27 @@ async def test_direct_api_call_blocks_validated_pagination(mock_ctx):
     first = await direct_api_call(chain_id="1", endpoint_path=path, ctx=mock_ctx)
     assert first.pagination is not None
     next_params = first.pagination.next_call.params
+    second = await direct_api_call(ctx=mock_ctx, **next_params)
+    assert isinstance(second.data, DirectApiData)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_direct_api_call_operations_query_params_pagination(mock_ctx):
+    sender = "0x91f51371D33e4E50e838057E8045265372f8d448"
+    try:
+        first = await direct_api_call(
+            chain_id="137",
+            endpoint_path="/api/v2/proxy/account-abstraction/operations",
+            query_params={"sender": sender},
+            ctx=mock_ctx,
+        )
+    except httpx.HTTPStatusError as exc:
+        pytest.skip(f"API returned {exc}")
+    assert first.pagination is not None
+    next_params = first.pagination.next_call.params
+    assert next_params["chain_id"] == "137"
+    assert next_params["endpoint_path"] == "/api/v2/proxy/account-abstraction/operations"
+    assert next_params["query_params"]["sender"] == sender
     second = await direct_api_call(ctx=mock_ctx, **next_params)
     assert isinstance(second.data, DirectApiData)

--- a/tests/integration/test_direct_api_tools_integration.py
+++ b/tests/integration/test_direct_api_tools_integration.py
@@ -1,0 +1,35 @@
+import pytest
+
+from blockscout_mcp_server.tools.direct_api_tools import direct_api_call
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_direct_api_call_stats_counters(mock_ctx):
+    result = await direct_api_call(chain_id="1", endpoint_path="/stats-service/api/v1/counters", ctx=mock_ctx)
+    assert isinstance(result.data, dict)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_direct_api_call_arbitrum_messages_pagination(mock_ctx):
+    first = await direct_api_call(
+        chain_id="42161",
+        endpoint_path="/api/v2/arbitrum/messages/to-rollup",
+        ctx=mock_ctx,
+    )
+    assert first.pagination is not None
+    next_params = first.pagination.next_call.params
+    second = await direct_api_call(ctx=mock_ctx, **next_params)
+    assert isinstance(second.data, dict)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_direct_api_call_blocks_validated_pagination(mock_ctx):
+    path = "/api/v2/addresses/0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97/blocks-validated"
+    first = await direct_api_call(chain_id="1", endpoint_path=path, ctx=mock_ctx)
+    assert first.pagination is not None
+    next_params = first.pagination.next_call.params
+    second = await direct_api_call(ctx=mock_ctx, **next_params)
+    assert isinstance(second.data, dict)

--- a/tests/integration/test_direct_api_tools_integration.py
+++ b/tests/integration/test_direct_api_tools_integration.py
@@ -43,7 +43,7 @@ async def test_direct_api_call_operations_query_params_pagination(mock_ctx):
     sender = "0x91f51371D33e4E50e838057E8045265372f8d448"
     try:
         first = await direct_api_call(
-            chain_id="137",
+            chain_id="1",
             endpoint_path="/api/v2/proxy/account-abstraction/operations",
             query_params={"sender": sender},
             ctx=mock_ctx,
@@ -52,7 +52,7 @@ async def test_direct_api_call_operations_query_params_pagination(mock_ctx):
         pytest.skip(f"API returned {exc}")
     assert first.pagination is not None
     next_params = first.pagination.next_call.params
-    assert next_params["chain_id"] == "137"
+    assert next_params["chain_id"] == "1"
     assert next_params["endpoint_path"] == "/api/v2/proxy/account-abstraction/operations"
     assert next_params["query_params"]["sender"] == sender
     second = await direct_api_call(ctx=mock_ctx, **next_params)

--- a/tests/integration/test_direct_api_tools_integration.py
+++ b/tests/integration/test_direct_api_tools_integration.py
@@ -1,5 +1,6 @@
 import pytest
 
+from blockscout_mcp_server.models import DirectApiData
 from blockscout_mcp_server.tools.direct_api_tools import direct_api_call
 
 
@@ -7,7 +8,7 @@ from blockscout_mcp_server.tools.direct_api_tools import direct_api_call
 @pytest.mark.asyncio
 async def test_direct_api_call_stats_counters(mock_ctx):
     result = await direct_api_call(chain_id="1", endpoint_path="/stats-service/api/v1/counters", ctx=mock_ctx)
-    assert isinstance(result.data, dict)
+    assert isinstance(result.data, DirectApiData)
 
 
 @pytest.mark.integration
@@ -21,7 +22,7 @@ async def test_direct_api_call_arbitrum_messages_pagination(mock_ctx):
     assert first.pagination is not None
     next_params = first.pagination.next_call.params
     second = await direct_api_call(ctx=mock_ctx, **next_params)
-    assert isinstance(second.data, dict)
+    assert isinstance(second.data, DirectApiData)
 
 
 @pytest.mark.integration
@@ -32,4 +33,4 @@ async def test_direct_api_call_blocks_validated_pagination(mock_ctx):
     assert first.pagination is not None
     next_params = first.pagination.next_call.params
     second = await direct_api_call(ctx=mock_ctx, **next_params)
-    assert isinstance(second.data, dict)
+    assert isinstance(second.data, DirectApiData)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from blockscout_mcp_server.models import (
     BlockInfoData,
     ChainInfo,
     DecodedInput,
+    DirectApiEndpointList,
     InstructionsData,
     NextCallInfo,
     NftCollectionHolding,
@@ -56,6 +57,8 @@ def test_tool_response_complex_data():
         time_based_query_rules="Time rule",
         block_time_estimation_rules="Block rule",
         efficiency_optimization_rules="Efficiency rule",
+        direct_api_call_rules="Direct API rule",
+        direct_api_endpoints=DirectApiEndpointList(common=[], specific=[]),
     )
     response = ToolResponse[InstructionsData](data=instructions_data)
     assert response.data.version == "1.0.0"
@@ -171,6 +174,8 @@ def test_instructions_data():
         time_based_query_rules="Time rules",
         block_time_estimation_rules="Block rules",
         efficiency_optimization_rules="Efficiency rules",
+        direct_api_call_rules="Direct API rules",
+        direct_api_endpoints=DirectApiEndpointList(common=[], specific=[]),
     )
     assert instructions.version == "2.0.0"
     assert instructions.error_handling_rules == "Error rules"

--- a/tests/tools/test_address_tools.py
+++ b/tests/tools/test_address_tools.py
@@ -432,6 +432,32 @@ async def test_get_address_info_success_with_metadata(mock_ctx):
         assert result.data.basic_info == mock_blockscout_response
         assert result.data.metadata == mock_metadata_response["addresses"][address]
         assert result.notes is None
+        expected_instructions = [
+            (f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs` to get Logs Emitted by Address."),
+            (
+                f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history-by-day` "
+                "to get daily native coin balance history."
+            ),
+            (
+                f"Use `direct_api_call` with endpoint `/addresses/{address}/coin-balance-history` "
+                "to get native coin balance history."
+            ),
+            (
+                f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/blocks-validated` "
+                "to get Blocks Validated by this Address."
+            ),
+            (
+                f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/accounts/{address}` "
+                "to get Account Abstraction info."
+            ),
+            (
+                f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/operations?sender={address}` "
+                "to get User Operations sent by this Address."
+            ),
+        ]
+        assert result.instructions is not None
+        for instr in expected_instructions:
+            assert instr in result.instructions
 
         assert mock_ctx.report_progress.call_count == 4
         assert mock_ctx.info.call_count == 4

--- a/tests/tools/test_address_tools.py
+++ b/tests/tools/test_address_tools.py
@@ -439,7 +439,7 @@ async def test_get_address_info_success_with_metadata(mock_ctx):
                 "to get daily native coin balance history."
             ),
             (
-                f"Use `direct_api_call` with endpoint `/addresses/{address}/coin-balance-history` "
+                f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history` "
                 "to get native coin balance history."
             ),
             (
@@ -451,8 +451,8 @@ async def test_get_address_info_success_with_metadata(mock_ctx):
                 "to get Account Abstraction info."
             ),
             (
-                f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/operations?sender={address}` "
-                "to get User Operations sent by this Address."
+                f"Use `direct_api_call` with endpoint `/api/v2/proxy/account-abstraction/operations` "
+                f"and query_params={{'sender': '{address}'}} to get User Operations sent by this Address."
             ),
         ]
         assert result.instructions is not None

--- a/tests/tools/test_direct_api_tools.py
+++ b/tests/tools/test_direct_api_tools.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -33,6 +33,7 @@ async def test_direct_api_call_no_params(mock_ctx):
         assert isinstance(result, ToolResponse)
         assert result.data == mock_response
         assert result.pagination is None
+        assert mock_ctx.report_progress.call_count == 3
 
 
 @pytest.mark.asyncio
@@ -42,8 +43,6 @@ async def test_direct_api_call_with_query_params_and_cursor(mock_ctx):
     mock_base_url = "https://eth.blockscout.com"
     mock_response = {"data": []}
     query_params = {"limit": "1"}
-    decoded_cursor = {"page": 2}
-
     with (
         patch(
             "blockscout_mcp_server.tools.direct_api_tools.get_blockscout_base_url",
@@ -54,12 +53,20 @@ async def test_direct_api_call_with_query_params_and_cursor(mock_ctx):
             new_callable=AsyncMock,
         ) as mock_request,
         patch(
-            "blockscout_mcp_server.tools.direct_api_tools.decode_cursor",
-            return_value=decoded_cursor,
-        ) as mock_decode,
+            "blockscout_mcp_server.tools.direct_api_tools.apply_cursor_to_params",
+            new_callable=MagicMock,
+        ) as mock_apply_cursor,
     ):
         mock_get_url.return_value = mock_base_url
         mock_request.return_value = mock_response
+
+        # Simulate cursor application updating params and assert inputs
+        def fake_apply(cursor, params):
+            assert cursor == "abc"
+            assert params == {"limit": "1"}
+            params.update({"page": 2})
+
+        mock_apply_cursor.side_effect = fake_apply
 
         result = await direct_api_call(
             chain_id=chain_id,
@@ -70,14 +77,16 @@ async def test_direct_api_call_with_query_params_and_cursor(mock_ctx):
         )
 
         mock_get_url.assert_called_once_with(chain_id)
-        mock_decode.assert_called_once_with("abc")
+        mock_apply_cursor.assert_called_once()
         mock_request.assert_called_once_with(
             base_url=mock_base_url,
             api_path=endpoint_path,
             params={"limit": "1", "page": 2},
         )
         assert isinstance(result, ToolResponse)
+        assert result.data == mock_response
         assert result.pagination is None
+        assert mock_ctx.report_progress.call_count == 3
 
 
 @pytest.mark.asyncio
@@ -105,4 +114,35 @@ async def test_direct_api_call_with_pagination(mock_ctx):
         assert isinstance(result, ToolResponse)
         assert result.pagination is not None
         assert result.pagination.next_call.tool_name == "direct_api_call"
-        assert "cursor" in result.pagination.next_call.params
+        nc = result.pagination.next_call.params
+        assert nc["chain_id"] == chain_id
+        assert nc["endpoint_path"] == endpoint_path
+        assert "cursor" in nc
+        assert "query_params" not in nc
+        mock_get_url.assert_called_once_with(chain_id)
+        mock_request.assert_called_once_with(base_url=mock_base_url, api_path=endpoint_path, params={})
+        assert mock_ctx.report_progress.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_direct_api_call_raises_on_request_error(mock_ctx):
+    chain_id = "1"
+    endpoint_path = "/api/v2/data"
+    mock_base_url = "https://eth.blockscout.com"
+    with (
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.make_blockscout_request",
+            new_callable=AsyncMock,
+        ) as mock_request,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_request.side_effect = TimeoutError("upstream timeout")
+        with pytest.raises(TimeoutError):
+            await direct_api_call(chain_id=chain_id, endpoint_path=endpoint_path, ctx=mock_ctx)
+        mock_get_url.assert_called_once_with(chain_id)
+        mock_request.assert_awaited_once()
+        assert mock_ctx.report_progress.call_count == 2

--- a/tests/tools/test_direct_api_tools.py
+++ b/tests/tools/test_direct_api_tools.py
@@ -1,0 +1,108 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from blockscout_mcp_server.models import ToolResponse
+from blockscout_mcp_server.tools.direct_api_tools import direct_api_call
+
+
+@pytest.mark.asyncio
+async def test_direct_api_call_no_params(mock_ctx):
+    chain_id = "1"
+    endpoint_path = "/api/v2/stats"
+    mock_base_url = "https://eth.blockscout.com"
+    mock_response = {"result": 1}
+
+    with (
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.make_blockscout_request",
+            new_callable=AsyncMock,
+        ) as mock_request,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_response
+
+        result = await direct_api_call(chain_id=chain_id, endpoint_path=endpoint_path, ctx=mock_ctx)
+
+        mock_get_url.assert_called_once_with(chain_id)
+        mock_request.assert_called_once_with(base_url=mock_base_url, api_path=endpoint_path, params={})
+        assert isinstance(result, ToolResponse)
+        assert result.data == mock_response
+        assert result.pagination is None
+
+
+@pytest.mark.asyncio
+async def test_direct_api_call_with_query_params_and_cursor(mock_ctx):
+    chain_id = "1"
+    endpoint_path = "/api/v2/foo"
+    mock_base_url = "https://eth.blockscout.com"
+    mock_response = {"data": []}
+    query_params = {"limit": "1"}
+    decoded_cursor = {"page": 2}
+
+    with (
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.make_blockscout_request",
+            new_callable=AsyncMock,
+        ) as mock_request,
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.decode_cursor",
+            return_value=decoded_cursor,
+        ) as mock_decode,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_response
+
+        result = await direct_api_call(
+            chain_id=chain_id,
+            endpoint_path=endpoint_path,
+            ctx=mock_ctx,
+            query_params=query_params,
+            cursor="abc",
+        )
+
+        mock_get_url.assert_called_once_with(chain_id)
+        mock_decode.assert_called_once_with("abc")
+        mock_request.assert_called_once_with(
+            base_url=mock_base_url,
+            api_path=endpoint_path,
+            params={"limit": "1", "page": 2},
+        )
+        assert isinstance(result, ToolResponse)
+        assert result.pagination is None
+
+
+@pytest.mark.asyncio
+async def test_direct_api_call_with_pagination(mock_ctx):
+    chain_id = "1"
+    endpoint_path = "/api/v2/data"
+    mock_base_url = "https://eth.blockscout.com"
+    mock_response = {"next_page_params": {"cursor": 123}, "items": []}
+
+    with (
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.get_blockscout_base_url",
+            new_callable=AsyncMock,
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.direct_api_tools.make_blockscout_request",
+            new_callable=AsyncMock,
+        ) as mock_request,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_request.return_value = mock_response
+
+        result = await direct_api_call(chain_id=chain_id, endpoint_path=endpoint_path, ctx=mock_ctx)
+
+        assert isinstance(result, ToolResponse)
+        assert result.pagination is not None
+        assert result.pagination.next_call.tool_name == "direct_api_call"
+        assert "cursor" in result.pagination.next_call.params

--- a/tests/tools/test_direct_api_tools.py
+++ b/tests/tools/test_direct_api_tools.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from blockscout_mcp_server.models import ToolResponse
+from blockscout_mcp_server.models import DirectApiData, ToolResponse
 from blockscout_mcp_server.tools.direct_api_tools import direct_api_call
 
 
@@ -31,7 +31,8 @@ async def test_direct_api_call_no_params(mock_ctx):
         mock_get_url.assert_called_once_with(chain_id)
         mock_request.assert_called_once_with(base_url=mock_base_url, api_path=endpoint_path, params={})
         assert isinstance(result, ToolResponse)
-        assert result.data == mock_response
+        assert isinstance(result.data, DirectApiData)
+        assert result.data.model_dump() == mock_response
         assert result.pagination is None
         assert mock_ctx.report_progress.call_count == 3
 
@@ -84,7 +85,8 @@ async def test_direct_api_call_with_query_params_and_cursor(mock_ctx):
             params={"limit": "1", "page": 2},
         )
         assert isinstance(result, ToolResponse)
-        assert result.data == mock_response
+        assert isinstance(result.data, DirectApiData)
+        assert result.data.model_dump() == mock_response
         assert result.pagination is None
         assert mock_ctx.report_progress.call_count == 3
 

--- a/tests/tools/test_initialization_tools.py
+++ b/tests/tools/test_initialization_tools.py
@@ -37,6 +37,11 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
         patch("blockscout_mcp_server.tools.initialization_tools.BLOCK_TIME_ESTIMATION_RULES", mock_block_rules),
         patch("blockscout_mcp_server.tools.initialization_tools.EFFICIENCY_OPTIMIZATION_RULES", mock_efficiency_rules),
         patch("blockscout_mcp_server.tools.initialization_tools.RECOMMENDED_CHAINS", mock_chains),
+        patch("blockscout_mcp_server.tools.initialization_tools.DIRECT_API_CALL_RULES", "Direct API rule"),
+        patch(
+            "blockscout_mcp_server.tools.initialization_tools.DIRECT_API_CALL_ENDPOINT_LIST",
+            {"common": [], "specific": []},
+        ),
     ):
         # ACT
         result = await __unlock_blockchain_analysis__(ctx=mock_ctx)
@@ -60,6 +65,8 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
         assert result.data.time_based_query_rules == mock_time_rules
         assert result.data.block_time_estimation_rules == mock_block_rules
         assert result.data.efficiency_optimization_rules == mock_efficiency_rules
+        assert result.data.direct_api_call_rules == "Direct API rule"
+        assert result.data.direct_api_endpoints.common == []
 
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -79,12 +79,11 @@ async def test_get_transaction_info_success(mock_ctx):
             assert data[key] == value
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
-        expected_instruction = (
-            "Use `direct_api_call` with endpoint "
-            f"`/api/v2/proxy/account-abstraction/operations?transaction_hash={hash}` "
-            "to get User Operations for this transaction."
+        assert result.instructions is not None
+        assert any(
+            "/api/v2/proxy/account-abstraction/operations" in instr and f"{hash}" in instr
+            for instr in result.instructions
         )
-        assert result.instructions is not None and expected_instruction in result.instructions
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_transaction_tools_2.py
+++ b/tests/tools/test_transaction_tools_2.py
@@ -79,6 +79,12 @@ async def test_get_transaction_info_success(mock_ctx):
             assert data[key] == value
         assert mock_ctx.report_progress.call_count == 3
         assert mock_ctx.info.call_count == 3
+        expected_instruction = (
+            "Use `direct_api_call` with endpoint "
+            f"`/api/v2/proxy/account-abstraction/operations?transaction_hash={hash}` "
+            "to get User Operations for this transaction."
+        )
+        assert result.instructions is not None and expected_instruction in result.instructions
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- drop invalid `limit` query param from Arbitrum messages and blocks-validated integration tests
- ensure pagination logic uses default server page sizes

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest`
- `pytest -m integration -v` *(fails: contract call runtime errors)*

Closes #215

------
https://chatgpt.com/codex/tasks/task_b_68ae9cdda01c83238ea708381dfe2f3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct_api_call tool for curated Blockscout endpoints with cursor pagination; exposed via REST, UI, MCP instructions, and surfaced as actionable guidance in address/transaction responses.

* **Documentation**
  * Added docs, spec, examples, OpenAPI, and GPT instruction entries for direct_api_call across README, API/SPEC, TESTING, and tool descriptions.

* **Models**
  * Added schema for direct API endpoints and response container; Instructions payload extended to include rules and endpoint list.

* **Tests**
  * Added unit, route, and integration tests for params, pagination, errors, and instruction propagation (some duplicated tests).

* **Chores**
  * Bumped project and extension manifest versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->