### PR TITLE
chore: allow to run agents outside of devcontainer

### DIFF
--- a/.claude/hooks/ensure-python-venv.sh
+++ b/.claude/hooks/ensure-python-venv.sh
@@ -7,24 +7,29 @@ INPUT=$(cat)
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
 [ -z "$COMMAND" ] && exit 0
 
-# Allow if already using venv path or uv run
-if printf '%s' "$COMMAND" | grep -qE '(\.venv/bin/|uv run )'; then
-    exit 0
+# Allow everything inside devcontainer (tools are installed system-wide)
+[ -f /.dockerenv ] && exit 0
+
+# Block uv pip install --system (installs outside venv)
+if printf '%s' "$COMMAND" | grep -qE 'uv pip install.*--system'; then
+    echo "uv pip install --system bypasses the project venv. Use: uv pip install --python .venv \"<package>\"" >&2
+    exit 2
 fi
 
-# Block bare tool invocations anywhere in the command (after |, ;, &&, or at start)
-if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];&|])(python3?|pytest|ruff)([[:space:]]|$)'; then
+# Remove known-safe invocations before scanning for bare tools.
+# This prevents false negatives like: `.venv/bin/python -V; pytest`
+# or `uv run pytest tests/ && python -V` from slipping through.
+SANITIZED=$(printf '%s' "$COMMAND" \
+    | sed -E 's/\.venv\/bin\/(python3?|pytest|ruff)[[:space:]]?//g' \
+    | sed -E 's/uv run (python3?|pytest|ruff)[[:space:]]?//g')
+
+# Block bare tool invocations anywhere in the sanitized command
+if printf '%s' "$SANITIZED" | grep -qE '(^|[[:space:];&|])(python3?|pytest|ruff)([[:space:]]|$)'; then
     cat >&2 <<'EOF'
 Bare Python tool detected. Use the project venv instead:
   .venv/bin/<tool> ...    (direct path)
   uv run <tool> ...       (via uv, also works in worktrees)
 EOF
-    exit 2
-fi
-
-# Block uv pip install --system (installs outside venv)
-if printf '%s' "$COMMAND" | grep -qE 'uv pip install.*--system|uv pip install.*-p[[:space:]]*system'; then
-    echo "uv pip install --system bypasses the project venv. Use: uv pip install --python .venv \"<package>\"" >&2
     exit 2
 fi
 

--- a/.claude/hooks/ensure-python-venv.sh
+++ b/.claude/hooks/ensure-python-venv.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# PreToolUse hook: blocks bare Python tool invocations that bypass the project venv.
+# Requires .venv/bin/<tool> or `uv run <tool>` to ensure consistent environment.
+# Works with pipelines (|), sequences (;), and compound commands (&&).
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$COMMAND" ] && exit 0
+
+# Allow if already using venv path or uv run
+if printf '%s' "$COMMAND" | grep -qE '(\.venv/bin/|uv run )'; then
+    exit 0
+fi
+
+# Block bare tool invocations anywhere in the command (after |, ;, &&, or at start)
+if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];&|])(python3?|pytest|ruff)([[:space:]]|$)'; then
+    cat >&2 <<'EOF'
+Bare Python tool detected. Use the project venv instead:
+  .venv/bin/<tool> ...    (direct path)
+  uv run <tool> ...       (via uv, also works in worktrees)
+EOF
+    exit 2
+fi
+
+# Block uv pip install --system (installs outside venv)
+if printf '%s' "$COMMAND" | grep -qE 'uv pip install.*--system|uv pip install.*-p[[:space:]]*system'; then
+    echo "uv pip install --system bypasses the project venv. Use: uv pip install --python .venv \"<package>\"" >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,16 @@
 {
-  "outputStyle": "default",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}\"/.claude/hooks/ensure-python-venv.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|clear",
@@ -13,20 +23,5 @@
       }
     ]
   },
-  "permissions": {
-    "allow": [
-      "WebSearch",
-      "WebFetch(domain:github.com)",
-      "WebFetch(domain:raw.githubusercontent.com)",
-      "WebFetch(domain:developers.openai.com)",
-      "Bash(gh pr diff:*)",
-      "Bash(pytest:*)",
-      "Bash(ruff check:*)",
-      "Bash(ruff format:*)",
-      "Bash(git log:*)",
-      "Bash(git clone:*)",
-      "Bash(git ls-remote:*)",
-      "Bash(git fetch:*)"
-    ]
-  }
+  "outputStyle": "default"
 }

--- a/.cursor/rules/010-implementation-rules.mdc
+++ b/.cursor/rules/010-implementation-rules.mdc
@@ -9,9 +9,13 @@ alwaysApply: true
 
 3. Local testing hints are in [TESTING.md](mdc:TESTING.md)
 
-4. You are working in VSCode devcontainer environment, so no any additional virtual environment management is required. 
+4. **Determining the execution environment:** Before running `pytest`, `ruff`, or `python`, check whether `/.dockerenv` exists:
+   - If `/.dockerenv` **exists** — you are inside the devcontainer. No virtual environment management is required; run tools directly (e.g. `pytest`, `ruff`).
+   - If `/.dockerenv` **does not exist** — you are on the host. Use `uv run <command>` (e.g. `uv run pytest`, `uv run ruff`).
 
-5. If any new package needs to be installed it needs to be done with 'sudo `which uv` pip install --system "<package>"' command. Don't forget to update [pyproject.toml](mdc:pyproject.toml) with the new package.
+5. If any new package needs to be installed, first update [pyproject.toml](mdc:pyproject.toml), then install it:
+   - Inside devcontainer: `sudo \`which uv\` pip install --system "<package>"`
+   - On host: `uv pip install --python .venv "<package>"`
 
 6. **File Size Guidelines**: Regular Python modules should generally not exceed 500 lines of code (LOC). If a module approaches this limit, consider splitting it into multiple focused modules (e.g., `address_tools.py` and `address_tools_advanced.py`) to maintain readability and logical organization.
 

--- a/.cursor/rules/300-ruff-lint-and-format.mdc
+++ b/.cursor/rules/300-ruff-lint-and-format.mdc
@@ -1,14 +1,14 @@
 ---
 description: Applicable to identifying and fixing linting and formatting issues
-globs: 
+globs:
 alwaysApply: false
 ---
 # Instructions to identify and fix linting and formatting issues with Ruff
 
 ### Prerequisites for Ruff usage
 
-- Python 3.11 or higher, with the project installed in development mode
-- Ruff installed: `pip install -e ".[dev]"`
+- Python 3.12, with the project installed in development mode including `[dev]` extras
+- See rule 4 in [010-implementation-rules.mdc](mdc:.cursor/rules/010-implementation-rules.mdc) to determine how to invoke `ruff` based on your environment (devcontainer vs. host)
 
 ### Apply linting & formatting before any PR
 
@@ -20,7 +20,7 @@ ruff format .
 ```
 
 - The `--fix` flag will auto-correct all supported issues.
-- `ruff format .` rewrites code to the Black-compatible style (line-length = 120).
+- `ruff format .` rewrites code to the Black-compatible style (line-length = 120).
 
 ### Handle long docstrings / string literals (E501)
 
@@ -41,4 +41,4 @@ ruff check .
 ruff format --check .
 ```
 
-Both commands must exit with code 0 before your PR can be merged.
+Both commands must exit with code 0 before your PR can be merged.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,30 +5,15 @@
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
-	"forwardPorts": [
-		8000
-	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": {
-		"safe-directory": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-		"uv": "curl -LsSf https://astral.sh/uv/install.sh | sh && sudo `which uv` pip install --system -e \".[test,dev]\" || exit 0",
-		"known_hosts": "sudo chown ${USER}:${USER} ${HOME}/.ssh && ssh-keyscan github.com > ${HOME}/.ssh/known_hosts",
-		"claude": "curl -fsSL https://claude.ai/install.sh | bash",
-		"ngrok": "curl -L https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-arm64.tgz | sudo tar -xvz -C /usr/local/bin || true",
-		"git-editor": "git config --global core.editor /usr/bin/vi"
+		"uv": "curl -LsSf https://astral.sh/uv/install.sh | sh && sudo `which uv` pip install --system -e \".[test,dev]\" || exit 0"
 	},
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/.devcontainer/bin"
 	},
 	// Allows to connect to services on the host machine (e.g Ollama) from inside the container.
 	// "runArgs": [ "--add-host=host.docker.internal:host-gateway"],
-	// "mounts": [
-	// 	"source=${localEnv:HOME}/.ssh/config,target=/home/vscode/.ssh/config,type=bind,consistency=cached",
-	// 	"source=${localEnv:HOME}/.ssh/id_rsa,target=/home/vscode/.ssh/id_rsa,type=bind,consistency=cached",
-	// 	"source=${localEnv:HOME}/.claude.devcontainer.json,target=/home/vscode/.claude.json,type=bind,consistency=cached",
-	// 	"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
-	// 	"source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
-	// ],
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
@@ -41,9 +26,7 @@
 				"charliermarsh.ruff",
 				"tamasfe.even-better-toml",
 				"davidanson.vscode-markdownlint",
-				"yzhang.markdown-all-in-one",
-				"openai.chatgpt",
-				"Anthropic.claude-code"
+				"yzhang.markdown-all-in-one"
 			]
 		}
 	}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Environment variables
 .env
 
+# Virtual environment
+.venv/
+uv.lock
+
 # Python cache
 __pycache__/
 *.py[cod]
@@ -17,6 +21,7 @@ htmlcov/
 
 # local documents
 temp/
+.ai/
 
 # MCP bundle build
 mcpb/_build/

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,9 +13,9 @@ The project includes a comprehensive unit test suite covering all 16 MCP tool fu
 
 ### Prerequisites for Unit Testing
 
-- Python 3.10+ with the project installed in development mode
-- Test dependencies installed: `pip install -e ".[test]"`
-  - This includes `pytest`, `pytest-asyncio`, and `pytest-cov` for coverage reporting
+- Python 3.12 with the project installed in development mode including `[test]` extras (`pytest`, `pytest-asyncio`, `pytest-cov`)
+- **Inside devcontainer** (Cursor, Copilot): dependencies are pre-installed system-wide — no setup needed
+- **On host** (Claude Code): run `uv pip install --python .venv -e ".[test]"` once, then invoke tests via `uv run pytest`
 
 ### Mocking Strategy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "uvicorn>=0.23.1",  # For HTTP Streamable mode
     "web3==7.13.0",
     "mixpanel==4.10.1",
+    # Pin below 1.0 — starlette 1.0.0 removed `add_event_handler`, which mcp 1.26.0 still uses.
+    "starlette<1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This pull request introduces improved enforcement and documentation for Python virtual environment usage across development environments, with a focus on ensuring consistency between host and devcontainer setups. The main changes add a pre-execution Bash hook to block bare Python tool invocations outside the venv, update documentation to clarify environment-specific tool usage, and streamline related configuration files.

@coderabbitai ignore