### PR TITLE
Fix MCP Registry publishing by updating to latest schema

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
           chmod +x mcp-publisher # Make it executable
 
       - name: Login to MCP Registry (DNS)

--- a/MCP-REGISTRY-README.md
+++ b/MCP-REGISTRY-README.md
@@ -21,7 +21,6 @@ The `server.json` file is the core configuration file for publishing your MCP se
 
 * **Version:** The current version of your server, aligning with your project's version.
     *Note: Ensure this version matches the `version` specified in `pyproject.toml` and `blockscout_mcp_server/__init__.py` to maintain consistency across the project and the registry.*
-* **Status:** The operational status of your server (e.g., `active`).
 * **Website URL:** The official website for your project.
 * **Repository:** Information about your project's source code repository.
 * **Remotes:** Details about how to connect to your server, including the transport type and URL.
@@ -32,7 +31,26 @@ For the Blockscout MCP Server, the `server.json` is configured to point to the o
 
 For the most up-to-date and comprehensive instructions on publishing an MCP server, please refer to the official MCP Registry documentation:
 
-[Publishing an MCP Server](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md)
+[Quickstart: Publish an MCP Server](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx)
+
+## Verifying DNS Configuration
+
+Before publishing, you can verify that the DNS TXT record for `blockscout.com` contains the MCP authentication public key:
+
+```bash
+curl -s "https://dns.google/resolve?name=blockscout.com&type=TXT" | jq '.Answer[] | select(.data | contains("MCPv1"))'
+```
+
+The output should show a record like:
+
+```json
+{
+  "name": "blockscout.com.",
+  "type": 16,
+  "TTL": 300,
+  "data": "v=MCPv1; k=ed25519; p=<PUBLIC_KEY>"
+}
+```
 
 ## Manual Publishing Steps
 
@@ -41,7 +59,7 @@ While the primary method for publishing new server versions is through GitHub Ac
 1. **Install `mcp-publisher` CLI:**
 
     ```bash
-    curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
+    curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
     ```
 
 2. **Login to the Registry with DNS Ownership Proof:**

--- a/server.json
+++ b/server.json
@@ -1,9 +1,8 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
   "version": "0.12.0",
-  "status": "active",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",


### PR DESCRIPTION
### Summary
- Update `server.json` schema from `2025-09-16` to `2025-12-11` and remove deprecated `status` field
- Update `mcp-publisher` installation to use latest release instead of hardcoded `v1.0.0`
- Add DNS verification command to documentation

### Problem
MCP Registry publishing failed with error:
```
validation failed: "unexpected property" at "body.status"
```

The MCP Registry updated their schema and the `status` field is no longer supported.

### Changes
- **server.json**: Updated schema version, removed `status` field
- **.github/workflows/mcp-registry.yml**: Use `latest` release for `mcp-publisher`
- **MCP-REGISTRY-README.md**: Updated documentation link, added DNS verification section, removed `status` field reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DNS verification section to publishing guide
  * Updated publishing instructions with streamlined MCP Publisher versioning process
  * Clarified DNS ownership verification steps

* **Updates**
  * Updated server configuration schema to latest version
  * Removed deprecated status field from server metadata

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->