### PR TITLE
fix: default args string for read_contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Refer to [TESTING.md](TESTING.md) for comprehensive instructions on running both
 14. `get_block_info(chain_id, number_or_hash, include_transactions=False)` - Returns block information including timestamp, gas used, burnt fees, and transaction count. Can optionally include a list of transaction hashes.
 15. `get_transaction_info(chain_id, hash, include_raw_input=False)` - Gets comprehensive transaction information with decoded input parameters and detailed token transfers.
 16. `get_transaction_logs(chain_id, hash, cursor=None)` - Returns transaction logs with decoded event data.
-17. `read_contract(chain_id, address, abi, function_name, args=None, block='latest')` - Executes a read-only smart contract function and returns its result. The `abi` argument is a JSON object describing the specific function's signature.
+17. `read_contract(chain_id, address, abi, function_name, args='[]', block='latest')` - Executes a read-only smart contract function and returns its result. The `abi` argument is a JSON object describing the specific function's signature.
 18. `direct_api_call(chain_id, endpoint_path, query_params=None, cursor=None)` - Calls a curated raw Blockscout API endpoint for specialized or chain-specific data.
 
 ## Example Prompts for AI Agents

--- a/SPEC.md
+++ b/SPEC.md
@@ -579,7 +579,7 @@ This server exposes a tool for on-chain smart contract read-only state access. I
 - **Implementation**: Uses Web3.py for ABI-based input encoding and output decoding. This leverages Web3's well-tested argument handling and return value decoding.
 - **ABI requirement**: Accepts the ABI of the specific function variant to call (a single ABI object for that function signature). This avoids ambiguity when contracts overload function names.
 - **Function name**: The `function_name` parameter must match the `name` field in the provided function ABI. Although redundant, it is kept intentionally to improve LLM tool-selection behavior and may be removed later.
-- **Arguments**: The `args` parameter is a JSON string containing an array of arguments. Nested structures and complex ABIv2 types are supported (arrays, tuples, structs). Argument normalization rules:
+- **Arguments**: The `args` parameter is a JSON string containing an array of arguments, defaulting to `[]` when omitted. Nested structures and complex ABIv2 types are supported (arrays, tuples, structs). Argument normalization rules:
   - Addresses can be provided as 0x-prefixed strings; the tool normalizes and applies EIP-55 checksum internally.
   - Numeric strings are coerced to integers.
   - Bytes values should be provided as 0x-hex strings; nested hex strings are handled.

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -274,7 +274,7 @@ async def read_contract(
                 "Order and types must match ABI inputs. Addresses: use 0x-prefixed strings; "
                 'Numbers: prefer integers (not quoted); numeric strings like "1" are also '
                 "accepted and coerced to integers. "
-                'Bytes: keep as 0x-hex strings. If omitted, defaults to "[]".'
+                "Bytes: keep as 0x-hex strings."
             )
         ),
     ] = "[]",
@@ -294,8 +294,7 @@ async def read_contract(
         Calls a smart contract function (view/pure, or non-view/pure simulated via eth_call) and returns the
         decoded result.
 
-        This tool provides a direct way to query the state of a smart contract. The `args`
-        parameter defaults to "[]" when omitted.
+        This tool provides a direct way to query the state of a smart contract.
 
         Example:
         To check the USDT balance of an address on Ethereum Mainnet, you would use the following arguments:

--- a/blockscout_mcp_server/tools/contract_tools.py
+++ b/blockscout_mcp_server/tools/contract_tools.py
@@ -325,14 +325,17 @@ async def read_contract(
     )
 
     # Parse args from JSON string
+    args_str = args.strip()
+    if args_str == "":
+        args_str = "[]"
     try:
-        parsed = json.loads(args)
+        parsed = json.loads(args_str)
     except json.JSONDecodeError as exc:
         raise ValueError(
             '`args` must be a JSON array string (e.g., "["0x..."]"). Received a string that is not valid JSON.'
         ) from exc
     if not isinstance(parsed, list):
-        raise ValueError("`args` must be a JSON array string, not a JSON object or scalar.")
+        raise ValueError(f"`args` must be a JSON array string representing a list; got {type(parsed).__name__}.")
     py_args = _convert_json_args(parsed)
 
     # Early arity validation for clearer feedback


### PR DESCRIPTION
Closes #224

## Summary
- fix read_contract to treat args as JSON string with default []

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest tests/tools/test_contract_tools.py`
- `pytest`
- `pytest -m integration` *(fails: Cannot connect to host eth.blockscout.com:443 ssl:default [Network is unreachable])*

------
https://chatgpt.com/codex/tasks/task_b_68b0ec41106c8323a35c45f806803b1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Contract-read args now must be a JSON array string, defaulting to "[]"; parsing and validation are consistent and unconditional.

- Documentation
  - README and spec updated: args default to [], normalization now recurses into nested lists/dicts; bytes remain 0x-hex and addresses/numerics normalization clarified.

- Tests
  - Added tests for whitespace-only args and stricter invalid-JSON/non-array error assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->