### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.12.0.dev1"
+__version__ = "0.12.0"

--- a/blockscout_mcp_server/analytics.py
+++ b/blockscout_mcp_server/analytics.py
@@ -225,14 +225,6 @@ def track_tool_invocation(
             "source": _determine_call_source(ctx),
         }
 
-        # TODO: Remove this log after validating Mixpanel analytics end-to-end
-        logger.info(
-            "Mixpanel event prepared: distinct_id=%s tool=%s properties=%s",
-            distinct_id,
-            tool_name,
-            properties,
-        )
-
         meta = {"ip": ip} if ip else None
         # Mixpanel Python SDK allows meta for IP geolocation mapping
         if meta is not None:

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -4,8 +4,7 @@ from blockscout_mcp_server import __version__
 
 SERVER_VERSION = __version__
 
-# TODO: replace with official MCP server before the final 0.11.0 release
-COMMUNITY_TELEMETRY_URL = "https://mcp.k8s-dev.blockscout.com"
+COMMUNITY_TELEMETRY_URL = "https://mcp.blockscout.com"
 COMMUNITY_TELEMETRY_ENDPOINT = "/v1/report_tool_usage"
 
 ERROR_HANDLING_RULES = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.12.0.dev1"
+version = "0.12.0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.12.0.dev1",
+  "version": "0.12.0",
   "status": "active",
   "websiteUrl": "https://blockscout.com",
   "repository": {


### PR DESCRIPTION
### Motivation
- Remove a temporary debug/info log used during Mixpanel validation and switch community telemetry to the official MCP endpoint while releasing a new patch version.

### Description
- Remove the temporary `logger.info` Mixpanel preparation log from `blockscout_mcp_server/analytics.py` to avoid noisy telemetry logs.
- Update `COMMUNITY_TELEMETRY_URL` to the official endpoint `https://mcp.blockscout.com` in `blockscout_mcp_server/constants.py`.
- Bump the MCP server version to `0.12.0` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`.

### Testing
- Ran `ruff check . --fix` and it completed successfully with no remaining issues.
- Ran `ruff format .` which left files unchanged where formatting was already compliant.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69690a09f36083238a84816fbab30dec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version released as 0.12.0 (stable)
  * Analytics endpoint switched to production configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->