### PR TITLE
Codex sessions bootstrap with a hook instead of the skill

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/bash \"$(git rev-parse --show-toplevel)/.codex/hooks/append_context.sh\"",
+            "statusMessage": "Loading repository rules"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/append_context.sh
+++ b/.codex/hooks/append_context.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(git rev-parse --show-toplevel)"
+
+readonly CONTEXT_FILES=(
+  ".cursor/AGENTS.md"
+  ".cursor/rules/000-role-and-task.mdc"
+  ".cursor/rules/010-implementation-rules.mdc"
+)
+
+for rel_path in "${CONTEXT_FILES[@]}"; do
+  if [[ ! -f "${PROJECT_DIR}/${rel_path}" ]]; then
+    printf '{"continue":false,"stopReason":"Required context file missing: %s","systemMessage":"Required context file missing: %s"}\n' "${rel_path}" "${rel_path}"
+    exit 0
+  fi
+done
+
+for rel_path in "${CONTEXT_FILES[@]}"; do
+  printf '<memory_file path="%s">\n' "${rel_path}"
+  cat "${PROJECT_DIR}/${rel_path}"
+  printf '\n</memory_file>\n'
+done


### PR DESCRIPTION
The skill was used before since Codex had no hooks functionality. Now with the hooks, the bootstraps can be done more efficiently.

@coderabbitai ignore
skip codex