### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/API.md
+++ b/API.md
@@ -536,7 +536,7 @@ Receive an anonymous tool usage report from a community-run server.
 
 ```bash
 curl -X POST "http://127.0.0.1:8000/v1/report_tool_usage" \\
-  -H "User-Agent: BlockscoutMCP/0.11.0.dev0" \\
+  -H "User-Agent: BlockscoutMCP/0.11.0" \\
   -H "Content-Type: application/json" \\
   -d '{"tool_name": "get_latest_block", "tool_args": {"chain_id": "1"}, "client_name": "test-client", "client_version": "1.2.3", "protocol_version": "2024-11-05"}'
 ```

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.11.0.dev2"
+__version__ = "0.11.0"

--- a/gpt/openapi.yaml
+++ b/gpt/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Blockscout MCP Server REST API
   description: |
     A web-friendly, stateless interface to powerful blockchain tools providing access to 50+ EVM-compatible blockchains.
-  version: 0.11.0.dev0
+  version: 0.11.0
   contact:
     name: Blockscout MCP Server
     url: https://github.com/blockscout/mcp-server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.11.0.dev2"
+version = "0.11.0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "status": "active",
   "websiteUrl": "https://blockscout.com",
   "repository": {


### PR DESCRIPTION
## Summary
- update the project metadata to the 0.11.0 release in pyproject and the package initializer
- align server.json, OpenAPI metadata, and API docs with the 0.11.0 version string

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d4787865608323ab2c51849de606c8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Released version 0.11.0 across the package, API spec, and server metadata for a stable, non-dev release.
  * Synchronized version identifiers to ensure clients and tooling reflect the latest stable release.

* Documentation
  * Updated the User-Agent value in examples to “BlockscoutMCP/0.11.0” for consistency with the new release.

No functional or behavioral changes; this update aligns metadata and documentation with the 0.11.0 stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->