### PR TITLE
feat: allow transport configuration via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,8 @@ BLOCKSCOUT_MIXPANEL_API_HOST=""
 BLOCKSCOUT_INTERMEDIARY_HEADER="Blockscout-MCP-Intermediary"
 BLOCKSCOUT_INTERMEDIARY_ALLOWLIST="ClaudeDesktop,HigressPlugin"
 
+# The transport mode for the server. 
+# Options: "stdio" (default), "http".
+# This allows running the server in HTTP mode without CLI flags, which is useful for container environments.
+# The --http CLI flag will always take precedence if provided.
+# BLOCKSCOUT_MCP_TRANSPORT="stdio"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,11 @@ ENV BLOCKSCOUT_MIXPANEL_API_HOST=""
 ENV BLOCKSCOUT_INTERMEDIARY_HEADER="Blockscout-MCP-Intermediary"
 ENV BLOCKSCOUT_INTERMEDIARY_ALLOWLIST="ClaudeDesktop,HigressPlugin"
 
+# Expose the default port for HTTP mode. This is for documentation and interoperability.
+EXPOSE 8000
+
+# Set the default transport mode. Can be overridden at runtime with -e.
+# Options: "stdio" (default), "http"
+ENV BLOCKSCOUT_MCP_TRANSPORT="stdio"
+
 CMD ["python", "-m", "blockscout_mcp_server"]

--- a/blockscout_mcp_server/config.py
+++ b/blockscout_mcp_server/config.py
@@ -42,6 +42,10 @@ class ServerConfig(BaseSettings):
     mixpanel_token: str = ""
     mixpanel_api_host: str = ""  # Optional custom API host (e.g., EU region)
 
+    # Transport mode for the server ("stdio" or "http").
+    # Controls the server's operational mode, can be overridden by CLI flags.
+    mcp_transport: str = "stdio"
+
     # Composite client name configuration
     intermediary_header: str = "Blockscout-MCP-Intermediary"
     intermediary_allowlist: str = "ClaudeDesktop,HigressPlugin"

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 from starlette.middleware.cors import CORSMiddleware
 
 from blockscout_mcp_server import analytics
+from blockscout_mcp_server.config import config
 from blockscout_mcp_server.constants import (
     BLOCK_TIME_ESTIMATION_RULES,
     CHAIN_ID_RULES,
@@ -159,14 +160,20 @@ def main_command(
     Use --http to enable HTTP Streamable mode.
     Use --http and --rest to enable the REST API.
     """
-    if http:
+    # Determine if we should run in HTTP mode based on CLI flag or environment variable.
+    run_in_http = http or config.mcp_transport == "http"
+
+    # When triggered by env var, default host must be 0.0.0.0 for container accessibility.
+    final_http_host = "0.0.0.0" if not http and run_in_http else http_host
+
+    if run_in_http:
         if rest:
-            print(f"Starting Blockscout MCP Server with REST API on {http_host}:{http_port}")
+            print(f"Starting Blockscout MCP Server with REST API on {final_http_host}:{http_port}")
             from blockscout_mcp_server.api.routes import register_api_routes
 
             register_api_routes(mcp)
         else:
-            print(f"Starting Blockscout MCP Server in HTTP Streamable mode on {http_host}:{http_port}")
+            print(f"Starting Blockscout MCP Server in HTTP Streamable mode on {final_http_host}:{http_port}")
 
         # Configure the existing 'mcp' instance for stateless HTTP with JSON responses
         mcp.settings.stateless_http = True  # Enable stateless mode
@@ -189,7 +196,7 @@ def main_command(
         )
 
         asgi_app.add_event_handler("shutdown", WEB3_POOL.close)
-        uvicorn.run(asgi_app, host=http_host, port=http_port)
+        uvicorn.run(asgi_app, host=final_http_host, port=http_port)
     elif rest:
         raise typer.BadParameter("The --rest flag can only be used with the --http flag.")
     else:

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,13 +1,20 @@
 # Smithery configuration file: https://smithery.ai/docs/build/project-config
 
+runtime: "container"
+
+build:
+  dockerfile: "Dockerfile"
+  dockerBuildPath: "."
+
 startCommand:
-  type: stdio
-  commandFunction:
-    # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
-    |-
-    (config) => ({ command: 'python', args: ['-m', 'blockscout_mcp_server.server'] })
+  type: "http"
   configSchema:
-    # JSON Schema defining the configuration options for the MCP.
-    type: object
+    # No user-configurable options are needed for this server at the moment.
+    type: "object"
     properties: {}
   exampleConfig: {}
+
+# Use environment variables to configure the container at runtime.
+# We set the transport to "http" for the Smithery.ai environment.
+env:
+  BLOCKSCOUT_MCP_TRANSPORT: "http"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,3 +54,18 @@ def test_stdio_mode_works(mock_mcp_run):
     result = runner.invoke(cli_app, [])
     assert result.exit_code == 0
     mock_mcp_run.assert_called_once()
+
+
+def test_env_var_triggers_http_mode(monkeypatch):
+    """Verify that setting BLOCKSCOUT_MCP_TRANSPORT=http starts the server in HTTP mode."""
+    from blockscout_mcp_server import server
+
+    monkeypatch.setattr(server.config, "mcp_transport", "http")
+    mock_run = MagicMock()
+    monkeypatch.setattr(server.uvicorn, "run", mock_run)
+
+    result = runner.invoke(server.cli_app, [])
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["host"] == "0.0.0.0"


### PR DESCRIPTION
Closes #219 

## Summary
- add BLOCKSCOUT_MCP_TRANSPORT setting and use it to select http or stdio transport
- document transport setting in Dockerfile and .env.example
- switch smithery config to container runtime with http transport

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68afa2aabea08323bb75ef9fdbe38a4e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select transport via BLOCKSCOUT_MCP_TRANSPORT (stdio or http); HTTP can run without CLI flags.
  * When triggered by env in containers, HTTP binds to 0.0.0.0 for external access.
* **Documentation**
  * Added .env.example entry documenting transport variable and defaults.
* **Chores**
  * Docker image exposes port 8000 and sets default transport for container runs.
* **Tests**
  * Added tests validating env-driven HTTP mode and host selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->