### PR TITLE
Fix Claude Code MCP URL (remove trailing slash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Visit [claude.com/connectors/blockscout](https://claude.com/connectors/blockscou
 To quickly install the Blockscout MCP server for use with Claude Code, run the following command in your terminal:
 
 ```sh
-claude mcp add --transport http blockscout https://mcp.blockscout.com/mcp/
+claude mcp add --transport http blockscout https://mcp.blockscout.com/mcp
 ```
 
 After running this command, Blockscout will be available as an MCP server in Claude Code, allowing you to access and analyze blockchain data directly from your coding environment.


### PR DESCRIPTION
### Motivation
- The Claude Code installation command in the docs used a trailing slash (`https://mcp.blockscout.com/mcp/`) which does not work with Claude Code, so the command needs to point to the correct URL without the trailing slash.

### Description
- Update `README.md` to change the Claude Code setup command from `claude mcp add --transport http blockscout https://mcp.blockscout.com/mcp/` to `claude mcp add --transport http blockscout https://mcp.blockscout.com/mcp`.

### Testing
- Ran `ruff check . --fix` and `ruff format .` and executed the test suite with `pytest`, and all checks/tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b6e22680483238d402cabdf7ae96f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed the Blockscout MCP server installation URL endpoint by removing the trailing slash to ensure proper server configuration when integrating with Claude Code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->