### PR TITLE
Serialize ToolResponse with alias keys for MCP and REST

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.15.0.dev0"
+__version__ = "0.15.0.dev2"

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -107,14 +107,14 @@ async def get_instructions_rest(request: Request) -> Response:
     # old route will be removed soon and another wrapper would add needless
     # indirection.
     tool_response = await __unlock_blockchain_analysis__(ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
 async def unlock_blockchain_analysis_rest(request: Request) -> Response:
     """REST wrapper for the __unlock_blockchain_analysis__ tool."""
     tool_response = await __unlock_blockchain_analysis__(ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -126,7 +126,7 @@ async def get_block_info_rest(request: Request) -> Response:
         optional=["include_transactions"],
     )
     tool_response = await get_block_info(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -134,7 +134,7 @@ async def get_latest_block_rest(request: Request) -> Response:
     """REST wrapper for the legacy get_latest_block tool."""
     params = extract_and_validate_params(request, required=["chain_id"], optional=[])
     tool_response = await get_block_number(chain_id=params["chain_id"], datetime=None, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -142,7 +142,7 @@ async def get_block_number_rest(request: Request) -> Response:
     """REST wrapper for the get_block_number tool."""
     params = extract_and_validate_params(request, required=["chain_id"], optional=["datetime"])
     tool_response = await get_block_number(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -150,7 +150,7 @@ async def get_address_by_ens_name_rest(request: Request) -> Response:
     """REST wrapper for the get_address_by_ens_name tool."""
     params = extract_and_validate_params(request, required=["name"], optional=[])
     tool_response = await get_address_by_ens_name(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -162,7 +162,7 @@ async def get_transactions_by_address_rest(request: Request) -> Response:
         optional=["age_to", "methods", "cursor"],
     )
     tool_response = await get_transactions_by_address(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -174,7 +174,7 @@ async def get_token_transfers_by_address_rest(request: Request) -> Response:
         optional=["age_to", "token", "cursor"],
     )
     tool_response = await get_token_transfers_by_address(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -182,7 +182,7 @@ async def lookup_token_by_symbol_rest(request: Request) -> Response:
     """REST wrapper for the lookup_token_by_symbol tool."""
     params = extract_and_validate_params(request, required=["chain_id", "symbol"], optional=[])
     tool_response = await lookup_token_by_symbol(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -190,7 +190,7 @@ async def get_contract_abi_rest(request: Request) -> Response:
     """REST wrapper for the get_contract_abi tool."""
     params = extract_and_validate_params(request, required=["chain_id", "address"], optional=[])
     tool_response = await get_contract_abi(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -198,7 +198,7 @@ async def inspect_contract_code_rest(request: Request) -> Response:
     """REST wrapper for the inspect_contract_code tool."""
     params = extract_and_validate_params(request, required=["chain_id", "address"], optional=["file_name"])
     tool_response = await inspect_contract_code(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -219,7 +219,7 @@ async def read_contract_rest(request: Request) -> Response:
     if "block" in params and params["block"].isdigit():
         params["block"] = int(params["block"])
     tool_response = await read_contract(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -227,7 +227,7 @@ async def get_address_info_rest(request: Request) -> Response:
     """REST wrapper for the get_address_info tool."""
     params = extract_and_validate_params(request, required=["chain_id", "address"], optional=[])
     tool_response = await get_address_info(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -235,7 +235,7 @@ async def get_tokens_by_address_rest(request: Request) -> Response:
     """REST wrapper for the get_tokens_by_address tool."""
     params = extract_and_validate_params(request, required=["chain_id", "address"], optional=["cursor"])
     tool_response = await get_tokens_by_address(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -257,7 +257,7 @@ async def nft_tokens_by_address_rest(request: Request) -> Response:
     """REST wrapper for the nft_tokens_by_address tool."""
     params = extract_and_validate_params(request, required=["chain_id", "address"], optional=["cursor"])
     tool_response = await nft_tokens_by_address(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -269,7 +269,7 @@ async def get_transaction_info_rest(request: Request) -> Response:
         optional=["include_raw_input"],
     )
     tool_response = await get_transaction_info(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -303,7 +303,7 @@ async def get_transaction_logs_rest(request: Request) -> Response:
 async def get_chains_list_rest(request: Request) -> Response:
     """REST wrapper for the get_chains_list tool."""
     tool_response = await get_chains_list(ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 @handle_rest_errors
@@ -321,7 +321,7 @@ async def direct_api_call_rest(request: Request) -> Response:
     if extra:
         params["query_params"] = extra
     tool_response = await direct_api_call(**params, ctx=get_mock_context(request))
-    return JSONResponse(tool_response.model_dump())
+    return JSONResponse(tool_response.model_dump(mode="json", by_alias=True))
 
 
 def _add_v1_tool_route(mcp: FastMCP, path: str, handler: Callable[..., Any]) -> None:

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -240,7 +240,9 @@ class TransactionSummaryData(BaseModel):
 class TokenTransfer(BaseModel):
     """Represents a single token transfer within a transaction."""
 
-    model_config = ConfigDict(extra="allow")  # External APIs may add new fields; allow them to avoid validation errors
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, validate_by_name=True
+    )  # External APIs may add new fields; allow them to avoid validation errors
 
     from_address: str | None = Field(alias="from", description="Sender address of the token transfer if available.")
     to_address: str | None = Field(alias="to", description="Recipient address of the token transfer if available.")
@@ -315,7 +317,9 @@ class UserOperationData(BaseModel):
 class TransactionInfoData(BaseModel):
     """Structured representation of get_transaction_info data."""
 
-    model_config = ConfigDict(extra="allow")  # External APIs may add new fields; allow them to avoid validation errors
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, validate_by_name=True
+    )  # External APIs may add new fields; allow them to avoid validation errors
 
     from_address: str | None = Field(
         default=None,
@@ -349,7 +353,9 @@ class TransactionInfoData(BaseModel):
 class AdvancedFilterItem(BaseModel):
     """Represents a single item from the advanced filter API response."""
 
-    model_config = ConfigDict(extra="allow")  # External APIs may add new fields; allow them to avoid validation errors
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, validate_by_name=True
+    )  # External APIs may add new fields; allow them to avoid validation errors
 
     from_address: str | None = Field(
         default=None,

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -189,7 +189,7 @@ def _wrap_tool_for_structured_output(tool_function):
     @wraps(tool_function)
     async def _wrapped_tool(*args, **kwargs):
         tool_response = await tool_function(*args, **kwargs)
-        structured = tool_response.model_dump(mode="json")
+        structured = tool_response.model_dump(mode="json", by_alias=True)
         content_text = _generate_content(tool_response, structured, *args, **kwargs)
         return CallToolResult(
             content=[TextContent(type="text", text=content_text)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.15.0.dev0"
+version = "0.15.0.dev2"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.15.0.dev0",
+  "version": "0.15.0.dev2",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -8,7 +8,7 @@ from httpx import ASGITransport, AsyncClient
 from mcp.server.fastmcp import FastMCP
 
 from blockscout_mcp_server.api.routes import register_api_routes
-from blockscout_mcp_server.models import ToolResponse
+from blockscout_mcp_server.models import AdvancedFilterItem, TokenTransfer, ToolResponse, TransactionInfoData
 
 
 @pytest.fixture
@@ -239,11 +239,15 @@ async def test_get_address_by_ens_name_missing_param(client: AsyncClient):
 )
 async def test_get_transactions_by_address_success(mock_tool, client: AsyncClient):
     """Test the /get_transactions_by_address endpoint."""
-    mock_tool.return_value = ToolResponse(data={"items": []})
+    mock_tool.return_value = ToolResponse(data=[AdvancedFilterItem(**{"from": "0xfrom", "to": "0xto"})])
     url = "/v1/get_transactions_by_address?chain_id=1&address=0xabc&age_from=2025-01-01T00:00:00.00Z&cursor=foo"
     response = await client.get(url)
     assert response.status_code == 200
-    assert response.json()["data"] == {"items": []}
+    transfer_item = response.json()["data"][0]
+    assert transfer_item["from"] == "0xfrom"
+    assert transfer_item["to"] == "0xto"
+    assert "from_address" not in transfer_item
+    assert "to_address" not in transfer_item
     mock_tool.assert_called_once_with(
         chain_id="1",
         address="0xabc",
@@ -260,11 +264,13 @@ async def test_get_transactions_by_address_success(mock_tool, client: AsyncClien
 )
 async def test_get_transactions_by_address_no_cursor(mock_tool, client: AsyncClient):
     """Endpoint works with required params only."""
-    mock_tool.return_value = ToolResponse(data={"items": []})
+    mock_tool.return_value = ToolResponse(data=[AdvancedFilterItem(**{"from": "0xfrom", "to": "0xto"})])
     url = "/v1/get_transactions_by_address?chain_id=1&address=0xabc&age_from=2025-01-01T00:00:00.00Z"
     response = await client.get(url)
     assert response.status_code == 200
-    assert response.json()["data"] == {"items": []}
+    transfer_item = response.json()["data"][0]
+    assert transfer_item["from"] == "0xfrom"
+    assert transfer_item["to"] == "0xto"
     mock_tool.assert_called_once_with(chain_id="1", address="0xabc", age_from="2025-01-01T00:00:00.00Z", ctx=ANY)
 
 
@@ -535,11 +541,25 @@ async def test_nft_tokens_by_address_missing_param(client: AsyncClient):
 @patch("blockscout_mcp_server.api.routes.get_transaction_info", new_callable=AsyncMock)
 async def test_get_transaction_info_success(mock_tool, client: AsyncClient):
     """Test /get_transaction_info endpoint."""
-    mock_tool.return_value = ToolResponse(data={"hash": "0x123"})
+    mock_tool.return_value = ToolResponse(
+        data=TransactionInfoData(
+            **{
+                "from": "0xfrom",
+                "to": "0xto",
+                "token_transfers": [TokenTransfer(**{"from": "0xa", "to": "0xb", "type": "transfer", "token": {}})],
+            },
+        )
+    )
     url = "/v1/get_transaction_info?chain_id=1&transaction_hash=0x123&include_raw_input=true"
     response = await client.get(url)
     assert response.status_code == 200
-    assert response.json()["data"] == {"hash": "0x123"}
+    transfer = response.json()["data"]["token_transfers"][0]
+    assert transfer["from"] == "0xa"
+    assert transfer["to"] == "0xb"
+    assert transfer["type"] == "transfer"
+    assert "from_address" not in transfer
+    assert "to_address" not in transfer
+    assert "transfer_type" not in transfer
     mock_tool.assert_called_once_with(
         chain_id="1",
         transaction_hash="0x123",
@@ -552,10 +572,21 @@ async def test_get_transaction_info_success(mock_tool, client: AsyncClient):
 @patch("blockscout_mcp_server.api.routes.get_transaction_info", new_callable=AsyncMock)
 async def test_get_transaction_info_no_optional(mock_tool, client: AsyncClient):
     """Works without include_raw_input parameter."""
-    mock_tool.return_value = ToolResponse(data={"hash": "0xabc"})
+    mock_tool.return_value = ToolResponse(
+        data=TransactionInfoData(
+            **{
+                "from": "0xfrom",
+                "to": "0xto",
+                "token_transfers": [TokenTransfer(**{"from": "0xa", "to": "0xb", "type": "mint", "token": None})],
+            },
+        )
+    )
     response = await client.get("/v1/get_transaction_info?chain_id=1&transaction_hash=0xabc")
     assert response.status_code == 200
-    assert response.json()["data"] == {"hash": "0xabc"}
+    transfer = response.json()["data"]["token_transfers"][0]
+    assert transfer["from"] == "0xa"
+    assert transfer["to"] == "0xb"
+    assert transfer["type"] == "mint"
     mock_tool.assert_called_once_with(chain_id="1", transaction_hash="0xabc", ctx=ANY)
 
 

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -553,7 +553,12 @@ async def test_get_transaction_info_success(mock_tool, client: AsyncClient):
     url = "/v1/get_transaction_info?chain_id=1&transaction_hash=0x123&include_raw_input=true"
     response = await client.get(url)
     assert response.status_code == 200
-    transfer = response.json()["data"]["token_transfers"][0]
+    data = response.json()["data"]
+    assert data["from"] == "0xfrom"
+    assert data["to"] == "0xto"
+    assert "from_address" not in data
+    assert "to_address" not in data
+    transfer = data["token_transfers"][0]
     assert transfer["from"] == "0xa"
     assert transfer["to"] == "0xb"
     assert transfer["type"] == "transfer"
@@ -583,7 +588,12 @@ async def test_get_transaction_info_no_optional(mock_tool, client: AsyncClient):
     )
     response = await client.get("/v1/get_transaction_info?chain_id=1&transaction_hash=0xabc")
     assert response.status_code == 200
-    transfer = response.json()["data"]["token_transfers"][0]
+    data = response.json()["data"]
+    assert data["from"] == "0xfrom"
+    assert data["to"] == "0xto"
+    assert "from_address" not in data
+    assert "to_address" not in data
+    transfer = data["token_transfers"][0]
     assert transfer["from"] == "0xa"
     assert transfer["to"] == "0xb"
     assert transfer["type"] == "mint"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -64,7 +64,9 @@ def assert_tool_response_round_trip(
     dumped = response.model_dump(mode="json", by_alias=True)
     validated = response_model.model_validate(dumped)
 
+    assert validated.data_description == response.data_description
     assert validated.notes == response.notes
+    assert validated.instructions == response.instructions
     assert validated.pagination == response.pagination
 
     return validated

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -64,6 +64,7 @@ def assert_tool_response_round_trip(
     dumped = response.model_dump(mode="json", by_alias=True)
     validated = response_model.model_validate(dumped)
 
+    assert validated.data == response.data
     assert validated.data_description == response.data_description
     assert validated.notes == response.notes
     assert validated.instructions == response.instructions

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,11 +1,11 @@
 import asyncio
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import httpx
 import pytest
 
-from blockscout_mcp_server.models import AddressLogItem, TransactionLogItem
+from blockscout_mcp_server.models import AddressLogItem, ToolResponse, TransactionLogItem
 
 RETRYABLE_HTTP_STATUSES = {500, 502, 503, 504}
 
@@ -54,3 +54,17 @@ def is_log_a_truncated_call_executed(log: TransactionLogItem | AddressLogItem) -
 
     value = data_param.get("value")
     return isinstance(value, dict) and value.get("value_truncated") is True
+
+
+def assert_tool_response_round_trip(
+    response: ToolResponse[Any],
+    response_model: type[ToolResponse[Any]],
+) -> ToolResponse[Any]:
+    """Validate that a ToolResponse survives model_dump/model_validate round-trip."""
+    dumped = response.model_dump(mode="json", by_alias=True)
+    validated = response_model.model_validate(dumped)
+
+    assert validated.notes == response.notes
+    assert validated.pagination == response.pagination
+
+    return validated

--- a/tests/integration/transaction/test_get_transaction_info_real.py
+++ b/tests/integration/transaction/test_get_transaction_info_real.py
@@ -4,7 +4,7 @@ from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT
 from blockscout_mcp_server.models import TokenTransfer, ToolResponse, TransactionInfoData
 from blockscout_mcp_server.tools.common import get_blockscout_base_url
 from blockscout_mcp_server.tools.transaction.get_transaction_info import get_transaction_info
-from tests.integration.helpers import retry_on_network_error
+from tests.integration.helpers import assert_tool_response_round_trip, retry_on_network_error
 
 
 def find_truncated_value(value):
@@ -46,6 +46,33 @@ async def test_get_transaction_info_integration(mock_ctx):
     for transfer in data.token_transfers:
         assert isinstance(transfer, TokenTransfer)
         assert isinstance(transfer.transfer_type, str)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_transaction_info_round_trip_with_token_transfers(mock_ctx):
+    """Ensure token transfer aliases survive the production round-trip path."""
+    tx_hash = "0xd4df84bf9e45af2aa8310f74a2577a28b420c59f2e3da02c52b6d39dc83ef10f"
+    result = await retry_on_network_error(
+        lambda: get_transaction_info(chain_id="1", transaction_hash=tx_hash, ctx=mock_ctx),
+        action_description="get_transaction_info round-trip request",
+    )
+
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, TransactionInfoData)
+    if not result.data.token_transfers:
+        pytest.skip("Token transfers were empty for the selected transaction.")
+
+    validated = assert_tool_response_round_trip(result, ToolResponse[TransactionInfoData])
+
+    for original_transfer, validated_transfer in zip(
+        result.data.token_transfers,
+        validated.data.token_transfers,
+        strict=True,
+    ):
+        assert validated_transfer.from_address == original_transfer.from_address
+        assert validated_transfer.to_address == original_transfer.to_address
+        assert validated_transfer.transfer_type == original_transfer.transfer_type
 
 
 @pytest.mark.integration

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -342,6 +342,72 @@ def test_token_transfer_accepts_populated_token_metadata_dict():
     assert model.token == token_payload
 
 
+def test_token_transfer_round_trip_by_alias():
+    transfer = TokenTransfer(from_address="0xa", to_address="0xb", transfer_type="transfer", token={"symbol": "TOK"})
+
+    validated = TokenTransfer.model_validate(transfer.model_dump(mode="json", by_alias=True))
+
+    assert validated.from_address == "0xa"
+    assert validated.to_address == "0xb"
+    assert validated.transfer_type == "transfer"
+
+
+def test_token_transfer_round_trip_by_name():
+    transfer = TokenTransfer(from_address="0xa", to_address="0xb", transfer_type="mint", token=None)
+
+    validated = TokenTransfer.model_validate(transfer.model_dump(mode="json"))
+
+    assert validated.from_address == "0xa"
+    assert validated.to_address == "0xb"
+    assert validated.transfer_type == "mint"
+
+
+def test_transaction_info_data_round_trip_with_nested_token_transfers():
+    payload = TransactionInfoData(
+        **{
+            "from": "0xfrom",
+            "to": "0xto",
+            "token_transfers": [TokenTransfer(**{"from": "0xa", "to": "0xb", "type": "transfer", "token": None})],
+        }
+    )
+
+    validated = TransactionInfoData.model_validate(payload.model_dump(mode="json", by_alias=True))
+
+    assert validated.from_address == "0xfrom"
+    assert validated.to_address == "0xto"
+    assert validated.token_transfers[0].from_address == "0xa"
+    assert validated.token_transfers[0].transfer_type == "transfer"
+
+
+def test_advanced_filter_item_round_trip_by_alias():
+    from blockscout_mcp_server.models import AdvancedFilterItem
+
+    item = AdvancedFilterItem(**{"from": "0xfrom", "to": "0xto"})
+
+    validated = AdvancedFilterItem.model_validate(item.model_dump(mode="json", by_alias=True))
+
+    assert validated.from_address == "0xfrom"
+    assert validated.to_address == "0xto"
+
+
+def test_tool_response_transaction_info_round_trip_with_aliases():
+    response = ToolResponse[TransactionInfoData](
+        data=TransactionInfoData(
+            **{
+                "from": "0xfrom",
+                "to": "0xto",
+                "token_transfers": [TokenTransfer(**{"from": "0xa", "to": "0xb", "type": "transfer", "token": {}})],
+            }
+        )
+    )
+
+    validated = ToolResponse[TransactionInfoData].model_validate(response.model_dump(mode="json", by_alias=True))
+
+    assert validated.data.from_address == "0xfrom"
+    assert validated.data.token_transfers[0].to_address == "0xb"
+    assert validated.data.token_transfers[0].transfer_type == "transfer"
+
+
 def test_block_info_data_model():
     """Verify BlockInfoData model structure and extra field handling."""
     block_data = {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -366,6 +366,39 @@ async def test_wrap_tool_for_structured_output_with_content_text():
 
 
 @pytest.mark.asyncio
+async def test_wrap_tool_for_structured_output_uses_aliases_for_nested_models():
+    from blockscout_mcp_server.models import TokenTransfer, ToolResponse, TransactionInfoData
+    from blockscout_mcp_server.server import _wrap_tool_for_structured_output
+
+    async def _tool() -> ToolResponse[TransactionInfoData]:
+        return ToolResponse(
+            data=TransactionInfoData(
+                **{
+                    "from": "0xfrom",
+                    "to": "0xto",
+                    "token_transfers": [
+                        TokenTransfer(**{"from": "0xa", "to": "0xb", "type": "transfer", "token": None})
+                    ],
+                }
+            )
+        )
+
+    wrapped = _wrap_tool_for_structured_output(_tool)
+    result = await wrapped()
+
+    transfer = result.structuredContent["data"]["token_transfers"][0]
+    assert transfer["from"] == "0xa"
+    assert transfer["to"] == "0xb"
+    assert transfer["type"] == "transfer"
+    assert "from_address" not in transfer
+    assert "to_address" not in transfer
+    assert "transfer_type" not in transfer
+
+    validated = ToolResponse[TransactionInfoData].model_validate(result.structuredContent)
+    assert validated.data.token_transfers[0].from_address == "0xa"
+
+
+@pytest.mark.asyncio
 async def test_wrap_tool_for_structured_output_fallback_and_metadata():
     from blockscout_mcp_server.models import ToolResponse
     from blockscout_mcp_server.server import _wrap_tool_for_structured_output


### PR DESCRIPTION
### Motivation
- Fix a ValidationError where MCP structured output used Python field names (`from_address`, `to_address`, `transfer_type`) but FastMCP expected alias keys (`from`, `to`, `type`) when validating `ToolResponse` payloads. 
- Ensure the MCP wrapper emits alias-key JSON so `FuncMetadata.convert_result()` and `ToolResponse` validation succeed for nested aliased models like `TokenTransfer`.
- Make REST API JSON responses consistent with MCP output and Blockscout field naming conventions. 
- Add defense-in-depth to models so future code paths that serialize by field name still validate.

### Description
- Changed the MCP wrapper `_wrap_tool_for_structured_output` in `blockscout_mcp_server/server.py` to serialize structured output with `tool_response.model_dump(mode="json", by_alias=True)`. 
- Updated all REST route handlers in `blockscout_mcp_server/api/routes.py` to return `JSONResponse(tool_response.model_dump(mode="json", by_alias=True))` so REST responses use alias keys. 
- Hardened aliased models by enabling name-based population/validation on affected models in `blockscout_mcp_server/models.py` (added `populate_by_name=True, validate_by_name=True` to `TokenTransfer`, `TransactionInfoData`, and `AdvancedFilterItem`) to provide defense-in-depth. 
- Added and updated tests: unit tests in `tests/test_server.py`, `tests/test_models.py`, and `tests/api/test_routes.py` to assert alias-key serialization and model round-trips, plus an integration helper and an integration test `tests/integration/transaction/test_get_transaction_info_real.py` to validate live round-trips with token-transfer-bearing transactions. 
- Closes #340

### Testing
- Ran formatting and lint fixes with `ruff check . --fix` and `ruff format .`, which completed successfully. 
- Executed focused unit tests: `pytest tests/test_server.py tests/test_models.py tests/api/test_routes.py -v`, all passed. 
- Executed the new integration scenario: `pytest -m integration tests/integration/transaction/test_get_transaction_info_real.py -v`, which passed. 
- Ran full test suite with `pytest`, which completed successfully (`455 passed` selected, 82 deselected). 
- Verified final lint/format checks with `ruff check .` and `ruff format --check .`, both passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a64a7635e48323a0b9fead9b2dda1f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * API responses now consistently emit public field names (aliases) in JSON using a unified JSON dumping mode for clearer payloads
  * Data models configured for reliable name-based population and validation to reduce mismatched fields

* **Tests**
  * Added comprehensive unit and integration round-trip tests validating structured responses, alias handling, and nested data serialization

* **Chores**
  * Bumped project version to 0.15.0.dev2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->