### PR TITLE
Remove redundant HTTP error handling in integration tests

### DIFF
--- a/tests/integration/contract/test_inspect_contract_code_real.py
+++ b/tests/integration/contract/test_inspect_contract_code_real.py
@@ -1,5 +1,4 @@
 import aiohttp
-import httpx
 import pytest
 
 from blockscout_mcp_server.tools.contract.inspect_contract_code import inspect_contract_code
@@ -19,7 +18,7 @@ async def test_inspect_vyper_contract(mock_ctx):
             lambda: inspect_contract_code(chain_id=CHAIN_ID_MAINNET, address=address, ctx=mock_ctx),
             action_description="inspect_contract_code vyper contract request",
         )
-    except (aiohttp.ClientError, httpx.HTTPError, OSError) as exc:
+    except (aiohttp.ClientError, OSError) as exc:
         pytest.skip(f"Network connectivity issue: {exc}")
 
     assert result.data.language.lower() == "vyper"
@@ -35,7 +34,7 @@ async def test_inspect_flattened_solidity_contract(mock_ctx):
             lambda: inspect_contract_code(chain_id=CHAIN_ID_MAINNET, address=address, ctx=mock_ctx),
             action_description="inspect_contract_code flattened solidity contract request",
         )
-    except (aiohttp.ClientError, httpx.HTTPError, OSError) as exc:
+    except (aiohttp.ClientError, OSError) as exc:
         pytest.skip(f"Network connectivity issue: {exc}")
 
     assert result.data.source_code_tree_structure == ["EternalStorageProxy.sol"]
@@ -50,7 +49,7 @@ async def test_inspect_multipart_stylus_contract(mock_ctx):
             lambda: inspect_contract_code(chain_id=CHAIN_ID_ARBITRUM, address=address, ctx=mock_ctx),
             action_description="inspect_contract_code stylus contract request",
         )
-    except (aiohttp.ClientError, httpx.HTTPError, OSError) as exc:
+    except (aiohttp.ClientError, OSError) as exc:
         pytest.skip(f"Network connectivity issue: {exc}")
 
     assert len(result.data.source_code_tree_structure) > 1
@@ -73,7 +72,7 @@ async def test_inspect_single_file_solidity_contract(mock_ctx):
             fetch_content,
             action_description="inspect_contract_code single-file contract request",
         )
-    except (aiohttp.ClientError, httpx.HTTPError, OSError) as exc:
+    except (aiohttp.ClientError, OSError) as exc:
         pytest.skip(f"Network connectivity issue: {exc}")
 
     assert "pragma solidity" in content.data.file_content
@@ -88,7 +87,7 @@ async def test_inspect_multipart_solidity_contract(mock_ctx):
             lambda: inspect_contract_code(chain_id=CHAIN_ID_MAINNET, address=address, ctx=mock_ctx),
             action_description="inspect_contract_code multipart solidity contract request",
         )
-    except (aiohttp.ClientError, httpx.HTTPError, OSError) as exc:
+    except (aiohttp.ClientError, OSError) as exc:
         pytest.skip(f"Network connectivity issue: {exc}")
 
     assert len(result.data.source_code_tree_structure) > 1
@@ -104,7 +103,7 @@ async def test_inspect_multipart_vyper_contract(mock_ctx):
             lambda: inspect_contract_code(chain_id=CHAIN_ID_SEPOLIA, address=address, ctx=mock_ctx),
             action_description="inspect_contract_code multipart vyper contract request",
         )
-    except (aiohttp.ClientError, httpx.HTTPError, OSError) as exc:
+    except (aiohttp.ClientError, OSError) as exc:
         pytest.skip(f"Network connectivity issue: {exc}")
 
     assert result.data.language.lower() == "vyper"
@@ -123,7 +122,7 @@ async def test_inspect_not_verified_contract(mock_ctx):
             lambda: inspect_contract_code(chain_id=CHAIN_ID_MAINNET, address=address, ctx=mock_ctx),
             action_description="inspect_contract_code unverified contract request",
         )
-    except (aiohttp.ClientError, httpx.HTTPError, OSError) as exc:
+    except (aiohttp.ClientError, OSError) as exc:
         pytest.skip(f"Network connectivity issue: {exc}")
 
     assert result.data.source_code_tree_structure == []

--- a/tests/integration/direct_api/test_address_logs_handler_real.py
+++ b/tests/integration/direct_api/test_address_logs_handler_real.py
@@ -1,4 +1,3 @@
-import httpx
 import pytest
 
 from blockscout_mcp_server.models import AddressLogItem, ToolResponse
@@ -11,13 +10,10 @@ from tests.integration.helpers import is_log_a_truncated_call_executed, retry_on
 async def test_direct_api_call_dispatches_to_logs_handler(mock_ctx):
     address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"  # USDC contract
     endpoint_path = f"/api/v2/addresses/{address}/logs"
-    try:
-        result = await retry_on_network_error(
-            lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
-            action_description="direct_api_call address logs request",
-        )
-    except httpx.HTTPError as exc:
-        pytest.fail(f"Live direct_api_call request failed for {endpoint_path}: {exc}")
+    result = await retry_on_network_error(
+        lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
+        action_description="direct_api_call address logs request",
+    )
 
     assert isinstance(result, ToolResponse)
     assert isinstance(result.data, list)
@@ -34,13 +30,10 @@ async def test_direct_api_call_pagination_integration(mock_ctx):
     chain_id = "1"
     endpoint_path = f"/api/v2/addresses/{address}/logs"
 
-    try:
-        first_page_result = await retry_on_network_error(
-            lambda: direct_api_call(chain_id=chain_id, endpoint_path=endpoint_path, ctx=mock_ctx),
-            action_description="direct_api_call logs first page request",
-        )
-    except httpx.HTTPStatusError as exc:
-        pytest.skip(f"API request failed, skipping pagination test: {exc}")
+    first_page_result = await retry_on_network_error(
+        lambda: direct_api_call(chain_id=chain_id, endpoint_path=endpoint_path, ctx=mock_ctx),
+        action_description="direct_api_call logs first page request",
+    )
 
     assert first_page_result.pagination is not None
     cursor = first_page_result.pagination.next_call.params.get("cursor")
@@ -49,18 +42,15 @@ async def test_direct_api_call_pagination_integration(mock_ctx):
     assert isinstance(first_page_result.data, list)
     assert len(first_page_result.data) > 0
 
-    try:
-        second_page_result = await retry_on_network_error(
-            lambda: direct_api_call(
-                chain_id=chain_id,
-                endpoint_path=endpoint_path,
-                cursor=cursor,
-                ctx=mock_ctx,
-            ),
-            action_description="direct_api_call logs second page request",
-        )
-    except httpx.HTTPStatusError as exc:
-        pytest.fail(f"API request for the second page failed with cursor: {exc}")
+    second_page_result = await retry_on_network_error(
+        lambda: direct_api_call(
+            chain_id=chain_id,
+            endpoint_path=endpoint_path,
+            cursor=cursor,
+            ctx=mock_ctx,
+        ),
+        action_description="direct_api_call logs second page request",
+    )
 
     assert isinstance(second_page_result.data, list)
     assert len(second_page_result.data) > 0
@@ -80,18 +70,15 @@ async def test_direct_api_call_paginated_search_for_truncation(mock_ctx):
     found_truncated_log = False
 
     for page_num in range(max_pages_to_check):
-        try:
-            result = await retry_on_network_error(
-                lambda: direct_api_call(
-                    chain_id=chain_id,
-                    endpoint_path=endpoint_path,
-                    cursor=cursor,
-                    ctx=mock_ctx,
-                ),
-                action_description=f"direct_api_call logs page {page_num + 1} request",
-            )
-        except httpx.HTTPStatusError as exc:
-            pytest.skip(f"API request failed on page {page_num + 1}: {exc}")
+        result = await retry_on_network_error(
+            lambda: direct_api_call(
+                chain_id=chain_id,
+                endpoint_path=endpoint_path,
+                cursor=cursor,
+                ctx=mock_ctx,
+            ),
+            action_description=f"direct_api_call logs page {page_num + 1} request",
+        )
 
         if any(is_log_a_truncated_call_executed(item) for item in result.data):
             found_truncated_log = True

--- a/tests/integration/direct_api/test_transaction_logs_handler_real.py
+++ b/tests/integration/direct_api/test_transaction_logs_handler_real.py
@@ -1,4 +1,3 @@
-import httpx
 import pytest
 
 from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT
@@ -14,13 +13,10 @@ async def test_direct_api_call_transaction_logs_integration(mock_ctx):
     tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
     endpoint_path = f"/api/v2/transactions/{tx_hash}/logs"
 
-    try:
-        result = await retry_on_network_error(
-            lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
-            action_description="direct_api_call transaction logs request",
-        )
-    except httpx.HTTPStatusError as exc:
-        pytest.skip(f"Transaction data is currently unavailable from the API: {exc}")
+    result = await retry_on_network_error(
+        lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
+        action_description="direct_api_call transaction logs request",
+    )
 
     assert isinstance(result, ToolResponse)
     assert result.pagination is not None
@@ -47,29 +43,23 @@ async def test_direct_api_call_transaction_logs_pagination(mock_ctx):
     tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
     endpoint_path = f"/api/v2/transactions/{tx_hash}/logs"
 
-    try:
-        first_page_response = await retry_on_network_error(
-            lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
-            action_description="direct_api_call transaction logs first page request",
-        )
-    except httpx.HTTPStatusError as exc:
-        pytest.skip(f"Transaction data is currently unavailable from the API: {exc}")
+    first_page_response = await retry_on_network_error(
+        lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
+        action_description="direct_api_call transaction logs first page request",
+    )
 
     assert first_page_response.pagination is not None
     cursor = first_page_response.pagination.next_call.params["cursor"]
 
-    try:
-        second_page_response = await retry_on_network_error(
-            lambda: direct_api_call(
-                chain_id="1",
-                endpoint_path=endpoint_path,
-                cursor=cursor,
-                ctx=mock_ctx,
-            ),
-            action_description="direct_api_call transaction logs second page request",
-        )
-    except httpx.HTTPStatusError as exc:
-        pytest.fail(f"Failed to fetch the second page of transaction logs due to an API error: {exc}")
+    second_page_response = await retry_on_network_error(
+        lambda: direct_api_call(
+            chain_id="1",
+            endpoint_path=endpoint_path,
+            cursor=cursor,
+            ctx=mock_ctx,
+        ),
+        action_description="direct_api_call transaction logs second page request",
+    )
 
     assert isinstance(second_page_response, ToolResponse)
     assert second_page_response.data
@@ -83,13 +73,10 @@ async def test_direct_api_call_transaction_logs_with_truncation(mock_ctx):
     tx_hash = "0xa519e3af3f07190727f490c599baf3e65ee335883d6f420b433f7b83f62cb64d"
     endpoint_path = f"/api/v2/transactions/{tx_hash}/logs"
 
-    try:
-        result = await retry_on_network_error(
-            lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
-            action_description="direct_api_call transaction logs truncation request",
-        )
-    except httpx.HTTPStatusError as exc:
-        pytest.skip(f"Transaction data is currently unavailable from the API: {exc}")
+    result = await retry_on_network_error(
+        lambda: direct_api_call(chain_id="1", endpoint_path=endpoint_path, ctx=mock_ctx),
+        action_description="direct_api_call transaction logs truncation request",
+    )
 
     assert result.notes is not None
     assert "One or more log items" in result.notes[0]
@@ -116,18 +103,15 @@ async def test_direct_api_call_transaction_logs_paginated_search_for_truncation(
     found_truncated_log = False
 
     for page_num in range(max_pages_to_check):
-        try:
-            result = await retry_on_network_error(
-                lambda: direct_api_call(
-                    chain_id="1",
-                    endpoint_path=endpoint_path,
-                    cursor=cursor,
-                    ctx=mock_ctx,
-                ),
-                action_description=f"direct_api_call transaction logs page {page_num + 1} request",
-            )
-        except httpx.HTTPStatusError as exc:
-            pytest.skip(f"API request failed on page {page_num + 1}: {exc}")
+        result = await retry_on_network_error(
+            lambda: direct_api_call(
+                chain_id="1",
+                endpoint_path=endpoint_path,
+                cursor=cursor,
+                ctx=mock_ctx,
+            ),
+            action_description=f"direct_api_call transaction logs page {page_num + 1} request",
+        )
 
         if any(is_log_a_truncated_call_executed(log) for log in result.data):
             found_truncated_log = True


### PR DESCRIPTION
### Motivation
- Integration tests were catching `httpx.HTTPStatusError` / `httpx.HTTPError` around calls to `retry_on_network_error`, duplicating retry/skip logic and producing inconsistent behavior (e.g., `pytest.fail()` vs `pytest.skip()`).
- The `retry_on_network_error` helper is the single source of truth for retries and skip decisions for transient network/5xx failures, so tests should not rewrap those errors.
- This change aligns tests with the integration testing guidelines (`.cursor/rules/220-integration-testing-guidelines.mdc`) and simplifies failure modes.

### Description
- Removed redundant `try/except` blocks that caught `httpx.HTTPStatusError`/`httpx.HTTPError` around `retry_on_network_error` calls in `tests/integration/direct_api/test_address_logs_handler_real.py` and `tests/integration/direct_api/test_transaction_logs_handler_real.py` and removed unused `httpx` imports.
- Narrowed exception tuples in `tests/integration/contract/test_inspect_contract_code_real.py` to exclude `httpx.HTTPError` while preserving `aiohttp.ClientError` and `OSError` so non-httpx network errors still skip the test.
- Updated `tests/integration/transaction/test_get_transaction_info_real.py` to (1) remove redundant exception handling, (2) use a live transaction that contains truncation, and (3) add a small `find_truncated_value` helper to locate truncated values in `decoded_input.parameters` instead of asserting a brittle path.
- All modified files: `tests/integration/transaction/test_get_transaction_info_real.py`, `tests/integration/direct_api/test_address_logs_handler_real.py`, `tests/integration/direct_api/test_transaction_logs_handler_real.py`, and `tests/integration/contract/test_inspect_contract_code_real.py`; also removed unused imports where applicable.
- Closes #299

### Testing
- Ran lint/format steps `ruff check . --fix` and `ruff format .` and verified `ruff check .` and `ruff format --check .` all passed with exit code 0.
- Ran the full unit test suite with `pytest` which completed with `395 passed, 74 deselected`.
- Ran the integration suite with `pytest -m integration -v` which completed with `55 passed, 19 skipped` and no unexpected failures.
- Confirmed formatting and linting remain clean after changes with `ruff check .` returning clean results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a5228d9a08323ac998565c645e7a0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined error handling in integration tests with consistent retry mechanisms
  * Removed conditional test skipping; tests now fail on unexpected errors
  * Enhanced test validation for detecting truncated transaction data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->