### PR TITLE
Bump server version to 0.15.0

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Blockscout MCP Server package."""
 
-__version__ = "0.15.0.dev2"
+__version__ = "0.15.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.15.0.dev2"
+version = "0.15.0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.15.0.dev2",
+  "version": "0.15.0",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",


### PR DESCRIPTION
### Motivation
- Align and publish the new release by updating the package, runtime, and MCP metadata version strings to `0.15.0` so all version sources remain consistent.

### Description
- Updated the version string to `0.15.0` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json` to keep packaging, runtime, and server metadata synchronized.

### Testing
- Ran `ruff check . --fix`, `ruff format .`, and verified the updated version strings with `rg`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a74661267083238eee89cf609fbbc5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.15.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->