### PR TITLE
chore: change repository license o Blockscout Software Licence

### DIFF
--- a/.claude/hooks/allow-temp-dirs.py
+++ b/.claude/hooks/allow-temp-dirs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """
 PreToolUse hook to automatically approve Bash mkdir operations for the temp/ directory.
 

--- a/.claude/hooks/allow-temp-writes.py
+++ b/.claude/hooks/allow-temp-writes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """
 PreToolUse hook to automatically approve Write operations to the temp/ directory.
 

--- a/.claude/hooks/tests/test_allow_temp_dirs.py
+++ b/.claude/hooks/tests/test_allow_temp_dirs.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """
 Unit tests for the allow-temp-dirs.py PreToolUse hook.
 

--- a/.claude/hooks/tests/test_allow_temp_writes.py
+++ b/.claude/hooks/tests/test_allow_temp_writes.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """
 Unit tests for the allow-temp-writes.py PreToolUse hook.
 

--- a/.claude/skills/test-guided-tool-run/scripts/find_test.py
+++ b/.claude/skills/test-guided-tool-run/scripts/find_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Helper script to find integration test files for MCP tools."""
 
 import sys

--- a/.gemini/hooks/restrict_write_access.py
+++ b/.gemini/hooks/restrict_write_access.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import json
 import os
 import sys

--- a/.gemini/skills/read-temp-file/scripts/read_temp_file.py
+++ b/.gemini/skills/read-temp-file/scripts/read_temp_file.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import os
 import sys
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,453 @@
-MIT License
+SPDX-License-Identifier: LicenseRef-Blockscout
 
-Copyright (c) 2025 Blockscout
+Effective Date: 2026-05-15
+Version: 1.0 (adapted per repository)
+Previous Version: N/A
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+PLEASE READ THIS LICENCE CAREFULLY. BY DOWNLOADING, ACCESSING, COPYING,
+MODIFYING, DISTRIBUTING, DEPLOYING, OR OTHERWISE USING THE SOFTWARE, YOU
+CONFIRM THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE LEGALLY BOUND BY
+THE TERMS OF THIS LICENCE IN FULL. IF YOU DO NOT AGREE TO THESE TERMS,
+YOU MUST NOT DOWNLOAD, USE, COPY, MODIFY, OR DISTRIBUTE THE SOFTWARE.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Definitions
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE. 
+“Commercial Licence” means a separate written commercial licence
+agreement entered into between you and the Licensor, which expressly
+references this Licence and supplements its terms by granting additional
+rights, or permitting uses, that are not granted or permitted under this
+Licence.
+
+“Derivative Work” means any work, whether in source or object form, that
+is based on or derived from the Software and in which any editorial
+revisions, annotations, elaborations, additions, deletions, or other
+modifications, taken as a whole, constitute an original work of
+authorship. For the avoidance of doubt, Derivative Works do not include
+works that remain separable from, or merely link to, the Software.
+
+“Feedback” means any comments, suggestions, recommendations, ideas,
+proposals, or other feedback, whether oral or written, provided by you in
+connection with or relating to the Software.
+
+“Group” means, in respect of an entity, that entity together with any
+other entity that directly or indirectly controls, is controlled by, or
+is under common control with, that entity. For the purposes of this
+definition, “control” means the direct or indirect ownership of more than
+fifty per cent (50%) of the voting securities or other ownership interest
+of an entity, or the power to direct or cause the direction of the
+management and policies of that entity (whether by ownership, contract,
+or otherwise).
+
+“Licence” means this Blockscout Software Licence, as amended or updated
+from time to time.
+
+“Licensor” means Blockscout Limited, an international business company
+incorporated under the laws of the Republic of Seychelles.
+
+“Prior Software” means any prior version, release, build, or component of
+the Software that was made available by or on behalf of the Licensor
+before the Effective Date, and that is not distributed under this Licence.
+
+“Software” means the Blockscout blockchain explorer, a tool for
+inspecting and analyzing blockchain networks, as made available by the
+Licensor under this Licence, including the source code, object code,
+executable files, configuration and deployment materials, documentation,
+APIs/SDKs (if any), and any part or portion thereof.
+
+“Software” means the Blockscout MCP Server, a tool that wraps Blockscout
+APIs and exposes blockchain data through the Model Context Protocol, as
+made available by the Licensor under this Licence, including the source
+code, object code, executable files, configuration and deployment
+materials, documentation, APIs/SDKs (if any), and any part or portio
+thereof.
+
+“You” or “your” means the individual who accepts this Licence. Where you
+act on behalf of an entity, “you” shall refer to both: (i) you as an
+individual exercising rights under this Licence; and (ii) the entity on
+whose behalf you are acting.
+
+2. Licence and Attribution
+
+  a. Licence. Subject to and conditional upon your compliance with this
+  Licence, the Licensor hereby grants you a temporary, worldwide,
+  non-exclusive, royalty-free, revocable, non-transferable, and
+  non-sublicensable licence to download, review, use, deploy, copy,
+  modify, and create Derivative Works of the Software. All rights not
+  expressly granted under this Licence are reserved by the Licensor.
+
+  b. Branding and Attribution. You shall preserve all copyright, patent,
+  trademark, branding, and attribution notices included in or displayed
+  by the Software, and shall not remove, obscure, conceal, replace,
+  alter, disable, or otherwise interfere with the display or integrity of
+  such notices.
+
+  c. Interface Attribution. Where the Software is used to power, enable,
+  or provide functionality for any user interface (including any website,
+  web application, mobile application, or other frontend), you shall
+  ensure that such interface includes clear and reasonably prominent
+  attribution to the Licensor at all times while you use the Software.
+  Such attribution shall (i) prominently identify the Licensor by the
+  brand name “Blockscout” (such as “Made with Blockscout” or “Powered by
+  Blockscout”), and (ii) include the respective attribution text, link
+  (or a hyperlink) to the website https://blockscout.com and any branding
+  or notices provided by the Licensor, in each case in the same form and
+  manner as displayed in the footer of the following website:
+  https://eth.blockscout.com.
+
+  d. No Endorsement or Service Provision. Except as expressly agreed in
+  writing by the Licensor, the Licensor does not provide, and shall not
+  be deemed to provide, any product or service that you (or any third
+  party) offer, operate, or make available using the Software, and the
+  Licensor is not a party to, and has no responsibility or liability for,
+  any relationship, transaction or interaction between you and any end
+  user or other third party. The Licensor does not endorse, sponsor,
+  approve, or recommend you, your business, or any of your products or
+  services. Except as expressly agreed in writing by the Licensor, you
+  shall not (and shall not authorise or permit any third party to) state,
+  represent, imply, or otherwise hold out that: (i) the Licensor provides
+  any services to or for you; (ii) the Licensor acts on your behalf;
+  (iii) you are acting as an agent, representative, partner, or affiliate
+  of the Licensor; or (iv) the Licensor endorses, sponsors, approves, or
+  recommends you, your business, or any of your products or services.
+
+3. Scope and Updates
+
+  a. Scope. Subject to Third-Party Licences clause, this Licence applies
+  solely to the version of the Software (and its components) with which
+  it is distributed by or on behalf of the Licensor. This Licence does
+  not apply to any Prior Software.
+
+
+  b. Software Changes. The Software is under active development and may
+  be modified, updated, improved, withdrawn, suspended, or discontinued
+  by the Licensor at any time, in whole or in part, with or without
+  notice. The Licensor does not warrant or guarantee that any particular
+  features, functionality, integrations, interfaces, or components of the
+  Software will remain available, unchanged, or compatible with any prior
+  or future versions. You acknowledge and agree that the Software may
+  change over time and that continued use of the Software is at your sole
+  risk.
+
+
+  c. Licence Updates. The Licensor may amend, replace, or update this
+  Licence at any time in its sole discretion, with or without notice.
+  Where you continue to access, use, deploy, copy, modify, or otherwise
+  use the Software after the effective date of an updated Licence, you
+  acknowledge and agree that your continued use constitutes acceptance
+  of, and you shall comply with, the updated Licence. For the avoidance
+  of doubt, an updated Licence may introduce additional restrictions or
+  permissions, including requiring a Commercial Licence for certain uses.
+
+4. Restricted Uses and Commercial Licence
+
+  a. Restricted Commercial or Monetised Use (including SaaS and RaaS).
+  Unless and until you obtain a Commercial Licence, you shall not, and
+  shall not authorise or permit any third party to exercise any rights
+  granted under this Licence to (directly or indirectly) sell, license,
+  monetise, commercialise, or otherwise make available the Software or
+  its functionality to any third party in exchange for any fee or other
+  consideration (including without limitation fees for hosting, access,
+  subscriptions, support, consulting, implementation, customisation,
+  maintenance, managed services, or any other services), where such
+  product or service incorporates, uses, depends on, or is materially
+  enabled by the Software (including offering the Software or its
+  functionality on a hosted, “as-a-service”, or managed basis).
+
+  b. Obtaining Commercial Licence. If you intend to exercise any rights
+  or engage in any uses of the Software that are prohibited, restricted,
+  or not granted under this Licence, you must, prior to such use, contact
+  the Licensor at https://eaas.blockscout.com/#contact to request a
+  Commercial Licence and applicable pricing and terms. Any such rights or
+  uses are unauthorised unless and until a Commercial Licence has been
+  expressly agreed in writing by the Licensor. Nothing in this Licence
+  obliges the Licensor to grant any Commercial Licence or to enter into
+  any agreement with you.
+
+  c. Compliance Verification. Upon the Licensor’s reasonable request, you
+  shall promptly provide the Licensor with such information and
+  documentation as the Licensor may reasonably require to verify your
+  compliance with this Licence, including (without limitation) to confirm
+  whether your use of the Software requires a Commercial Licence. The
+  Licensor shall use any such information solely for compliance
+  verification purposes.
+
+  d. Name and Branding Restrictions. You shall not distribute, market, or
+  otherwise make available the Software or any Derivative Works under any
+  name, designation, branding, or identifier that is identical or
+  confusingly similar to the Licensor’s product names, trademarks,
+  service marks, or trade names, or that is likely to cause confusion as
+  to the origin, sponsorship, affiliation, or endorsement by the Licensor.
+
+5. Derivative Works
+
+  a. Permission. Subject to and conditional upon your compliance with
+  this Licence, you may create Derivative Works of the Software solely
+  for your internal use of the Software.
+
+  b. Restrictions. You shall not distribute, sublicense, sell, license,
+  make available, or otherwise provide any Derivative Works, in whole or
+  in part, to any third party without first obtaining a Commercial
+  Licence.
+
+  c. Ownership and Licence. Except as expressly provided in this Licence,
+  ownership of any Derivative Works shall remain with you.
+  Notwithstanding the foregoing, you hereby grant the Licensor a
+  perpetual, irrevocable, worldwide, royalty-free, non-exclusive,
+  transferable, and sublicensable licence to use, reproduce, modify,
+  adapt, incorporate, and otherwise exploit any Derivative Works for any
+  purpose, including to develop, improve, or distribute the Software.
+
+  d. Tracking of Changes. Where you modify the Software or create any
+  Derivative Works, you shall ensure that any modified files carry
+  prominent notices stating that you have modified the Software and
+  indicating the date of such modification. Any such notices shall not be
+  construed as modifying, limiting, or otherwise affecting this Licence.
+
+  e. Warranties. You represent and warrant that you own or otherwise have
+  all necessary rights to create and license any Derivative Works as
+  contemplated by this Licence, and that such Derivative Works do not
+  infringe any third-party intellectual property rights, violate this
+  Licence, or breach any applicable laws or regulations.
+
+6. Feedback
+
+  a. Permission and Rights. You may, but are not obliged to, provide
+  Feedback. Where you provide any Feedback, you acknowledge and agree
+  that the Licensor may, in its sole discretion, use, reproduce,
+  disclose, make publicly available, and otherwise exploit such Feedback
+  for any purpose, commercial or otherwise, without restriction and
+  without any obligation to you, including without acknowledgment or
+  compensation.
+
+  b. Licence. You hereby grant the Licensor a perpetual, irrevocable,
+  worldwide, royalty-free, transferable, and sublicensable licence to
+  use, reproduce, modify, adapt, publish, translate, distribute, publicly
+  perform, publicly display, and otherwise exploit the Feedback, in whole
+  or in part, in any manner and for any purpose. To the extent permitted
+  by applicable law, you waive, and agree not to assert, any moral rights
+  or similar rights you may have in the Feedback.
+
+  c. Warranties. You represent and warrant that you own or otherwise have
+  all necessary rights to grant the licence set out in this clause, and
+  that the Feedback does not infringe any third-party rights or
+  applicable laws.
+
+7. Ownership
+
+  a. Ownership. The Licensor is and shall remain the sole owner (or,
+  where applicable, the authorised licensor) of the Software. Nothing in
+  this Licence shall operate to assign, transfer, or otherwise convey to
+  you any right, title, or interest in or to the Software, save for the
+  limited licence expressly granted under this Licence and the Commercial
+  Licence, if applicable. All rights are licensed, not sold. You shall
+  not take, or assist others in taking, any action that may diminish the
+  Licensor's rights in the Software.
+
+  b. Branding. Subject to your compliance with this Licence, the Licensor
+  hereby grants you a temporary, worldwide, non-exclusive, royalty-free,
+  revocable, non-transferable, and non-sublicensable licence to display
+  the Licensor’s trademarks, trade names, and logos as provided along
+  with the Software or as required under this Licence, solely for
+  attribution purposes as required under this Licence. Except for the
+  foregoing, no rights in any trademarks, trade names, or logos of the
+  Licensor or its affiliates are granted under this Licence.
+
+  c. Third-Party Licences. While the Software is made available in its
+  entirety under this Licence, certain components of the Software may
+  incorporate or be derived from third-party open-source software
+  provided under permissive licences. Such specific third-party
+  open-source software components are distributed under the terms of the
+  applicable third-party licences. To the extent required by such
+  third-party licences, applicable copyright notices, licence texts, and
+  attribution requirements shall be preserved. Subject to the foregoing,
+  the Software as a whole, and all parts thereof, is licensed under this
+  Licence.
+
+8. Disclaimers
+
+To the maximum extent permitted by applicable law, the Software is
+provided on an “AS IS” and “AS AVAILABLE” basis and is used at your sole
+risk. The Licensor disclaims all warranties of any kind, whether express,
+implied, statutory, or otherwise, including (without limitation) any
+implied warranties of merchantability, satisfactory quality, fitness for
+a particular purpose, non-infringement, and title, and any warranties
+arising out of course of dealing, course of performance, or usage of
+trade. Without limiting the foregoing, the Licensor makes no
+representation or warranty that the Software will function as expected,
+meet your requirements, operate in combination with any other software,
+have any specific functionality, be uninterrupted, timely, secure,
+accurate, complete, or error-free, or that any defects or errors will be
+corrected. Nothing in this Licence excludes or limits any warranty,
+liability, or other term to the extent it cannot be excluded or limited
+under applicable law. The Software is provided for informational and
+technical purposes only and does not constitute legal, financial, tax,
+investment, or other professional advice. You are solely responsible for
+determining whether use of the Software is appropriate for your purposes.
+
+9. Limitation of Liability
+
+Nothing in this Licence excludes or limits liability for: (i) death or
+personal injury caused by negligence; (ii) fraud or fraudulent
+misrepresentation; or (iii) any other liability which cannot be excluded
+or limited under applicable law. Subject to the foregoing, to the maximum
+extent permitted by applicable law, the Licensor shall not be liable to
+you for any loss or damage whatsoever (whether direct, indirect,
+incidental, special, punitive or consequential), or for any loss of
+profits, revenue, business, business opportunity, anticipated savings,
+goodwill or data, or for any business interruption, arising out of or in
+connection with the use of, or inability to use, the Software, whether in
+contract, tort (including negligence), misrepresentation, restitution,
+breach of statutory duty, or otherwise, even if advised of the
+possibility of such loss or damage. To the extent that the Licensor is
+held liable notwithstanding the above, the total aggregate liability
+arising out of or in connection with this Licence or the Software shall
+not exceed the total amounts actually paid by you to the Licensor under
+this Licence in the twelve (12) months preceding the event giving rise to
+the claim (or, if no such amounts were paid, USD 100).
+
+10. Term and Termination
+
+  a. Automatic Termination. This Licence shall automatically terminate,
+  without any further action by the Licensor, upon any breach by you of
+  its terms.
+
+  b. Termination by the Licensor. The Licensor may terminate this Licence
+  at any time in its sole discretion. Where reasonably practicable, the
+  Licensor will use reasonable efforts to provide you with advance notice
+  of termination.
+
+  c. Effect of Termination. Upon termination of this Licence for any
+  reason: (i) all rights granted to you under this Licence shall
+  immediately cease; (ii) all Commercial Licences executed with you shall
+  automatically terminate simultaneously with this Licence; (iii) you
+  shall immediately cease all access to and use of the Software and any
+  Derivative Works; (iv) you shall uninstall and delete the Software and
+  any Derivative Works from all systems under your control and destroy
+  all copies in your possession or control (in each case including any
+  copies held by your contractors or service providers), except to the
+  extent retention is required by applicable law; (v) you shall
+  immediately cease all distribution or making available of the Software
+  and any Derivative Works; and (vi) any provisions of this Licence which
+  by their nature are intended to survive termination shall survive,
+  including without limitation provisions relating to ownership,
+  trademarks, feedback, disclaimers, limitation of liability, and
+  governing law and jurisdiction.
+
+11. Governing Law and Arbitration
+
+  a. Governing Law. This Licence and any dispute or claim (including
+  non-contractual disputes or claims) arising out of or in connection
+  with it or its subject matter or formation shall be governed by and
+  construed in accordance with the law of England and Wales, excluding
+  its conflict of law rules. For the avoidance of doubt, the provisions
+  of the United Nations Convention on the International Sale of Goods
+  shall not apply to this Licence.
+
+  b. Dispute Resolution. The parties shall first attempt to resolve any
+  dispute arising out of or in connection with this Licence informally.
+  You may initiate such informal discussions by giving notice to the
+  Licensor by email at info@blockscout.com. If the dispute is not
+  resolved within thirty (30) days of such notice, the dispute shall be
+  referred to and finally resolved by arbitration under the LCIA Rules,
+  which Rules are deemed incorporated by reference into this clause. The
+  seat (legal place) of arbitration shall be London, United Kingdom. The
+  tribunal shall consist of one (1) arbitrator. The language of the
+  arbitration shall be English. The governing law of this arbitration
+  agreement shall be the laws of England and Wales. To the maximum extent
+  permitted by applicable law, you may bring claims against the Licensor
+  only in your individual capacity and not as a claimant or class member
+  in any purported class, collective, consolidated, or representative
+  proceeding. Any notices, requests, demands, or other communications
+  given in connection with the arbitration may be sent in electronic
+  form, including via email or any electronic filing system operated by
+  the LCIA, and shall be deemed received when successfully transmitted to
+  the recipient (as evidenced by no delivery failure notice).
+
+12. Miscellaneous
+
+  a. Injunctive Relief. You acknowledge and agree that any breach of this
+  Licence (including any breach of the restrictions on use of the
+  Software) may cause the Licensor irreparable harm for which damages may
+  not be an adequate remedy. Accordingly, the Licensor shall be entitled
+  to seek injunctive relief, specific performance, and/or any other
+  equitable relief for any such breach, in addition to any other rights
+  or remedies available at law.
+
+  b. Rights and Remedies. The rights and remedies provided under this
+  Licence are cumulative and are in addition to, and not exclusive of,
+  any rights or remedies provided by law. Any right or remedy may be
+  exercised as often as required.
+
+  c. Assignment. Unless otherwise permitted under this Licence, you shall
+  not assign, transfer, charge, subcontract, declare a trust over, or
+  deal in any other manner with any of your rights or obligations under
+  this Licence without the prior written consent of the Licensor. The
+  Licensor may at any time assign, transfer, charge, subcontract, or
+  otherwise deal with any of its rights or obligations under this Licence
+  without your consent or notice to you.
+
+  d. Severability. If any provision (or part of a provision) of this
+  Licence is found by any court or competent authority to be invalid,
+  illegal, or unenforceable, that provision (or part-provision) shall be
+  deemed modified to the minimum extent necessary to make it valid,
+  legal, and enforceable. If such modification is not possible, the
+  relevant provision (or part-provision) shall be deemed deleted. Any
+  modification to or deletion of a provision (or part-provision) under
+  this clause shall not affect the validity and enforceability of the
+  remainder of this Licence.
+
+  e. Entire Agreement. This Licence (together with the Commercial
+  Licence, if any) constitutes the entire agreement between you and the
+  Licensor in relation to its subject matter and supersedes and
+  extinguishes all prior and contemporaneous agreements, understandings,
+  negotiations, representations, and arrangements between the parties,
+  whether written or oral. You acknowledge and agree that you shall have
+  no remedies in respect of any statement, representation, assurance, or
+  warranty (whether made innocently or negligently) that is not set out
+  in this Licence (or the Commercial Licence).
+
+  f. Commercial Licence. If a Commercial Licence is in place, it forms an
+  integral part of this Licence. In the event of any conflict or
+  inconsistency between the terms of this Licence and the Commercial
+  Licence, the terms of the Commercial Licence shall prevail to the
+  extent of such conflict or inconsistency.
+
+  g. Notices. Any notice or other communication given by the Licensor
+  under or in connection with this Licence may be given using any
+  available means reasonably selected by the Licensor, including (without
+  limitation) publication of notice in the Software repository, on the
+  Licensor’s website, or through any other communication channel
+  reasonably selected by the Licensor. Where you have a Commercial
+  Licence in force, any notice or other communication given by the
+  Licensor under or in connection with this Licence shall be in writing
+  and may be delivered by email to the email address(es) specified for
+  notices in the executed Commercial Licence. A notice sent by email
+  shall be deemed received: (i) if sent during normal business hours, at
+  the time of transmission; or (ii) if sent outside normal business
+  hours, at 9:00 a.m. on the next business day. Notices sent by email
+  shall be legally effective.
+
+  h. Waiver. No failure or delay by the Licensor to exercise any right or
+  remedy under this Licence or by law shall constitute a waiver of that
+  or any other right or remedy, nor shall it prevent or restrict any
+  further exercise of that or any other right or remedy. No single or
+  partial exercise of any right or remedy shall prevent or restrict the
+  further exercise of that or any other right or remedy.
+
+  i. Third Party Rights. Except as expressly provided in this clause, a
+  person who is not a party to this Licence shall not have any rights
+  under the Contracts (Rights of Third Parties) Act 1999 to enforce any
+  term of this Licence. Notwithstanding the foregoing, the Licensor’s
+  affiliates and the Licensor’s directors, officers, employees,
+  contractors, agents, representatives, and other personnel shall be
+  entitled, pursuant to the Contracts (Rights of Third Parties) Act 1999,
+  to enforce and rely on any provision of this Licence that limits or
+  excludes the liability of the Licensor (including any limitations and
+  exclusions of liability and any indemnities in favour of the Licensor)
+  as if they were parties to this Licence. This Licence may be amended,
+  varied, terminated, or rescinded (in whole or in part) without the
+  consent of any such person.
+
+END OF THE LICENCE
+
+Copyright © Blockscout Limited 2026

--- a/README.md
+++ b/README.md
@@ -354,4 +354,6 @@ export BLOCKSCOUT_DISABLE_COMMUNITY_TELEMETRY=true
 
 ## License
 
-This project is primarily distributed under the terms of the MIT license. See [LICENSE](LICENSE) for details.
+[![License: Blockscout Software Licence](https://img.shields.io/badge/License-Blockscout%20Software%20Licence-blue.svg)](LICENSE)
+
+This project is licensed under the Blockscout Software Licence. See the [LICENSE](LICENSE) file for full terms.

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
 __version__ = "0.15.0"

--- a/blockscout_mcp_server/__main__.py
+++ b/blockscout_mcp_server/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from blockscout_mcp_server.server import run_server_cli
 
 if __name__ == "__main__":

--- a/blockscout_mcp_server/analytics.py
+++ b/blockscout_mcp_server/analytics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Centralized Mixpanel analytics for MCP tool invocations.
 
 Tracking is enabled only when:

--- a/blockscout_mcp_server/api/__init__.py
+++ b/blockscout_mcp_server/api/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/api/dependencies.py
+++ b/blockscout_mcp_server/api/dependencies.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Dependencies for the REST API, such as mock context providers."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/api/helpers.py
+++ b/blockscout_mcp_server/api/helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Shared utilities for REST API route handlers."""
 
 from collections.abc import Awaitable, Callable

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Module for registering all REST API routes with the FastMCP server."""
 
 import json

--- a/blockscout_mcp_server/cache.py
+++ b/blockscout_mcp_server/cache.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Simple in-memory cache for chain metadata."""
 
 import time

--- a/blockscout_mcp_server/client_meta.py
+++ b/blockscout_mcp_server/client_meta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Client metadata extraction and defaults shared across logging and analytics."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/config.py
+++ b/blockscout_mcp_server/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Constants used throughout the Blockscout MCP Server."""
 
 from blockscout_mcp_server import __version__

--- a/blockscout_mcp_server/logging_utils.py
+++ b/blockscout_mcp_server/logging_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Logging utilities for the Blockscout MCP Server."""
 
 import logging

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Pydantic models for standardized tool responses."""
 
 from typing import Any, Generic, TypeVar

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import json
 from functools import wraps
 from pathlib import Path

--- a/blockscout_mcp_server/telemetry.py
+++ b/blockscout_mcp_server/telemetry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import logging
 
 import httpx

--- a/blockscout_mcp_server/tools/__init__.py
+++ b/blockscout_mcp_server/tools/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Tools package for Blockscout MCP Server."""

--- a/blockscout_mcp_server/tools/address/__init__.py
+++ b/blockscout_mcp_server/tools/address/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/address/get_address_info.py
+++ b/blockscout_mcp_server/tools/address/get_address_info.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 import json
 from typing import Annotated

--- a/blockscout_mcp_server/tools/address/get_tokens_by_address.py
+++ b/blockscout_mcp_server/tools/address/get_tokens_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/address/nft_tokens_by_address.py
+++ b/blockscout_mcp_server/tools/address/nft_tokens_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/block/__init__.py
+++ b/blockscout_mcp_server/tools/block/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/block/get_block_info.py
+++ b/blockscout_mcp_server/tools/block/get_block_info.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 from typing import Annotated
 

--- a/blockscout_mcp_server/tools/block/get_block_number.py
+++ b/blockscout_mcp_server/tools/block/get_block_number.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from datetime import UTC, datetime
 from typing import Annotated
 

--- a/blockscout_mcp_server/tools/chains/__init__.py
+++ b/blockscout_mcp_server/tools/chains/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/chains/get_chains_list.py
+++ b/blockscout_mcp_server/tools/chains/get_chains_list.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from mcp.server.fastmcp import Context
 
 from blockscout_mcp_server.models import ChainInfo, ToolResponse

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import base64
 import json
 import logging

--- a/blockscout_mcp_server/tools/contract/__init__.py
+++ b/blockscout_mcp_server/tools/contract/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/contract/_shared.py
+++ b/blockscout_mcp_server/tools/contract/_shared.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Any
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/contract/get_contract_abi.py
+++ b/blockscout_mcp_server/tools/contract/get_contract_abi.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/contract/inspect_contract_code.py
+++ b/blockscout_mcp_server/tools/contract/inspect_contract_code.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/contract/read_contract.py
+++ b/blockscout_mcp_server/tools/contract/read_contract.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import json
 from typing import Annotated, Any
 

--- a/blockscout_mcp_server/tools/decorators.py
+++ b/blockscout_mcp_server/tools/decorators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 import functools
 import inspect

--- a/blockscout_mcp_server/tools/direct_api/__init__.py
+++ b/blockscout_mcp_server/tools/direct_api/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/direct_api/direct_api_call.py
+++ b/blockscout_mcp_server/tools/direct_api/direct_api_call.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import json
 from typing import Annotated, Any
 

--- a/blockscout_mcp_server/tools/direct_api/dispatcher.py
+++ b/blockscout_mcp_server/tools/direct_api/dispatcher.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Dispatcher for direct_api_call tool to route to specialized handlers."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/tools/direct_api/handlers/__init__.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Import all handlers in this package to trigger registration with the dispatcher."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/tools/direct_api/handlers/address_logs_handler.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/address_logs_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Specialized handler for processing address logs responses."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/tools/direct_api/handlers/transaction_logs_handler.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/transaction_logs_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Specialized handler for processing transaction logs responses."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/tools/direct_api/handlers/transaction_summary_handler.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/transaction_summary_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Specialized handler for processing transaction summary responses."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/tools/direct_api/handlers/user_operation_handler.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/user_operation_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Specialized handler for processing user operation responses."""
 
 from __future__ import annotations

--- a/blockscout_mcp_server/tools/ens/__init__.py
+++ b/blockscout_mcp_server/tools/ens/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/ens/get_address_by_ens_name.py
+++ b/blockscout_mcp_server/tools/ens/get_address_by_ens_name.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/initialization/__init__.py
+++ b/blockscout_mcp_server/tools/initialization/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
+++ b/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from mcp.server.fastmcp import Context
 
 from blockscout_mcp_server.constants import (

--- a/blockscout_mcp_server/tools/search/__init__.py
+++ b/blockscout_mcp_server/tools/search/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/search/lookup_token_by_symbol.py
+++ b/blockscout_mcp_server/tools/search/lookup_token_by_symbol.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/transaction/__init__.py
+++ b/blockscout_mcp_server/tools/transaction/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout

--- a/blockscout_mcp_server/tools/transaction/_shared.py
+++ b/blockscout_mcp_server/tools/transaction/_shared.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from mcp.server.fastmcp import Context
 
 from blockscout_mcp_server.config import config

--- a/blockscout_mcp_server/tools/transaction/get_token_transfers_by_address.py
+++ b/blockscout_mcp_server/tools/transaction/get_token_transfers_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/tools/transaction/get_transaction_info.py
+++ b/blockscout_mcp_server/tools/transaction/get_transaction_info.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 from typing import Annotated
 

--- a/blockscout_mcp_server/tools/transaction/get_transactions_by_address.py
+++ b/blockscout_mcp_server/tools/transaction/get_transactions_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Annotated
 
 from mcp.server.fastmcp import Context

--- a/blockscout_mcp_server/web3_pool.py
+++ b/blockscout_mcp_server/web3_pool.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Async Web3 connection pool optimized for Blockscout RPC.
 
 The custom provider in this module normalizes JSON-RPC parameters and enforces

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Tests for the REST API routes."""
 
 from unittest.mock import ANY, AsyncMock, MagicMock, patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 # tests/conftest.py
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 # Integration tests for Blockscout MCP Server
 #
 # These tests make real network calls to live APIs and are slower than unit tests.

--- a/tests/integration/address/test_get_address_info_real.py
+++ b/tests/integration/address/test_get_address_info_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT

--- a/tests/integration/address/test_get_tokens_by_address_real.py
+++ b/tests/integration/address/test_get_tokens_by_address_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import ToolResponse

--- a/tests/integration/address/test_nft_tokens_by_address_real.py
+++ b/tests/integration/address/test_nft_tokens_by_address_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import NftCollectionHolding, ToolResponse

--- a/tests/integration/block/test_get_block_info_real.py
+++ b/tests/integration/block/test_get_block_info_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.tools.block.get_block_info import get_block_info

--- a/tests/integration/block/test_get_block_number_real.py
+++ b/tests/integration/block/test_get_block_number_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.tools.block.get_block_number import get_block_number

--- a/tests/integration/chains/test_get_chains_list_real.py
+++ b/tests/integration/chains/test_get_chains_list_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 import time
 from unittest.mock import AsyncMock, patch

--- a/tests/integration/contract/test_get_contract_abi_real.py
+++ b/tests/integration/contract/test_get_contract_abi_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import ContractAbiData, ToolResponse

--- a/tests/integration/contract/test_inspect_contract_code_real.py
+++ b/tests/integration/contract/test_inspect_contract_code_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import aiohttp
 import pytest
 

--- a/tests/integration/contract/test_read_contract_real.py
+++ b/tests/integration/contract/test_read_contract_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/integration/direct_api/test_address_logs_handler_real.py
+++ b/tests/integration/direct_api/test_address_logs_handler_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import AddressLogItem, ToolResponse

--- a/tests/integration/direct_api/test_direct_api_call_real.py
+++ b/tests/integration/direct_api/test_direct_api_call_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.config import config

--- a/tests/integration/direct_api/test_transaction_logs_handler_real.py
+++ b/tests/integration/direct_api/test_transaction_logs_handler_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.constants import LOG_DATA_TRUNCATION_LIMIT

--- a/tests/integration/direct_api/test_transaction_summary_handler_real.py
+++ b/tests/integration/direct_api/test_transaction_summary_handler_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import ToolResponse, TransactionSummaryData

--- a/tests/integration/direct_api/test_user_operation_handler_real.py
+++ b/tests/integration/direct_api/test_user_operation_handler_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import ToolResponse, UserOperationData

--- a/tests/integration/ens/test_get_address_by_ens_name_real.py
+++ b/tests/integration/ens/test_get_address_by_ens_name_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import EnsAddressData, ToolResponse

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar

--- a/tests/integration/search/test_lookup_token_by_symbol_real.py
+++ b/tests/integration/search/test_lookup_token_by_symbol_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import TokenSearchResult, ToolResponse

--- a/tests/integration/test_common_helpers.py
+++ b/tests/integration/test_common_helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 # tests/integration/test_common_helpers.py
 import pytest
 

--- a/tests/integration/transaction/test_get_token_transfers_by_address_real.py
+++ b/tests/integration/transaction/test_get_token_transfers_by_address_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import AdvancedFilterItem, ToolResponse

--- a/tests/integration/transaction/test_get_transaction_info_real.py
+++ b/tests/integration/transaction/test_get_transaction_info_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.constants import INPUT_DATA_TRUNCATION_LIMIT

--- a/tests/integration/transaction/test_get_transactions_by_address_real.py
+++ b/tests/integration/transaction/test_get_transactions_by_address_real.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import pytest
 
 from blockscout_mcp_server.models import AdvancedFilterItem, ToolResponse

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import types
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_analytics_helpers.py
+++ b/tests/test_analytics_helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from types import SimpleNamespace
 
 from blockscout_mcp_server.analytics import _build_distinct_id, _extract_request_ip

--- a/tests/test_analytics_source.py
+++ b/tests/test_analytics_source.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from types import SimpleNamespace
 
 from blockscout_mcp_server.analytics import _determine_call_source

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from collections.abc import Callable
 from unittest.mock import patch
 

--- a/tests/test_client_meta.py
+++ b/tests/test_client_meta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from types import SimpleNamespace
 
 from mcp.types import RequestParams

--- a/tests/test_integration_helpers.py
+++ b/tests/test_integration_helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock
 
 import httpx

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Unit tests for blockscout_mcp_server.logging_utils module."""
 
 import logging

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 """Tests for the Pydantic response models."""
 
 import json

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import importlib
 import json
 import re

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import ANY, AsyncMock, patch
 
 import pytest

--- a/tests/test_web3_pool.py
+++ b/tests/test_web3_pool.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp

--- a/tests/tools/address/test_get_address_info.py
+++ b/tests/tools/address/test_get_address_info.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx

--- a/tests/tools/address/test_get_tokens_by_address.py
+++ b/tests/tools/address/test_get_tokens_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/tools/address/test_nft_tokens_by_address.py
+++ b/tests/tools/address/test_nft_tokens_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, patch
 
 import httpx

--- a/tests/tools/address/test_nft_tokens_by_address_pagination.py
+++ b/tests/tools/address/test_nft_tokens_by_address_pagination.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import ANY, AsyncMock, patch
 
 import pytest

--- a/tests/tools/block/test_get_block_info.py
+++ b/tests/tools/block/test_get_block_info.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx

--- a/tests/tools/block/test_get_block_number.py
+++ b/tests/tools/block/test_get_block_number.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/tools/chains/test_get_chains_list.py
+++ b/tests/tools/chains/test_get_chains_list.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/tools/contract/test_fetch_and_process_contract.py
+++ b/tests/tools/contract/test_fetch_and_process_contract.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/tools/contract/test_get_contract_abi.py
+++ b/tests/tools/contract/test_get_contract_abi.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/tools/contract/test_inspect_contract_code.py
+++ b/tests/tools/contract/test_inspect_contract_code.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/tools/contract/test_read_contract.py
+++ b/tests/tools/contract/test_read_contract.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/tools/direct_api/handlers/test_address_logs_handler.py
+++ b/tests/tools/direct_api/handlers/test_address_logs_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from __future__ import annotations
 
 import re

--- a/tests/tools/direct_api/handlers/test_transaction_logs_handler.py
+++ b/tests/tools/direct_api/handlers/test_transaction_logs_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from __future__ import annotations
 
 import re

--- a/tests/tools/direct_api/handlers/test_transaction_summary_handler.py
+++ b/tests/tools/direct_api/handlers/test_transaction_summary_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from __future__ import annotations
 
 import re

--- a/tests/tools/direct_api/handlers/test_user_operation_handler.py
+++ b/tests/tools/direct_api/handlers/test_user_operation_handler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from __future__ import annotations
 
 import re

--- a/tests/tools/direct_api/test_direct_api_call.py
+++ b/tests/tools/direct_api/test_direct_api_call.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/tools/direct_api/test_dispatcher.py
+++ b/tests/tools/direct_api/test_dispatcher.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from __future__ import annotations
 
 import re

--- a/tests/tools/ens/test_get_address_by_ens_name.py
+++ b/tests/tools/ens/test_get_address_by_ens_name.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/tools/initialization/test___unlock_blockchain_analysis__.py
+++ b/tests/tools/initialization/test___unlock_blockchain_analysis__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import patch
 
 import pytest

--- a/tests/tools/search/test_lookup_token_by_symbol.py
+++ b/tests/tools/search/test_lookup_token_by_symbol.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import patch
 
 import httpx

--- a/tests/tools/test_common_truncate.py
+++ b/tests/tools/test_common_truncate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from blockscout_mcp_server.tools.common import (
     INPUT_DATA_TRUNCATION_LIMIT,
     _truncate_constructor_args,

--- a/tests/tools/test_decorators.py
+++ b/tests/tools/test_decorators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 import asyncio
 import logging
 from types import SimpleNamespace

--- a/tests/tools/transaction/test_get_token_transfers_by_address.py
+++ b/tests/tools/transaction/test_get_token_transfers_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import ANY, AsyncMock, patch
 
 import pytest

--- a/tests/tools/transaction/test_get_transaction_info.py
+++ b/tests/tools/transaction/test_get_transaction_info.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx

--- a/tests/tools/transaction/test_get_transactions_by_address.py
+++ b/tests/tools/transaction/test_get_transactions_by_address.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/tools/transaction/test_get_transactions_by_address_pagination.py
+++ b/tests/tools/transaction/test_get_transactions_by_address_pagination.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/tools/transaction/test_helpers.py
+++ b/tests/tools/transaction/test_helpers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 from blockscout_mcp_server.tools.transaction._shared import (
     _transform_advanced_filter_item,
     _transform_transaction_info,


### PR DESCRIPTION
Change repository license from MIT to Blockscout Software Licence; adapt Software definition to Blockscout MCP Server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **License**
  * Updated project license from MIT to Blockscout Software Licence with commercial use restrictions.

* **Improvements**
  * Enhanced Web3 connection pooling and request handling for improved reliability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/mcp-server/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->