### PR TITLE
Add standard tool annotations metadata

### DIFF
--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -106,7 +106,7 @@ When adding a new tool to the MCP server, you need to modify these files:
 3. **Register the tool in `blockscout_mcp_server/server.py`**:
    - Import the tool function
    - Register it with the MCP server using the `@mcp.tool()` decorator
-   - [ ] **Apply standard annotations**: In the `mcp.tool()` call, use the `create_tool_annotations()` helper function to generate the `annotations` object, passing the tool's human-readable title.
+   - In the `mcp.tool()` call, use the `create_tool_annotations()` helper function to generate the `annotations` object, passing the tool's human-readable title.
 
 4. **Update documentation in `AGENTS.md`**:
    - If you created a new module, add it to the project structure file listing

--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -106,6 +106,7 @@ When adding a new tool to the MCP server, you need to modify these files:
 3. **Register the tool in `blockscout_mcp_server/server.py`**:
    - Import the tool function
    - Register it with the MCP server using the `@mcp.tool()` decorator
+   - [ ] **Apply standard annotations**: In the `mcp.tool()` call, use the `create_tool_annotations()` helper function to generate the `annotations` object, passing the tool's human-readable title.
 
 4. **Update documentation in `AGENTS.md`**:
    - If you created a new module, add it to the project structure file listing

--- a/SPEC.md
+++ b/SPEC.md
@@ -417,6 +417,10 @@ This architecture provides the flexibility of a multi-protocol server without th
 
    This keeps API semantics intact, avoids masking persistent upstream problems, and improves reliability for both MCP tools and the REST API endpoints that proxy through the same business logic.
 
+10. **Standardized Tool Annotations**:
+
+    To ensure consistent behavior reporting and provide a better user experience, all MCP tools are registered with a `ToolAnnotations` object. This metadata, generated via a helper function in `blockscout_mcp_server/server.py`, serves two functions: it provides a clean, human-readable `title` for each tool, and it explicitly signals to clients that the tools are `readOnlyHint=True` (they do not modify the local environment), `destructiveHint=False`, and `openWorldHint=True` (they interact with external, dynamic APIs). This convention provides clear, uniform metadata for all tools.
+
 ### Instructions Delivery and the `__unlock_blockchain_analysis__` Tool
 
 #### The Initial Problem: Bypassed Server Instructions

--- a/SPEC.md
+++ b/SPEC.md
@@ -419,7 +419,7 @@ This architecture provides the flexibility of a multi-protocol server without th
 
 10. **Standardized Tool Annotations**:
 
-    To ensure consistent behavior reporting and provide a better user experience, all MCP tools are registered with a `ToolAnnotations` object. This metadata, generated via a helper function in `blockscout_mcp_server/server.py`, serves two functions: it provides a clean, human-readable `title` for each tool, and it explicitly signals to clients that the tools are `readOnlyHint=True` (they do not modify the local environment), `destructiveHint=False`, and `openWorldHint=True` (they interact with external, dynamic APIs). This convention provides clear, uniform metadata for all tools.
+    To ensure consistent behavior reporting and provide a better user experience, all MCP tools are registered with a `ToolAnnotations` object. This metadata, generated via a helper function in `blockscout_mcp_server/server.py`, serves two functions: it provides a clean, human-readable `title` for each tool, and it explicitly signals to clients that the tools are `readOnlyHint=True` (they do not modify the local environment), `destructiveHint=False`, and `openWorldHint=True` (they interact with external, dynamic APIs). This convention provides clear, uniform metadata for all tools. More about annotations for MCP tools is in [the MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations).
 
 ### Instructions Delivery and the `__unlock_blockchain_analysis__` Tool
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -4,6 +4,7 @@ from typing import Annotated
 import typer
 import uvicorn
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from starlette.middleware.cors import CORSMiddleware
 
 from blockscout_mcp_server import analytics
@@ -116,6 +117,18 @@ Here is the list of IDs of most popular chains:
 </direct_call_endpoint_list>
 """
 
+
+def create_tool_annotations(title: str) -> ToolAnnotations:
+    """Creates a standard ToolAnnotations object with a given title."""
+
+    return ToolAnnotations(
+        title=title,
+        readOnlyHint=True,
+        destructiveHint=False,
+        openWorldHint=True,
+    )
+
+
 mcp = FastMCP(name=SERVER_NAME, instructions=composed_instructions)
 
 
@@ -124,24 +137,78 @@ mcp = FastMCP(name=SERVER_NAME, instructions=composed_instructions)
 # The description will be taken from the function's docstring
 # The arguments (name, type, description) will be inferred from type hints
 # TODO: structured_output is disabled for all tools so far to preserve the LLM context since it adds to the `list/tools` response ~20K tokens.  # noqa: E501
-mcp.tool(structured_output=False)(__unlock_blockchain_analysis__)
-mcp.tool(structured_output=False)(get_block_info)
-mcp.tool(structured_output=False)(get_latest_block)
-mcp.tool(structured_output=False)(get_address_by_ens_name)
-mcp.tool(structured_output=False)(get_transactions_by_address)
-mcp.tool(structured_output=False)(get_token_transfers_by_address)
-mcp.tool(structured_output=False)(lookup_token_by_symbol)
-mcp.tool(structured_output=False)(get_contract_abi)
-mcp.tool(structured_output=False)(inspect_contract_code)
-mcp.tool(structured_output=False)(read_contract)
-mcp.tool(structured_output=False)(get_address_info)
-mcp.tool(structured_output=False)(get_tokens_by_address)
-mcp.tool(structured_output=False)(transaction_summary)
-mcp.tool(structured_output=False)(nft_tokens_by_address)
-mcp.tool(structured_output=False)(get_transaction_info)
-mcp.tool(structured_output=False)(get_transaction_logs)
-mcp.tool(structured_output=False)(get_chains_list)
-mcp.tool(structured_output=False)(direct_api_call)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Unlock Blockchain Analysis"),
+)(__unlock_blockchain_analysis__)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Block Information"),
+)(get_block_info)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Latest Block"),
+)(get_latest_block)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Address by ENS Name"),
+)(get_address_by_ens_name)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Transactions by Address"),
+)(get_transactions_by_address)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Token Transfers by Address"),
+)(get_token_transfers_by_address)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Lookup Token by Symbol"),
+)(lookup_token_by_symbol)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Contract ABI"),
+)(get_contract_abi)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Inspect Contract Code"),
+)(inspect_contract_code)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Read from Contract"),
+)(read_contract)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Address Information"),
+)(get_address_info)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Tokens by Address"),
+)(get_tokens_by_address)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Transaction Summary"),
+)(transaction_summary)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get NFT Tokens by Address"),
+)(nft_tokens_by_address)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Transaction Information"),
+)(get_transaction_info)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get Transaction Logs"),
+)(get_transaction_logs)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Get List of Chains"),
+)(get_chains_list)
+mcp.tool(
+    structured_output=False,
+    annotations=create_tool_annotations("Direct Blockscout API Call"),
+)(direct_api_call)
 
 
 # Initialize logging and override the rich formatter defined in the FastMCP


### PR DESCRIPTION
## Summary
- add a `create_tool_annotations` helper and annotate every registered tool with consistent metadata
- document the new annotations convention in SPEC.md and the new tool checklist

## Testing
- pytest

Closes #242

------
https://chatgpt.com/codex/tasks/task_b_68ce124211208323bc5e09284d6b052f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standardized tool metadata across tools, adding per-tool human-readable titles and safety hints (read-only, destructive, open-world) to improve client display and signaling without changing behavior.

- **Documentation**
  - Added and expanded a section describing standardized tool annotations (appears multiple times) and guidance on initialization, progress reporting, observability, and analytics.

- **Chores**
  - Updated internal checklist and registration flow to apply standardized annotations during tool registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->