### PR TITLE
Add EvaluationSuite intermediary allowlist for eval traffic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ BLOCKSCOUT_DISABLE_COMMUNITY_TELEMETRY=false
 
 # Annotate MCP client name with an allowlisted intermediary when running in HTTP mode.
 BLOCKSCOUT_INTERMEDIARY_HEADER="Blockscout-MCP-Intermediary"
-BLOCKSCOUT_INTERMEDIARY_ALLOWLIST="ClaudeDesktop,HigressPlugin"
+BLOCKSCOUT_INTERMEDIARY_ALLOWLIST="ClaudeDesktop,HigressPlugin,EvaluationSuite"
 
 # The transport mode for the server. 
 # Options: "stdio" (default), "http".

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV BLOCKSCOUT_MCP_USER_AGENT="Blockscout MCP"
 ENV BLOCKSCOUT_MIXPANEL_API_HOST=""
 ENV BLOCKSCOUT_DISABLE_COMMUNITY_TELEMETRY="false"
 ENV BLOCKSCOUT_INTERMEDIARY_HEADER="Blockscout-MCP-Intermediary"
-ENV BLOCKSCOUT_INTERMEDIARY_ALLOWLIST="ClaudeDesktop,HigressPlugin"
+ENV BLOCKSCOUT_INTERMEDIARY_ALLOWLIST="ClaudeDesktop,HigressPlugin,EvaluationSuite"
 
 # Set the default transport mode. Can be overridden at runtime with -e.
 # Options: "stdio" (default), "http"

--- a/SPEC.md
+++ b/SPEC.md
@@ -698,7 +698,7 @@ If the client name cannot be determined from the MCP session parameters, the ser
 
 This provides a clear audit trail, helping to diagnose issues that may be specific to certain client versions or protocol implementations. For stateless calls, such as those from the REST API where no client is present, this information is gracefully omitted.
 
-In HTTP streamable mode, an allowlisted intermediary identifier can annotate the client name. The header name is configured via `BLOCKSCOUT_INTERMEDIARY_HEADER` (default: `Blockscout-MCP-Intermediary`) and allowed values via `BLOCKSCOUT_INTERMEDIARY_ALLOWLIST` (default: `ClaudeDesktop,HigressPlugin`). After trimming, collapsing whitespace, and validating length (≤16), the intermediary is appended to the base client name as `base/variant`. Invalid or disallowed values are ignored.
+In HTTP streamable mode, an allowlisted intermediary identifier can annotate the client name. The header name is configured via `BLOCKSCOUT_INTERMEDIARY_HEADER` (default: `Blockscout-MCP-Intermediary`) and allowed values via `BLOCKSCOUT_INTERMEDIARY_ALLOWLIST` (default: `ClaudeDesktop,HigressPlugin,EvaluationSuite`). After trimming, collapsing whitespace, and validating length (≤16), the intermediary is appended to the base client name as `base/variant`. Invalid or disallowed values are ignored.
 
 #### 3. Dual-Mode Analytics
 

--- a/blockscout_mcp_server/config.py
+++ b/blockscout_mcp_server/config.py
@@ -60,7 +60,7 @@ class ServerConfig(BaseSettings):
 
     # Composite client name configuration
     intermediary_header: str = "Blockscout-MCP-Intermediary"
-    intermediary_allowlist: str = "ClaudeDesktop,HigressPlugin"
+    intermediary_allowlist: str = "ClaudeDesktop,HigressPlugin,EvaluationSuite"
 
 
 config = ServerConfig()

--- a/tests/evals/.gemini/settings.json
+++ b/tests/evals/.gemini/settings.json
@@ -15,7 +15,10 @@
   "mcpServers": {
     "blockscout": {
       "httpUrl": "${MCP_SERVER_URL}/mcp",
-      "timeout": 180000
+      "timeout": 180000,
+      "headers": {
+        "Blockscout-MCP-Intermediary": "EvaluationSuite"
+      }
     }
   }
 }

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -43,7 +43,7 @@ The MCP server URL flows through the configuration chain:
 .env → docker-compose.yml → .gemini/settings.json
 ```
 
-The `.gemini/settings.json` file is kept intentionally minimal, as the main Gemini configuration is expected to be in `${GEMINI_USER_PROFILE}/settings.json`.
+The `.gemini/settings.json` file is kept intentionally minimal, as the main Gemini configuration is expected to be in `${GEMINI_USER_PROFILE}/settings.json`. It intentionally includes one `headers` override (`Blockscout-MCP-Intermediary: EvaluationSuite`) so eval traffic is identified distinctly from regular users in MCP server logs and analytics.
 
 ### Instructions and Output Format
 

--- a/tests/test_client_meta.py
+++ b/tests/test_client_meta.py
@@ -130,6 +130,24 @@ def test_parse_intermediary_header_allowlisted():
     assert _parse_intermediary_header(" claudeDESKTOP ", allowlist) == "claudeDESKTOP"
 
 
+def test_parse_intermediary_header_evaluation_suite_allowlisted():
+    allowlist = "ClaudeDesktop,HigressPlugin,EvaluationSuite"
+    assert _parse_intermediary_header("EvaluationSuite", allowlist) == "EvaluationSuite"
+
+
+def test_intermediary_header_appends_evaluation_suite(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "intermediary_allowlist",
+        "ClaudeDesktop,HigressPlugin,EvaluationSuite",
+        raising=False,
+    )
+    ctx = _ctx_with_intermediary("EvaluationSuite")
+
+    meta = extract_client_meta_from_ctx(ctx)
+    assert meta.name == "node/EvaluationSuite"
+
+
 def test_parse_intermediary_header_not_allowlisted():
     allowlist = "ClaudeDesktop,HigressPlugin"
     assert _parse_intermediary_header("Unknown", allowlist) == ""


### PR DESCRIPTION
This pull request expands support for identifying evaluation suite traffic in the MCP server by adding `EvaluationSuite` to the allowlist of intermediary identifiers. This ensures that requests originating from evaluation suites are distinctly annotated and recognized in logs and analytics. 

------

Closes #335 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698e4e3ea56083238266c55cf2342f63)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for EvaluationSuite as an allowed intermediary type in HTTP-mode integration.

* **Documentation**
  * Updated specification and configuration documentation to reflect the new intermediary allowlist entry.

* **Tests**
  * Extended test coverage for intermediary header validation with the new EvaluationSuite type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->