### PR TITLE
Fix tool JSON Schemas for strict validators

### DIFF
--- a/blockscout_mcp_server/tools/contract/read_contract.py
+++ b/blockscout_mcp_server/tools/contract/read_contract.py
@@ -53,7 +53,11 @@ async def read_contract(
                 "The JSON ABI for the specific function being called. This should be "
                 "a dictionary that defines the function's name, inputs, and outputs. "
                 "The function ABI can be obtained using the `get_contract_abi` tool."
-            )
+            ),
+            # Some MCP clients/providers reject any JSON Schema object node that omits
+            # "properties", even when "additionalProperties" is used for dict-like
+            # objects. Including an empty "properties" keeps such clients happy.
+            json_schema_extra={"properties": {}},
         ),
     ],
     function_name: Annotated[

--- a/blockscout_mcp_server/tools/direct_api/direct_api_call.py
+++ b/blockscout_mcp_server/tools/direct_api/direct_api_call.py
@@ -28,9 +28,15 @@ async def direct_api_call(
     ],
     ctx: Context,
     query_params: Annotated[
-        dict[str, Any] | None,
-        Field(description="Optional query parameters forwarded to the Blockscout API."),
-    ] = None,
+        dict[str, Any],
+        Field(
+            description="Optional query parameters forwarded to the Blockscout API.",
+            # Some MCP clients/providers reject any JSON Schema object node that omits
+            # "properties", even when "additionalProperties" is used for dict-like
+            # objects. Including an empty "properties" keeps such clients happy.
+            json_schema_extra={"properties": {}},
+        ),
+    ] = {},
     cursor: Annotated[
         str | None,
         Field(description="The pagination cursor from a previous response to get the next page of results."),
@@ -74,7 +80,7 @@ async def direct_api_call(
 
     handler_response = await dispatcher.dispatch(
         endpoint_path=endpoint_path,
-        query_params=query_params,
+        query_params=query_params or None,
         response_json=response_json,
         chain_id=chain_id,
         base_url=base_url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ version = "0.11.0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [
-    # Pinned to 1.11.0 – newer (≥1.12.0) versions break HTTP Streamable mode (see PR #174)
-    "mcp[cli]==1.13.1",
+    "mcp[cli]==1.24.0",
     "httpx>=0.27.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/tests/test_tool_schemas_jsonschema.py
+++ b/tests/test_tool_schemas_jsonschema.py
@@ -1,0 +1,53 @@
+"""Regression tests for MCP tool JSON Schemas.
+
+Some MCP clients/providers perform strict JSON Schema validation and reject any
+schema node with {"type": "object"} that omits the "properties" key, even when
+"additionalProperties" is used to model dict-like objects.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+
+def _iter_object_schema_nodes(schema: object, path: str = "$") -> Iterable[tuple[str, dict]]:
+    """Yield (path, node) for any dict node that represents a JSON Schema object."""
+    if isinstance(schema, dict):
+        yield path, schema
+        for key, value in schema.items():
+            if isinstance(value, (dict, list)):
+                yield from _iter_object_schema_nodes(value, f"{path}.{key}")
+    elif isinstance(schema, list):
+        for idx, item in enumerate(schema):
+            if isinstance(item, (dict, list)):
+                yield from _iter_object_schema_nodes(item, f"{path}[{idx}]")
+
+
+@pytest.mark.asyncio
+async def test_all_tool_schemas_include_properties_for_object_nodes():
+    """Ensure strict clients don't reject our tool schemas.
+
+    Rule enforced: any schema node with {"type": "object"} must include a
+    "properties" key (it may be {}).
+    """
+    from blockscout_mcp_server.server import mcp
+
+    tools = await mcp.list_tools()
+    failures: list[str] = []
+
+    for tool in tools:
+        tool_dict = tool.model_dump()
+        for schema_key in ("inputSchema", "outputSchema"):
+            schema = tool_dict.get(schema_key)
+            if not isinstance(schema, dict):
+                continue
+
+            for node_path, node in _iter_object_schema_nodes(schema, path=f"{tool_dict.get('name')}:{schema_key}"):
+                if node.get("type") == "object" and "properties" not in node:
+                    failures.append(f"{node_path} is object schema missing properties: {node}")
+
+    assert failures == []
+
+


### PR DESCRIPTION
Fixes strict tool schema validation failures (object schema missing properties). Adds regression test and bumps mcp[cli] to 1.24.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated MCP dependency from 1.13.1 to 1.24.0.

* **Bug Fixes**
  * Enhanced JSON schema compatibility for contract read and direct API operations to ensure proper validation across MCP clients.

* **Tests**
  * Added regression tests to validate schema structures across tool interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->