### PR TITLE
Default endpoint for HTTP Streamable changed to `/mcp` without trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The easiest way to use the Blockscout MCP server with Claude Desktop is through 
 
 ### Using the Official Blockscout MCP Server
 
-The official cloud-hosted instance at `https://mcp.blockscout.com/mcp/` provides a reliable, always-updated service.
+The official cloud-hosted instance at `https://mcp.blockscout.com/mcp` provides a reliable, always-updated service.
 
 **Claude Desktop Setup:**
 
@@ -61,7 +61,7 @@ The official cloud-hosted instance at `https://mcp.blockscout.com/mcp/` provides
             "sparfenyuk/mcp-proxy:latest",
             "--transport",
             "streamablehttp",
-            "https://mcp.blockscout.com/mcp/"
+            "https://mcp.blockscout.com/mcp"
           ]
         }
       }
@@ -73,7 +73,7 @@ The official cloud-hosted instance at `https://mcp.blockscout.com/mcp/` provides
 
 **Cursor Setup:**
 
-Use [this deeplink](https://cursor.com/en/install-mcp?name=blockscout&config=eyJ1cmwiOiJodHRwczovL21jcC5ibG9ja3Njb3V0LmNvbS9tY3AvIiwidGltZW91dCI6MTgwMDAwLCJoZWFkZXJzIjp7fX0%3D) to install the Blockscout MCP server in Cursor.
+Use [this deeplink](https://cursor.com/en/install-mcp?name=blockscout&config=eyJ1cmwiOiJodHRwczovL21jcC5ibG9ja3Njb3V0LmNvbS9tY3AiLCJ0aW1lb3V0IjoxODAwMDB9) to install the Blockscout MCP server in Cursor.
 
 **Gemini CLI Setup:**
 
@@ -83,7 +83,7 @@ Use [this deeplink](https://cursor.com/en/install-mcp?name=blockscout&config=eyJ
     {
       "mcpServers": {
         "blockscout": {
-          "httpUrl": "https://mcp.blockscout.com/mcp/",
+          "httpUrl": "https://mcp.blockscout.com/mcp",
           "timeout": 180000
         }
       }

--- a/SPEC.md
+++ b/SPEC.md
@@ -536,8 +536,8 @@ To gain insight into tool usage patterns, the server can optionally report tool 
 
 - Anonymous identity (distinct_id) (as per Mixpanel's [documentation](https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified#server-side-identity-management)):
   - A stable `distinct_id` is generated to anonymously identify unique users.
-  - The fingerprint is the concatenation of: namespace URL (`"https://blockscout.com/mcp"`), client IP, client name, and client version.
-  - This provides stable identification even when multiple clients share the same name/version (e.g., Claude Desktop), because their IPs differ.
+  - The fingerprint is the concatenation of: namespace URL ("https://mcp.blockscout.com/mcp"), client IP, client name, and client version.
+  - This yields stable identification even when multiple clients share the same name/version (e.g., Claude Desktop) because their IPs differ.
 
 - REST API support and source attribution:
   - The REST context mock is extended with a request context wrapper so analytics can extract IP and headers consistently (see `blockscout_mcp_server/api/dependencies.py`).

--- a/SPEC.md
+++ b/SPEC.md
@@ -19,7 +19,7 @@ The Blockscout MCP Server supports two primary operational modes:
 2. **HTTP Mode**:
    - Enabled with the `--http` flag.
    - By default, this mode provides a pure MCP-over-HTTP endpoint at `/mcp`, using the same JSON-RPC 2.0 protocol as stdio mode.
-   - While it is stateless and streams Server‑Sent Events (SSE, text/event-stream) rather than prettified JSON, it still convenient for testing and integration (e.g. by using `curl` or `Insomnia`).
+   - While it is stateless and streams Server‑Sent Events (SSE, text/event-stream) rather than prettified JSON, it is still convenient for testing and integration (e.g., using `curl` or `Insomnia`).
 
    The HTTP mode can be optionally extended to serve additional web and REST API endpoints. This is disabled by default and can be enabled by providing the `--rest` flag at startup.
 
@@ -590,20 +590,20 @@ To enhance the flexibility and extensibility of the Blockscout MCP Server, a new
 
 While the existing MCP tools provide high-level, optimized access to common blockchain data, they do not cover every possible endpoint or chain-specific functionality offered by Blockscout. Introducing a dedicated tool for every niche endpoint would lead to "tool sprawl," overwhelming the LLM's context and making tool selection difficult. The `direct_api_call` tool addresses this by providing a controlled mechanism to access specialized data without proliferating the core toolset. It is specifically designed for:
 
-*   Accessing chain-specific data (e.g., rollup batch information, validator lists for PoS chains).
-*   Retrieving data from less frequently used or experimental Blockscout API endpoints.
-*   Providing a flexible interface for future Blockscout API additions without requiring server code changes.
+- Accessing chain-specific data (e.g., rollup batch information, validator lists for PoS chains).
+- Retrieving data from less frequently used or experimental Blockscout API endpoints.
+- Providing a flexible interface for future Blockscout API additions without requiring server code changes.
 
 **Architectural Integration and Curation Strategy:**
 
 The `direct_api_call` tool is integrated into the server with careful consideration for LLM usability and context optimization:
 
-1.  **Functional Uniqueness:** The endpoints exposed via `direct_api_call` are strictly curated to *not* duplicate functionality already provided by existing, specific MCP tools. This eliminates "tool selection confusion" for the AI, ensuring that `direct_api_call` serves a complementary role.
-2.  **Endpoint Discovery:**
-    *   A primary, curated list of general and chain-specific endpoints is provided to the AI through the `__unlock_blockchain_analysis__` tool's response. This ensures the AI is aware of the tool's capabilities from the outset.
-    *   Additionally, context-relevant endpoints are suggested in the `instructions` field of responses from other specific tools (e.g., `get_address_info`). This allows the AI to "dig deeper" into related data only when it's contextually relevant, optimizing LLM token usage.
-3.  **Input Simplicity:** The curated endpoints are chosen to have relatively simple input parameters, making it easier for the AI to construct valid calls. The AI is responsible for substituting any path parameters (e.g., `{account_address}`) directly into the `endpoint_path` string.
-4.  **Output Conciseness:** Endpoints that return excessively large or complex raw data payloads are generally excluded from the curated list. This prevents overwhelming the LLM's context window with unmanageable information, aligning with the server's overall "Response Processing and Context Optimization" strategy.
+1. **Functional Uniqueness:** The endpoints exposed via `direct_api_call` are strictly curated to *not* duplicate functionality already provided by existing, specific MCP tools. This eliminates "tool selection confusion" for the AI, ensuring that `direct_api_call` serves a complementary role.
+2. **Endpoint Discovery:**
+    - A primary, curated list of general and chain-specific endpoints is provided to the AI through the `__unlock_blockchain_analysis__` tool's response. This ensures the AI is aware of the tool's capabilities from the outset.
+    - Additionally, context-relevant endpoints are suggested in the `instructions` field of responses from other specific tools (e.g., `get_address_info`). This allows the AI to "dig deeper" into related data only when it's contextually relevant, optimizing LLM token usage.
+3. **Input Simplicity:** The curated endpoints are chosen to have relatively simple input parameters, making it easier for the AI to construct valid calls. The AI is responsible for substituting any path parameters (e.g., `{account_address}`) directly into the `endpoint_path` string.
+4. **Output Conciseness:** Endpoints that return excessively large or complex raw data payloads are generally excluded from the curated list. This prevents overwhelming the LLM's context window with unmanageable information, aligning with the server's overall "Response Processing and Context Optimization" strategy.
 
 **High-Level Implementation Details:**
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -536,7 +536,7 @@ To gain insight into tool usage patterns, the server can optionally report tool 
 
 - Anonymous identity (distinct_id) (as per Mixpanel's [documentation](https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified#server-side-identity-management)):
   - A stable `distinct_id` is generated to anonymously identify unique users.
-  - The fingerprint is the concatenation of: namespace URL (`"https://blockscout.com/mcp/"`), client IP, client name, and client version.
+  - The fingerprint is the concatenation of: namespace URL (`"https://blockscout.com/mcp"`), client IP, client name, and client version.
   - This provides stable identification even when multiple clients share the same name/version (e.g., Claude Desktop), because their IPs differ.
 
 - REST API support and source attribution:

--- a/SPEC.md
+++ b/SPEC.md
@@ -19,7 +19,7 @@ The Blockscout MCP Server supports two primary operational modes:
 2. **HTTP Mode**:
    - Enabled with the `--http` flag.
    - By default, this mode provides a pure MCP-over-HTTP endpoint at `/mcp`, using the same JSON-RPC 2.0 protocol as stdio mode.
-   - It is stateless and uses JSON responses, making it convenient for testing and integration.
+   - While it is stateless and streams Server‑Sent Events (SSE, text/event-stream) rather than prettified JSON, it still convenient for testing and integration (e.g. by using `curl` or `Insomnia`).
 
    The HTTP mode can be optionally extended to serve additional web and REST API endpoints. This is disabled by default and can be enabled by providing the `--rest` flag at startup.
 
@@ -536,7 +536,7 @@ To gain insight into tool usage patterns, the server can optionally report tool 
 
 - Anonymous identity (distinct_id) (as per Mixpanel's [documentation](https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified#server-side-identity-management)):
   - A stable `distinct_id` is generated to anonymously identify unique users.
-  - The fingerprint is the concatenation of: namespace URL ("https://mcp.blockscout.com/mcp"), client IP, client name, and client version.
+  - The fingerprint is the concatenation of: namespace URL (`https://mcp.blockscout.com/mcp`), client IP, client name, and client version.
   - This yields stable identification even when multiple clients share the same name/version (e.g., Claude Desktop) because their IPs differ.
 
 - REST API support and source attribution:

--- a/TESTING.md
+++ b/TESTING.md
@@ -120,13 +120,13 @@ The server will start and listen on `http://127.0.0.1:8000`.
 
 ### Testing MCP over HTTP
 
-These examples show how to interact with the server using the native MCP JSON-RPC protocol over HTTP. The MCP endpoint is available at `/mcp/`. **Note**: The trailing slash is required.
+These examples show how to interact with the server using the native MCP JSON-RPC protocol over HTTP. The MCP endpoint is available at `/mcp`.
 
 #### 1. List Available Tools
 
 ```bash
 curl --request POST \
-  --url http://127.0.0.1:8000/mcp/ \
+  --url http://127.0.0.1:8000/mcp \
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json, text/event-stream' \
   --data '{
@@ -134,6 +134,7 @@ curl --request POST \
     "id": 0,
     "method": "tools/list"
   }'
+```
 
 This will return a list of all available tools with their descriptions and input schemas.
 
@@ -141,7 +142,7 @@ This will return a list of all available tools with their descriptions and input
 
 ```bash
 curl --request POST \
-  --url http://127.0.0.1:8000/mcp/ \
+  --url http://127.0.0.1:8000/mcp \
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json, text/event-stream' \
   --data '{
@@ -159,7 +160,7 @@ curl --request POST \
 
 ```bash
 curl --request POST \
-  --url http://127.0.0.1:8000/mcp/ \
+  --url http://127.0.0.1:8000/mcp \
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json, text/event-stream' \
   --data '{

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.10.0.dev1"
+__version__ = "0.10.0.dev2"

--- a/blockscout_mcp_server/analytics.py
+++ b/blockscout_mcp_server/analytics.py
@@ -115,7 +115,7 @@ def _build_distinct_id(ip: str, client_name: str, client_version: str) -> str:
     # User-Agent is merged into client_name in extract_client_meta_from_ctx when name is unavailable.
     # Therefore composite requires only ip, client_name and client_version for a stable fingerprint.
     composite = "|".join([ip or "", client_name or "", client_version or ""])
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, "https://blockscout.com/mcp/" + composite))
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, "https://mcp.blockscout.com/mcp" + composite))
 
 
 def _determine_call_source(ctx: Any) -> str:

--- a/blockscout_mcp_server/llms.txt
+++ b/blockscout_mcp_server/llms.txt
@@ -14,7 +14,7 @@
 **Benefits:** Context-aware, progress tracking, intelligent pagination, optimized for LLM token usage
 
 **Configuration:**
-- **Cloud instance:** `https://mcp.blockscout.com/mcp/`
+- **Cloud instance:** `https://mcp.blockscout.com/mcp`
 - **Claude Desktop (DXT Extension):** Download and install `blockscout-mcp.dxt` from GitHub releases for one-click setup
 - **Claude Desktop (Docker):** Use `sparfenyuk/mcp-proxy:latest` with streamable HTTP transport
 - **Cursor and Gemini CLI:** Direct HTTP URL with 180-second timeout

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 import uvicorn
 from mcp.server.fastmcp import FastMCP
+from starlette.middleware.cors import CORSMiddleware
 
 from blockscout_mcp_server import analytics
 from blockscout_mcp_server.constants import (
@@ -174,6 +175,20 @@ def main_command(
         # Enable analytics in HTTP mode
         analytics.set_http_mode(True)
         asgi_app = mcp.streamable_http_app()
+
+        # Wrap ASGI application with CORS middleware to expose Mcp-Session-Id header
+        # for browser-based clients (ensures 500 errors get proper CORS headers)
+        # See: https://github.com/modelcontextprotocol/python-sdk/pull/1059
+        asgi_app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],  # Configure this more restrictively if needed
+            allow_credentials=True,
+            allow_methods=["GET", "POST", "OPTIONS", "HEAD"],
+            allow_headers=["*"],
+            expose_headers=["mcp-session-id"],  # Allow client to read session ID
+            max_age=86400,
+        )
+
         asgi_app.add_event_handler("shutdown", WEB3_POOL.close)
         uvicorn.run(asgi_app, host=http_host, port=http_port)
     elif rest:

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -182,7 +182,6 @@ def main_command(
         asgi_app.add_middleware(
             CORSMiddleware,
             allow_origins=["*"],  # Configure this more restrictively if needed
-            allow_credentials=True,
             allow_methods=["GET", "POST", "OPTIONS", "HEAD"],
             allow_headers=["*"],
             expose_headers=["mcp-session-id"],  # Allow client to read session ID

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -135,7 +135,7 @@ def main_command(
 
         # Configure the existing 'mcp' instance for stateless HTTP with JSON responses
         mcp.settings.stateless_http = True  # Enable stateless mode
-        mcp.settings.json_response = True  # Enable JSON responses instead of SSE for tool calls
+        mcp.settings.json_response = False  # Enable JSON responses instead of SSE for tool calls
         # Enable analytics in HTTP mode
         analytics.set_http_mode(True)
         asgi_app = mcp.streamable_http_app()

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -169,7 +169,8 @@ def main_command(
 
         # Configure the existing 'mcp' instance for stateless HTTP with JSON responses
         mcp.settings.stateless_http = True  # Enable stateless mode
-        mcp.settings.json_response = False  # Enable JSON responses instead of SSE for tool calls
+        # TODO: As soon as addressed in https://github.com/modelcontextprotocol/python-sdk/issues/1294, we can enable JSON responses instead of SSE for tool calls  # noqa: E501
+        mcp.settings.json_response = False
         # Enable analytics in HTTP mode
         analytics.set_http_mode(True)
         asgi_app = mcp.streamable_http_app()

--- a/blockscout_mcp_server/templates/index.html
+++ b/blockscout_mcp_server/templates/index.html
@@ -84,7 +84,7 @@
         "sparfenyuk/mcp-proxy:latest",
         "--transport",
         "streamablehttp",
-        "https://mcp.blockscout.com/mcp/"
+        "https://mcp.blockscout.com/mcp"
       ]
     }
   }
@@ -100,14 +100,14 @@
     <p class="copy-hint">You can copy this prompt and paste it into your Claude Desktop conversation.</p>
 
     <h3>Cursor Setup</h3>
-    <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=blockscout&config=eyJ1cmwiOiJodHRwczovL21jcC5ibG9ja3Njb3V0LmNvbS9tY3AvIiwidGltZW91dCI6MTgwMDAwfQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add Blockscout MCP server to Cursor" height="32" /></a>
+    <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=blockscout&config=eyJ1cmwiOiJodHRwczovL21jcC5ibG9ja3Njb3V0LmNvbS9tY3AiLCJ0aW1lb3V0IjoxODAwMDB9"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add Blockscout MCP server to Cursor" height="32" /></a>
 
     <h3>Gemini CLI Setup</h3>
     <p>To configure the Blockscout MCP server with Gemini CLI, add the following to your <code>~/.gemini/settings.json</code> file:</p>
     <pre><code>{
   "mcpServers": {
     "blockscout": {
-      "httpUrl": "https://mcp.blockscout.com/mcp/",
+      "httpUrl": "https://mcp.blockscout.com/mcp",
       "timeout": 180000
     }
   }

--- a/dxt/README.md
+++ b/dxt/README.md
@@ -14,7 +14,7 @@ The blockscout MCP Server Desktop Extension doesn't include the original Python 
 
 The reasons for this are:
 
-- **Upgradeless improvements**: the stable version of the Blockscout MCP Server with the newest functionality is always deployed on `http://mcp.blockscout.com/mcp/`, therefore users don't need to upgrade the extension to get access to the newest features.
+- **Upgradeless improvements**: the stable version of the Blockscout MCP Server with the newest functionality is always deployed on `http://mcp.blockscout.com/mcp`, therefore users don't need to upgrade the extension to get access to the newest features.
 - **Simplify the distribution**: while Claude Desktop supports installing Python-based extensions, Python is not shipped with the application whereas Node.js (which is required for `mcp-remote`) is. Reducing assumptions about the software stack makes the extension more accessible to a wider range of users. If a user is experienced enough to install Python/Docker, they can easily install the original MCP server on the local machine by themselves.
 - **Simplify the development**: there is no need to adapt the MCP server to comply with the DXT specification.
 - **Open source in action**: the Blockscout MCP server code does not need to implement its own proxy functionality; instead, community-tested and trusted `mcp-remote` is used.
@@ -41,7 +41,7 @@ docker run --rm -it -v "$(pwd)"/dxt:/workspace -w /workspace node:20-slim bash -
 
 #### Build Modes
 
-- **Production (`prod`)**: Uses `manifest.json` and connects to the official `https://mcp.blockscout.com/mcp/` server. Creates `blockscout-mcp.dxt`.
+- **Production (`prod`)**: Uses `manifest.json` and connects to the official `https://mcp.blockscout.com/mcp` server. Creates `blockscout-mcp.dxt`.
 - **Development (`dev`)**: Uses `manifest-dev.json` with configurable URL and creates `blockscout-mcp-dev.dxt`. Users can configure the Blockscout MCP server URL during installation in Claude Desktop.
 
 This will automatically handle all the steps below and create the extension at `dxt/_build/blockscout-mcp[--dev].dxt`.

--- a/dxt/manifest-dev.json
+++ b/dxt/manifest-dev.json
@@ -36,8 +36,8 @@
     "blockscout_url": {
       "type": "string",
       "title": "Blockscout MCP Server URL",
-      "description": "The URL of the Blockscout MCP server to connect to (e.g., http://127.0.0.1:8000/mcp/ for local development)",
-      "default": "http://127.0.0.1:8000/mcp/",
+      "description": "The URL of the Blockscout MCP server to connect to (e.g., http://127.0.0.1:8000/mcp for local development)",
+      "default": "http://127.0.0.1:8000/mcp",
       "required": true
     }
   },

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -24,7 +24,7 @@
       "command": "node",
       "args": [
         "${__dirname}/node_modules/mcp-remote/dist/proxy.js",
-        "https://mcp.blockscout.com/mcp/",
+        "https://mcp.blockscout.com/mcp",
         "--transport", "http-only",
         "--header", "Blockscout-MCP-Intermediary: ClaudeDesktop"
       ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [
     # Pinned to 1.11.0 – newer (≥1.12.0) versions break HTTP Streamable mode (see PR #174)
-    "mcp[cli]==1.11.0",
+    "mcp[cli]==1.13.1",
     "httpx>=0.27.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.10.0.dev1"
+version = "0.10.0.dev2"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/evals/.gemini/settings.json
+++ b/tests/evals/.gemini/settings.json
@@ -3,7 +3,7 @@
   "theme": "ANSI",
   "mcpServers": {
     "blockscout": {
-      "httpUrl": "${MCP_SERVER_URL}/mcp/",
+      "httpUrl": "${MCP_SERVER_URL}/mcp",
       "timeout": 180000
     }
   }


### PR DESCRIPTION
Bump of Python MCP SDK to 1.13.1 allows to use `/mcp` without trailing slash as a default endpoint. It is more preferable since some platforms proxying MCP requests cut the trailing slash that lead in the past to inability to communicate with the MCP server.

Due to known issue https://github.com/modelcontextprotocol/python-sdk/issues/1294, json response is switched off so far. Obvious disadvantage identified till to this moment is that stream events received from the server by Curl/Insomnia instead of pure JSON that is why the response of the server is not prettified.

All the files where the endpoint `/mcp/` was mentioned modified to have `/mcp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Tool-call HTTP responses now stream via Server-Sent Events (SSE) by default.
  - Browser clients can access the mcp-session-id header (CORS exposed).
  - Added a new tool to make direct Blockscout API calls for niche endpoints.

- Documentation
  - Standardized MCP URLs by removing trailing slashes across docs, samples, and setup deeplinks.
  - Updated Docker, Cursor, and CLI configuration examples.

- Tests
  - Updated test/eval settings to use the new MCP URL format.

- Chores
  - Bumped project and CLI dependency versions.
  - Fingerprint namespace/base URL changed (may alter generated identifiers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->