### PR TITLE
Parse and truncate address metadata tag `meta` values in `get_address_info`

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -503,7 +503,7 @@ This architecture provides the flexibility of a multi-protocol server without th
     - **Mechanism**: Before including metadata in the `get_address_info` response, the server parses each tag's `meta` JSON string into a structured JSON value (dict, list, or primitive). The parsed value is then processed by the same recursive truncation function used for transaction input data and log decoded values. Any individual string value exceeding `INPUT_DATA_TRUNCATION_LIMIT` (514 characters) is replaced with `{"value_sample": "...", "value_truncated": true}`. If `meta` is already a dict or list (rather than a JSON string), the truncation is applied directly.
     - **Graceful Degradation**: If a `meta` value is not valid JSON, the raw string itself is passed through the truncation function as a fallback, ensuring that even unparseable large strings do not bypass the context optimization.
     - **Schema Agnosticism**: Because different tag types (e.g., `warpcast-account`, `gitcoin-grantee`) have different `meta` schemas, the truncation is applied generically to all string values rather than targeting specific field names. This ensures the optimization remains effective as new tag types are introduced.
-    - **Truncation Notification**: When any metadata tag field is truncated, a note is appended to the tool response.
+    - **Truncation Notification**: When any metadata tag field is truncated, a note is appended to the tool response with a curl example for the metadata endpoint so agents can retrieve the complete untruncated payload when needed.
 
 
 7. **HTTP Request Robustness**

--- a/SPEC.md
+++ b/SPEC.md
@@ -496,6 +496,16 @@ This architecture provides the flexibility of a multi-protocol server without th
         - **MCP Mode (AI Agents)**: The limit is strictly enforced. If a response exceeds the limit, the tool raises a `ResponseTooLargeError` and advises the agent to use filters.
         - **REST Mode (Scripts/Middleware)**: The limit is enforced by default to prevent accidental overload. However, developers can explicitly bypass this check by including the HTTP header `X-Blockscout-Allow-Large-Response: true`.
 
+    **j) Address Metadata Tag Sanitization**
+
+    The Metadata API returns address tags with a `meta` field that is typically a JSON-encoded string. These strings may contain arbitrarily large embedded content such as URL-encoded SVG icons or Base64 image data that provides no value to LLM reasoning but consumes significant context.
+
+    - **Mechanism**: Before including metadata in the `get_address_info` response, the server parses each tag's `meta` JSON string into a structured JSON value (dict, list, or primitive). The parsed value is then processed by the same recursive truncation function used for transaction input data and log decoded values. Any individual string value exceeding `INPUT_DATA_TRUNCATION_LIMIT` (514 characters) is replaced with `{"value_sample": "...", "value_truncated": true}`. If `meta` is already a dict or list (rather than a JSON string), the truncation is applied directly.
+    - **Graceful Degradation**: If a `meta` value is not valid JSON, the raw string itself is passed through the truncation function as a fallback, ensuring that even unparseable large strings do not bypass the context optimization.
+    - **Schema Agnosticism**: Because different tag types (e.g., `warpcast-account`, `gitcoin-grantee`) have different `meta` schemas, the truncation is applied generically to all string values rather than targeting specific field names. This ensures the optimization remains effective as new tag types are introduced.
+    - **Truncation Notification**: When any metadata tag field is truncated, a note is appended to the tool response.
+
+
 7. **HTTP Request Robustness**
 
    Blockscout HTTP requests are centralized via the helper `make_blockscout_request`. To improve resilience against transient, transport-level issues observed in real-world usage (for example, incomplete chunked reads), the helper employs a small and conservative retry policy:

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.15.0.dev0"
+__version__ = "0.15.0.dev1"

--- a/blockscout_mcp_server/tools/address/get_address_info.py
+++ b/blockscout_mcp_server/tools/address/get_address_info.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from typing import Annotated
 
 from mcp.server.fastmcp import Context
@@ -10,6 +11,7 @@ from blockscout_mcp_server.models import (
     ToolResponse,
 )
 from blockscout_mcp_server.tools.common import (
+    _recursively_truncate_and_flag_long_strings,
     build_tool_response,
     get_blockscout_base_url,
     make_blockscout_request,
@@ -17,6 +19,38 @@ from blockscout_mcp_server.tools.common import (
     report_and_log_progress,
 )
 from blockscout_mcp_server.tools.decorators import log_tool_invocation
+
+
+def _process_metadata_tags(metadata_data: dict | None) -> tuple[dict | None, bool]:
+    """Parse and truncate metadata tag values to keep response payload context-friendly."""
+    if metadata_data is None or "tags" not in metadata_data or not isinstance(metadata_data["tags"], list):
+        return metadata_data, False
+
+    any_truncated = False
+    for tag in metadata_data["tags"]:
+        if not isinstance(tag, dict) or "meta" not in tag:
+            continue
+
+        meta = tag["meta"]
+        parsed_meta = None
+        if isinstance(meta, str):
+            try:
+                parsed_meta = json.loads(meta)
+            except json.JSONDecodeError:
+                processed_meta, was_truncated = _recursively_truncate_and_flag_long_strings(meta)
+                tag["meta"] = processed_meta
+                any_truncated = any_truncated or was_truncated
+                continue
+        elif isinstance(meta, dict | list):
+            parsed_meta = meta
+        else:
+            continue
+
+        processed_meta, was_truncated = _recursively_truncate_and_flag_long_strings(parsed_meta)
+        tag["meta"] = processed_meta
+        any_truncated = any_truncated or was_truncated
+
+    return metadata_data, any_truncated
 
 
 @log_tool_invocation
@@ -98,6 +132,12 @@ async def get_address_info(
         metadata_data = metadata_result["addresses"].get(address_key) if address_key else None
     else:
         metadata_data = None
+
+    metadata_data, meta_was_truncated = _process_metadata_tags(metadata_data)
+    if meta_was_truncated:
+        notes.append(
+            'Some metadata tag fields were truncated to conserve context (indicated by "value_truncated": true).'
+        )
 
     address_data = AddressInfoData(
         basic_info=address_info_result,

--- a/blockscout_mcp_server/tools/address/get_address_info.py
+++ b/blockscout_mcp_server/tools/address/get_address_info.py
@@ -1,10 +1,12 @@
 import asyncio
 import json
 from typing import Annotated
+from urllib.parse import quote_plus
 
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
+from blockscout_mcp_server.config import config
 from blockscout_mcp_server.models import (
     AddressInfoData,
     FirstTransactionDetails,
@@ -135,8 +137,16 @@ async def get_address_info(
 
     metadata_data, meta_was_truncated = _process_metadata_tags(metadata_data)
     if meta_was_truncated:
-        notes.append(
-            'Some metadata tag fields were truncated to conserve context (indicated by "value_truncated": true).'
+        metadata_url = str(config.metadata_url).rstrip("/")
+        notes.extend(
+            [
+                'Some metadata tag fields were truncated to conserve context (indicated by "value_truncated": true).',
+                (
+                    "To retrieve the full, untruncated metadata tags, query the metadata endpoint directly. "
+                    "For example, using curl:\n"
+                    f'`curl "{metadata_url}/api/v1/metadata?addresses={quote_plus(address)}&chainId={chain_id}"`'
+                ),
+            ]
         )
 
     address_data = AddressInfoData(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.15.0.dev0"
+version = "0.15.0.dev1"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.15.0.dev0",
+  "version": "0.15.0.dev1",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/integration/address/test_get_address_info_real.py
+++ b/tests/integration/address/test_get_address_info_real.py
@@ -1,8 +1,28 @@
 import pytest
 
+from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import AddressInfoData, ToolResponse
 from blockscout_mcp_server.tools.address.get_address_info import get_address_info
 from tests.integration.helpers import retry_on_network_error
+
+
+def _assert_no_oversized_strings(value: object) -> None:
+    if isinstance(value, str):
+        assert len(value) <= INPUT_DATA_TRUNCATION_LIMIT
+        return
+
+    if isinstance(value, list):
+        for item in value:
+            _assert_no_oversized_strings(item)
+        return
+
+    if isinstance(value, dict):
+        if value.get("value_truncated") is True:
+            assert "value_sample" in value
+            return
+
+        for nested_value in value.values():
+            _assert_no_oversized_strings(nested_value)
 
 
 @pytest.mark.integration
@@ -44,3 +64,35 @@ async def test_get_address_info_integration(mock_ctx):
     usdc_tag = next((tag for tag in metadata["tags"] if tag.get("slug") == "usdc"), None)
     assert usdc_tag is not None, "Could not find the 'usdc' tag in metadata"
     assert usdc_tag["name"].lower() in {"usd coin", "usdc"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_address_info_vitalik_metadata_meta_is_parsed_and_truncated(mock_ctx):
+    address = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"  # vitalik.eth
+
+    result = await retry_on_network_error(
+        lambda: get_address_info(chain_id="1", address=address, ctx=mock_ctx),
+        action_description="get_address_info vitalik.eth address request",
+    )
+
+    if result.notes and any("Could not retrieve address metadata" in note for note in result.notes):
+        pytest.skip("Metadata service unavailable; cannot verify metadata meta truncation.")
+
+    metadata = result.data.metadata
+    assert isinstance(metadata, dict)
+
+    tags = metadata.get("tags")
+    if not isinstance(tags, list):
+        pytest.skip("No metadata tags found; cannot verify truncation.")
+
+    tags_with_meta = [tag for tag in tags if isinstance(tag, dict) and "meta" in tag]
+    if not tags_with_meta:
+        pytest.skip("No metadata tags with meta field found; cannot verify truncation.")
+
+    for tag in tags_with_meta:
+        meta = tag["meta"]
+        if isinstance(meta, dict | list):
+            _assert_no_oversized_strings(meta)
+        elif isinstance(meta, str):
+            assert len(meta) <= INPUT_DATA_TRUNCATION_LIMIT

--- a/tests/tools/address/test_get_address_info.py
+++ b/tests/tools/address/test_get_address_info.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import httpx
 import pytest
 
+from blockscout_mcp_server.config import config
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import AddressInfoData, ToolResponse
 from blockscout_mcp_server.tools.address.get_address_info import _process_metadata_tags, get_address_info
@@ -499,5 +500,8 @@ async def test_get_address_info_adds_note_when_metadata_meta_is_truncated(mock_c
 
     assert result.notes is not None
     assert any("Some metadata tag fields were truncated" in note for note in result.notes)
+    expected_metadata_prefix = f'`curl "{str(config.metadata_url).rstrip("/")}/api/v1/metadata?addresses={address}'
+    assert any(expected_metadata_prefix in note for note in result.notes)
+    assert any(f"chainId={chain_id}" in note for note in result.notes)
     assert result.data.metadata is not None
     assert result.data.metadata["tags"][0]["meta"]["tagIcon"]["value_truncated"] is True

--- a/tests/tools/address/test_get_address_info.py
+++ b/tests/tools/address/test_get_address_info.py
@@ -3,8 +3,13 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import httpx
 import pytest
 
+from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import AddressInfoData, ToolResponse
-from blockscout_mcp_server.tools.address.get_address_info import get_address_info
+from blockscout_mcp_server.tools.address.get_address_info import _process_metadata_tags, get_address_info
+
+
+def _long_string() -> str:
+    return "x" * (INPUT_DATA_TRUNCATION_LIMIT + 20)
 
 
 @pytest.mark.asyncio
@@ -357,3 +362,142 @@ async def test_get_address_info_blockscout_failure(mock_ctx):
 
         assert mock_ctx.report_progress.await_count == 2
         assert mock_ctx.info.await_count == 2
+
+
+def test_process_metadata_tags_truncates_oversized_meta_values():
+    metadata_data = {
+        "tags": [
+            {
+                "slug": "warpcast-account",
+                "meta": ('{"tagUrl":"https://example.com/user","tagIcon":"' + _long_string() + '"}'),
+            }
+        ]
+    }
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is True
+    assert processed is not None
+    meta = processed["tags"][0]["meta"]
+    assert meta["tagUrl"] == "https://example.com/user"
+    assert meta["tagIcon"]["value_truncated"] is True
+
+
+def test_process_metadata_tags_preserves_small_meta_values():
+    metadata_data = {"tags": [{"meta": '{"tagUrl":"https://example.com/user","tagName":"Alice"}'}]}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is False
+    assert processed == {"tags": [{"meta": {"tagUrl": "https://example.com/user", "tagName": "Alice"}}]}
+
+
+def test_process_metadata_tags_invalid_json_short_string_is_preserved():
+    metadata_data = {"tags": [{"meta": "not json"}]}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is False
+    assert processed == metadata_data
+
+
+def test_process_metadata_tags_invalid_json_oversized_string_is_truncated():
+    metadata_data = {"tags": [{"meta": _long_string()}]}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is True
+    assert processed is not None
+    assert processed["tags"][0]["meta"]["value_truncated"] is True
+
+
+def test_process_metadata_tags_truncates_when_meta_is_dict():
+    metadata_data = {"tags": [{"meta": {"icon": _long_string(), "label": "ok"}}]}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is True
+    assert processed is not None
+    assert processed["tags"][0]["meta"]["icon"]["value_truncated"] is True
+    assert processed["tags"][0]["meta"]["label"] == "ok"
+
+
+def test_process_metadata_tags_truncates_when_meta_parses_to_array():
+    metadata_data = {"tags": [{"meta": '[{"k":"' + _long_string() + '"}]'}]}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is True
+    assert processed is not None
+    assert processed["tags"][0]["meta"][0]["k"]["value_truncated"] is True
+
+
+def test_process_metadata_tags_parses_json_primitives():
+    metadata_data = {"tags": [{"meta": "null"}, {"meta": "true"}]}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is False
+    assert processed == {"tags": [{"meta": None}, {"meta": True}]}
+
+
+def test_process_metadata_tags_truncates_long_json_string_primitive():
+    metadata_data = {"tags": [{"meta": '"' + _long_string() + '"'}]}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert truncated is True
+    assert processed is not None
+    assert processed["tags"][0]["meta"]["value_truncated"] is True
+
+
+def test_process_metadata_tags_handles_missing_tags_key():
+    metadata_data = {"name": "metadata without tags"}
+
+    processed, truncated = _process_metadata_tags(metadata_data)
+
+    assert processed == metadata_data
+    assert truncated is False
+
+
+def test_process_metadata_tags_handles_none_metadata():
+    processed, truncated = _process_metadata_tags(None)
+
+    assert processed is None
+    assert truncated is False
+
+
+@pytest.mark.asyncio
+async def test_get_address_info_adds_note_when_metadata_meta_is_truncated(mock_ctx):
+    chain_id = "1"
+    address = "0x123abc"
+    mock_base_url = "https://eth.blockscout.com"
+    mock_blockscout_response = {"hash": address, "is_contract": True}
+    mock_first_tx_response = {"items": []}
+    mock_metadata_response = {
+        "addresses": {
+            address: {"tags": [{"meta": ('{"tagUrl":"https://example.com/user","tagIcon":"' + _long_string() + '"}')}]}
+        }
+    }
+
+    with (
+        patch(
+            "blockscout_mcp_server.tools.address.get_address_info.get_blockscout_base_url", new_callable=AsyncMock
+        ) as mock_get_url,
+        patch(
+            "blockscout_mcp_server.tools.address.get_address_info.make_blockscout_request", new_callable=AsyncMock
+        ) as mock_bs_request,
+        patch(
+            "blockscout_mcp_server.tools.address.get_address_info.make_metadata_request", new_callable=AsyncMock
+        ) as mock_meta_request,
+    ):
+        mock_get_url.return_value = mock_base_url
+        mock_bs_request.side_effect = [mock_blockscout_response, mock_first_tx_response]
+        mock_meta_request.return_value = mock_metadata_response
+
+        result = await get_address_info(chain_id=chain_id, address=address, ctx=mock_ctx)
+
+    assert result.notes is not None
+    assert any("Some metadata tag fields were truncated" in note for note in result.notes)
+    assert result.data.metadata is not None
+    assert result.data.metadata["tags"][0]["meta"]["tagIcon"]["value_truncated"] is True


### PR DESCRIPTION
### Motivation
- Metadata tags returned by the Metadata API include a `meta` field that is often a JSON-encoded string and may contain very large embedded payloads (SVGs, base64 blobs) that exhaust LLM context; individual string values need to be inspected and truncated by the same recursive truncation logic used elsewhere.

### Description
- Add helper `_process_metadata_tags(metadata_data)` to `blockscout_mcp_server/tools/address/get_address_info.py` to parse `tag["meta"]` (JSON string or already-parsed dict/list) and apply ` _recursively_truncate_and_flag_long_strings` to the resolved value, with a fallback truncation path for invalid JSON strings.
- Integrate the helper into `get_address_info` so processed metadata replaces the original and, when any truncation occurs, append a user-visible note indicating truncated metadata fields.
- Add focused unit tests in `tests/tools/address/test_get_address_info.py` covering: oversized JSON fields, small values preserved, invalid-JSON short and oversized strings, dict/list parsing, JSON primitives, missing tags, and end-to-end truncation note behavior.
- Add an integration test `tests/integration/address/test_get_address_info_real.py` that requests Vitalik's address metadata (stable target) and asserts parsed/truncated invariants without assuming particular tags exist.
- Document the behavior in `SPEC.md` under new subsection "j) Address Metadata Tag Sanitization".
- Files changed: `blockscout_mcp_server/tools/address/get_address_info.py`, `tests/tools/address/test_get_address_info.py`, `tests/integration/address/test_get_address_info_real.py`, and `SPEC.md`.

### Testing
- Ran linter/formatters: `ruff check . --fix` and `ruff format .` and `ruff format --check .` succeeded.
- Unit tests: `pytest tests/tools/address/test_get_address_info.py -v` passed (17 passed), and the full unit test suite `pytest tests/tools/` passed (240 passed).
- Integration tests: `pytest -m integration tests/integration/address/test_get_address_info_real.py -v` passed for the new Vitalik test, and a full integration test run `pytest -m integration tests/integration/` completed (63 passed, 19 skipped) on the environment used for verification.
- Verified style/format for modified Python files with `ruff check` and `ruff format --check` (passed).

Closes #339

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a635bb2470832399e84ba3acd1ca75)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address metadata tags now sanitize oversized content: long string values are truncated and replaced with a sample + truncation flag; responses include a truncation notification when applicable.

* **Tests**
  * Added integration and unit tests to verify metadata parsing, truncation behavior, and sample presence for truncated values.

* **Documentation**
  * SPEC updated with a new section describing address metadata tag sanitization.

* **Chores**
  * Package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->