### PR TITLE
Change `read_contract` `args` Parameter From `list[Any]` to `str`

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -579,7 +579,7 @@ This server exposes a tool for on-chain smart contract read-only state access. I
 - **Implementation**: Uses Web3.py for ABI-based input encoding and output decoding. This leverages Web3's well-tested argument handling and return value decoding.
 - **ABI requirement**: Accepts the ABI of the specific function variant to call (a single ABI object for that function signature). This avoids ambiguity when contracts overload function names.
 - **Function name**: The `function_name` parameter must match the `name` field in the provided function ABI. Although redundant, it is kept intentionally to improve LLM tool-selection behavior and may be removed later.
-- **Arguments**: The `args` parameter is a JSON array. Nested structures and complex ABIv2 types are supported (arrays, tuples, structs). Argument normalization rules:
+- **Arguments**: The `args` parameter is a JSON string containing an array of arguments. Nested structures and complex ABIv2 types are supported (arrays, tuples, structs). Argument normalization rules:
   - Addresses can be provided as 0x-prefixed strings; the tool normalizes and applies EIP-55 checksum internally.
   - Numeric strings are coerced to integers.
   - Bytes values should be provided as 0x-hex strings; nested hex strings are handled.
@@ -594,10 +594,10 @@ This server exposes a tool for on-chain smart contract read-only state access. I
 #### LLM guidance
 
 - Tool and argument descriptions explicitly instruct LLMs to:
-  - Provide arguments as a JSON array (not a quoted string)
-  - Provide 0x-prefixed address strings
+  - Provide arguments as a JSON string containing an array (e.g., `"[\"0xabc...\"]"` for a single address)
+  - Provide 0x-prefixed address strings within the array
   - Supply integers for numeric values (not quoted) when possible; numeric strings will be coerced
-  - Keep bytes as 0x-hex strings
+  - Keep bytes as 0x-hex strings within the array
 - These instructions improve the likelihood of valid `eth_call` preparation and encoding.
 
 #### Limitations

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.10.0.dev2"
+__version__ = "0.10.0.dev3"

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -189,11 +189,7 @@ async def read_contract_rest(request: Request) -> Response:
         raise ValueError("Invalid JSON for 'abi'") from e
     if not isinstance(params["abi"], dict):
         raise ValueError("'abi' must be a JSON object")
-    if "args" in params:
-        try:
-            params["args"] = json.loads(params["args"])
-        except json.JSONDecodeError as e:
-            raise ValueError("Invalid JSON for 'args'") from e
+    # args parameter is now passed as a JSON string directly to the tool
     if "block" in params and params["block"].isdigit():
         params["block"] = int(params["block"])
     tool_response = await read_contract(**params, ctx=get_mock_context(request))

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -341,9 +341,7 @@ async def read_contract(
     # Early arity validation for clearer feedback
     abi_inputs = abi.get("inputs", [])
     if isinstance(abi_inputs, list) and len(py_args) != len(abi_inputs):
-        raise ValueError(
-            f"Argument count mismatch: expected {len(abi_inputs)} per ABI, got {len(py_args)}."
-        )
+        raise ValueError(f"Argument count mismatch: expected {len(abi_inputs)} per ABI, got {len(py_args)}.")
 
     # Normalize block if it is a decimal string
     if isinstance(block, str) and block.isdigit():

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -270,8 +270,9 @@ async def read_contract(
                 "A JSON string containing an array of arguments. "
                 'Example: "["0xabc..."]" for a single address argument, or "[]" for no arguments. '
                 "Order and types must match ABI inputs. Addresses: use 0x-prefixed strings; "
-                "Numbers: use integers (not quoted); Bytes: keep as 0x-hex strings. If no arguments, "
-                'pass "[]" or omit this field.'
+                'Numbers: prefer integers (not quoted); numeric strings like "1" are also '
+                "accepted and coerced to integers. "
+                'Bytes: keep as 0x-hex strings. If no arguments, pass "[]" or omit this field.'
             )
         ),
     ] = None,
@@ -325,7 +326,7 @@ async def read_contract(
     if args is not None:
         try:
             parsed = json.loads(args)
-        except Exception as exc:  # noqa: BLE001
+        except json.JSONDecodeError as exc:
             raise ValueError(
                 '`args` must be a JSON array string (e.g., "["0x..."]"). Received a string that is not valid JSON.'
             ) from exc

--- a/gpt/action_tool_descriptions.md
+++ b/gpt/action_tool_descriptions.md
@@ -75,7 +75,7 @@ To check the USDT balance of an address on Ethereum Mainnet, you would use the f
         "type": "function"
     },
     "function_name": "balanceOf",
-    "args": ["0xF977814e90dA44bFA03b6295A0616a897441aceC"]
+    "args": "[\"0xF977814e90dA44bFA03b6295A0616a897441aceC\"]"
     }
 }
 ```

--- a/gpt/openapi.yaml
+++ b/gpt/openapi.yaml
@@ -708,7 +708,7 @@ paths:
         - name: args
           in: query
           required: false
-          description: A JSON array of arguments. Order and types must match ABI inputs. For addresses use 0x-prefixed strings; For numbers use integers (not quoted); For bytes keep as 0x-hex strings.
+          description: A JSON string containing an array of arguments. Order and types must match ABI inputs. For addresses use 0x-prefixed strings; For numbers use integers (not quoted); For bytes keep as 0x-hex strings.
           schema:
             type: string
           example: "[\"0xF977814e90dA44bFA03b6295A0616a897441aceC\"]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.10.0.dev2"
+version = "0.10.0.dev3"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -364,6 +364,23 @@ async def test_read_contract_missing_param(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_read_contract_invalid_abi_json(client: AsyncClient):
+    url = "/v1/read_contract?chain_id=1&address=0xabc&abi=%7B&function_name=foo"
+    resp = await client.get(url)
+    assert resp.status_code == 400
+    assert "Invalid JSON for 'abi'" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_read_contract_invalid_args_json(client: AsyncClient):
+    # The tool validation fails and bubbles as 400 via decorator
+    url = "/v1/read_contract?chain_id=1&address=0xabc&abi=%7B%7D&function_name=foo&args=%5B"
+    resp = await client.get(url)
+    assert resp.status_code == 400
+    assert "must be a JSON array string" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
 @patch("blockscout_mcp_server.api.routes.get_address_info", new_callable=AsyncMock)
 async def test_get_address_info_success(mock_tool, client: AsyncClient):
     """Test /get_address_info endpoint."""

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -350,7 +350,7 @@ async def test_read_contract_with_optional(mock_tool, client: AsyncClient):
         address="0xabc",
         abi={},
         function_name="foo",
-        args=[1],
+        args="[1]",
         block=5,
         ctx=ANY,
     )

--- a/tests/tools/test_contract_tools.py
+++ b/tests/tools/test_contract_tools.py
@@ -319,7 +319,7 @@ async def test_read_contract_success(mock_ctx):
             address=address,
             abi=abi,
             function_name=function_name,
-            args=["1"],
+            args='["1"]',
             block="latest",
             ctx=mock_ctx,
         )

--- a/tests/tools/test_contract_tools.py
+++ b/tests/tools/test_contract_tools.py
@@ -445,7 +445,7 @@ async def test_read_contract_arity_mismatch(mock_ctx):
             address="0x0000000000000000000000000000000000000abc",
             abi={"name": "foo", "type": "function", "inputs": [{"type": "uint256"}], "outputs": []},
             function_name="foo",
-            args='[]',  # Empty args but ABI expects 1 input
+            args="[]",  # Empty args but ABI expects 1 input
             ctx=mock_ctx,
         )
     assert "Argument count mismatch: expected 1 per ABI, got 0" in str(exc_info.value)

--- a/tests/tools/test_contract_tools.py
+++ b/tests/tools/test_contract_tools.py
@@ -408,3 +408,29 @@ async def test_read_contract_default_args(mock_ctx):
     fn_mock.assert_called_once_with()
     fn_result.call.assert_awaited_once_with(block_identifier="latest")
     assert mock_ctx.report_progress.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_read_contract_invalid_args_json(mock_ctx):
+    with pytest.raises(ValueError):
+        await read_contract(
+            chain_id="1",
+            address="0x0000000000000000000000000000000000000abc",
+            abi={"name": "foo", "type": "function", "inputs": [], "outputs": []},
+            function_name="foo",
+            args="[",  # invalid JSON
+            ctx=mock_ctx,
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_contract_args_not_array(mock_ctx):
+    with pytest.raises(ValueError):
+        await read_contract(
+            chain_id="1",
+            address="0x0000000000000000000000000000000000000abc",
+            abi={"name": "foo", "type": "function", "inputs": [], "outputs": []},
+            function_name="foo",
+            args='{"x":1}',  # JSON object instead of array
+            ctx=mock_ctx,
+        )


### PR DESCRIPTION
Closes #222 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Contract-read endpoint now expects arguments as a JSON-encoded string (string containing a JSON array) and forwards that raw string to the contract call flow.

- Bug Fixes
  - Improved validation and clearer error responses for invalid JSON, non-array args, and argument-count mismatches; negative and large integers are handled correctly.

- Documentation
  - Examples and API docs updated to show args as a string-encoded JSON array and usage notes.

- Tests
  - Unit and integration tests updated to use JSON-string args and cover new validation cases.

- Chores
  - Version bumped to 0.10.0.dev3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->