### PR TITLE
Handle null total supply in token search results

### DIFF
--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -180,7 +180,7 @@ class TokenSearchResult(BaseModel):
     name: str = Field(description="The full name of the token (e.g., 'USD Coin').")
     symbol: str = Field(description="The symbol of the token (e.g., 'USDC').")
     token_type: str = Field(description="The token standard (e.g., 'ERC-20').")
-    total_supply: str = Field(description="The total supply of the token.")
+    total_supply: str | None = Field(description="The total supply of the token.")
     circulating_market_cap: str | None = Field(description="The circulating market cap, if available.")
     exchange_rate: str | None = Field(description="The current exchange rate, if available.")
     is_smart_contract_verified: bool = Field(description="Indicates if the token's contract is verified.")

--- a/blockscout_mcp_server/tools/search/lookup_token_by_symbol.py
+++ b/blockscout_mcp_server/tools/search/lookup_token_by_symbol.py
@@ -74,7 +74,7 @@ async def lookup_token_by_symbol(
             name=item.get("name", ""),
             symbol=item.get("symbol", ""),
             token_type=item.get("token_type", ""),
-            total_supply=item.get("total_supply", ""),
+            total_supply=item.get("total_supply"),
             circulating_market_cap=item.get("circulating_market_cap"),
             exchange_rate=item.get("exchange_rate"),
             is_smart_contract_verified=item.get("is_smart_contract_verified", False),

--- a/tests/integration/search/test_lookup_token_by_symbol_real.py
+++ b/tests/integration/search/test_lookup_token_by_symbol_real.py
@@ -19,6 +19,7 @@ async def test_lookup_token_by_symbol_integration(mock_ctx):
         assert isinstance(result.data[0], TokenSearchResult)
         assert result.data[0].address.startswith("0x")
         assert isinstance(result.data[0].name, str)
+        assert isinstance(result.data[0].total_supply, str | type(None))
 
     if len(result.data) < TOKEN_RESULTS_LIMIT:
         assert result.notes is None


### PR DESCRIPTION
## Summary
- make the TokenSearchResult.total_supply field optional so Blockscout responses with null totals validate
- pass through total_supply values as-is when building lookup_token_by_symbol results
- add regression coverage for null totals in unit and integration tests

## Testing
- pytest tests/tools/search/test_lookup_token_by_symbol.py
- pytest -m integration tests/integration/search/test_lookup_token_by_symbol_real.py
- pytest
- ruff check . --fix
- ruff format .

------
https://chatgpt.com/codex/tasks/task_b_68eff4299e288323b09418ead6786854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token search results now return total supply as null when unavailable, instead of an empty string, improving data accuracy and avoiding misleading empty values. Other fields and search behavior remain unchanged. This may affect clients that assumed a non-null string.

* **Tests**
  * Expanded unit and integration tests to validate that total supply can be null and that None values propagate correctly through token lookup responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->