### PR TITLE
Gemini CLI slash commands set extended

### DIFF
--- a/.gemini/commands/codealive/chat.toml
+++ b/.gemini/commands/codealive/chat.toml
@@ -8,3 +8,7 @@ debug: false
 
 Return only the assistant’s final text.
 """
+
+[[params]]
+name = "question"
+description = "The question to ask the CodeAlive MCP server."

--- a/.gemini/commands/codealive/find.toml
+++ b/.gemini/commands/codealive/find.toml
@@ -7,7 +7,7 @@ data_source_ids: ["YOUR_DATA_SOURCE_ID_HERE"]  # Use the tool `get_data_sources`
 mode: "{{mode}}"
 include_content: false
 
-Return the search results showing file locations and code snippets.
+Return the search results showing file locations only.
 """
 
 [[params]]

--- a/.gemini/commands/codealive/find.toml
+++ b/.gemini/commands/codealive/find.toml
@@ -1,0 +1,19 @@
+description = "Search for files with the CodeAlive MCP server."
+prompt = """
+Use the CodeAlive MCP tool search_code to find files that could be relevant to the question. Call it with:
+
+query: "{{question}}"
+data_source_ids: ["YOUR_DATA_SOURCE_ID_HERE"]  # Use the tool `get_data_sources` to get the data source ID
+mode: "{{mode}}"
+include_content: false
+
+Return the search results showing file locations and code snippets.
+"""
+
+[[params]]
+name = "question"
+description = "The search query - can be natural language or code patterns (e.g., 'find reporting logic' or 'function read_contract')."
+
+[[params]]
+name = "mode"
+description = "Search mode: 'auto' (recommended), 'fast', 'fast_deeper', or 'deep'."

--- a/.gemini/commands/codealive/search.toml
+++ b/.gemini/commands/codealive/search.toml
@@ -1,0 +1,19 @@
+description = "Search for code snippets using the CodeAlive MCP server."
+prompt = """
+Use the CodeAlive MCP tool search_code to find code snippets. Call it with:
+
+query: "{{question}}"
+data_source_ids: ["YOUR_DATA_SOURCE_ID_HERE"]  # Use the tool `get_data_sources` to get the data source ID
+mode: "{{mode}}"
+include_content: true
+
+Return the search results showing file locations and code snippets.
+"""
+
+[[params]]
+name = "question"
+description = "The search query - can be natural language or code patterns (e.g., 'find reporting logic' or 'function read_contract')."
+
+[[params]]
+name = "mode"
+description = "Search mode: 'auto' (recommended), 'fast', 'fast_deeper', or 'deep'."

--- a/.gemini/commands/gh/issue.toml
+++ b/.gemini/commands/gh/issue.toml
@@ -1,5 +1,5 @@
 description = "Create a GitHub issue description."
-prompt = "Prepare a GitHub issue description. Your sole and exclusive output must be a single, well-structured Markdown document in {{.file}}"
+prompt = "Prepare a GitHub issue description. Your sole and exclusive output must be a single, well-structured Markdown document in `temp/gh_issues/{{.file}}`"
 
 [[params]]
 name = "file"

--- a/.gemini/commands/plan/pre.toml
+++ b/.gemini/commands/plan/pre.toml
@@ -1,0 +1,6 @@
+description = "Describes high level changes."
+prompt = """
+Describe very high level changes required to implement discussed functionality (functionality, test, docs).
+
+Only provide the description of the changes. Don't provide any code changes yet.
+"""


### PR DESCRIPTION
1. [Two new new slash commands `/codealive:find` and `/codealive:search` for easier communication with the CodeAlive MCP server](https://github.com/blockscout/mcp-server/commit/c1a836a675f7ad621ccfaf55bebb67876e0bc713)
2. [Added missed params part for existing `/codealive:chat` command](https://github.com/blockscout/mcp-server/commit/41bf5fade9092af12af4249159561aca7a68dd04)
3. [The new slash command `/plan:pre` to prepare high level plans](https://github.com/blockscout/mcp-server/commit/f4de5cdbdb51258bbfa13753c442c930c829f424)
4. [The slash command `/gh:issue` is simplified to specify an output file for a GitHub issue description](https://github.com/blockscout/mcp-server/commit/12a4f2ed84f41f5f83b2410a4b6455975bb15c89)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added CodeAlive search and find commands to locate code snippets and files by query, with selectable search modes.
  - Added a planning command to generate high-level change outlines (functionality, tests, docs) without code.

- Enhancements
  - Exposed a “question” input for the CodeAlive chat command to clarify queries.
  - Adjusted GitHub issue output path handling for more predictable file placement.

- Chores
  - Added guidance to obtain data source IDs when configuring CodeAlive searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->