### PR TITLE
Remove BLOCKSCOUT_BS_API_KEY and stop injecting apikey into Blockscout requests

### DIFF
--- a/.cursor/rules/110-new-mcp-tool.mdc
+++ b/.cursor/rules/110-new-mcp-tool.mdc
@@ -14,7 +14,6 @@ If your new tool needs to access an API endpoint that is different from the exis
    ```python
    class ServerConfig(BaseSettings):
        # Existing endpoints (examples)
-       bs_api_key: str = ""
        bs_timeout: float = 120.0
        bens_url: str = "https://bens.services.blockscout.com"
        bens_timeout: float = 30.0

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-BLOCKSCOUT_BS_API_KEY=""
-
 BLOCKSCOUT_BENS_URL="https://bens.services.blockscout.com"
 
 BLOCKSCOUT_CHAINSCOUT_URL="http://chains.blockscout.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,6 @@ mcp-server/
     * **`.env.example`**:
         * Provides a template for users to create their own `.env` file for local development.
         * Lists all required environment variables, such as:
-            * `BLOCKSCOUT_BS_API_KEY`: API key for Blockscout API access (if required).
             * `BLOCKSCOUT_BS_TIMEOUT`: Timeout for Blockscout API requests.
             * `BLOCKSCOUT_BENS_URL`: Base URL for the BENS (Blockscout ENS) API.
             * `BLOCKSCOUT_BENS_TIMEOUT`: Timeout for BENS API requests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ ENV PYTHONUNBUFFERED=1
 
 # Expose environment variables that can be set at runtime
 # Set defaults here to document expected environment variables
-# ENV BLOCKSCOUT_BS_API_KEY="" # It is commented out because docker build warns about sensitive data in ENV instructions
 ENV BLOCKSCOUT_BS_TIMEOUT="120.0"
 ENV BLOCKSCOUT_BS_REQUEST_MAX_RETRIES="3"
 ENV BLOCKSCOUT_BENS_URL="https://bens.services.blockscout.com"

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.16.0.dev5"
+__version__ = "0.16.0.dev6"

--- a/blockscout_mcp_server/config.py
+++ b/blockscout_mcp_server/config.py
@@ -8,7 +8,6 @@ class ServerConfig(BaseSettings):
     # and require the BLOCKSCOUT_ prefix for all settings
     model_config = SettingsConfigDict(env_prefix="BLOCKSCOUT_", env_file=".env", env_file_encoding="utf-8")
 
-    bs_api_key: str = ""  # Default to empty, can be set via env
     bs_timeout: float = 120.0  # Default timeout in seconds
     bs_light_timeout: float = 20.0  # Default timeout for simple point-lookup requests
     bs_request_max_retries: int = 3  # Conservative retries for transient transport errors

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -253,8 +253,6 @@ async def _make_blockscout_http_request(
     effective_timeout = timeout if timeout is not None else config.bs_timeout
     async with _create_httpx_client(timeout=effective_timeout) as client:
         local_params = dict(params) if params is not None else {}
-        if config.bs_api_key:
-            local_params["apikey"] = config.bs_api_key
 
         url = f"{base_url.rstrip('/')}/{api_path.lstrip('/')}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.16.0.dev5"
+version = "0.16.0.dev6"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.16.0.dev5",
+  "version": "0.16.0.dev6",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,3 +18,9 @@ def test_server_config_light_timeout_env_override(monkeypatch):
     config = ServerConfig(_env_file=None)
 
     assert config.bs_light_timeout == 42.0
+
+
+def test_server_config_does_not_expose_bs_api_key():
+    config = ServerConfig(_env_file=None)
+
+    assert not hasattr(config, "bs_api_key")

--- a/tests/tools/test_common_post_request.py
+++ b/tests/tools/test_common_post_request.py
@@ -24,7 +24,7 @@ class MockResponse:
 
 
 @pytest.mark.asyncio
-async def test_make_blockscout_post_request_success_with_params_and_apikey():
+async def test_make_blockscout_post_request_success_with_params_preserved():
     calls = []
 
     class Client:
@@ -38,13 +38,10 @@ async def test_make_blockscout_post_request_success_with_params_and_apikey():
             calls.append((url, json, params.copy()))
             return MockResponse({"ok": True})
 
-    with (
-        patch("blockscout_mcp_server.tools.common._create_httpx_client", return_value=Client()),
-        patch("blockscout_mcp_server.tools.common.config.bs_api_key", "k"),
-    ):
+    with patch("blockscout_mcp_server.tools.common._create_httpx_client", return_value=Client()):
         data = await make_blockscout_post_request("https://a", "/b", {"x": 1}, {"q": "1"})
     assert data == {"ok": True}
-    assert calls[0][2]["apikey"] == "k"
+    assert calls[0][2] == {"q": "1"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- The `BLOCKSCOUT_BS_API_KEY` / `bs_api_key` configuration is unused and should be removed to avoid carrying dead configuration and accidental injection of credentials. 
- Automatic addition of an `apikey` query parameter to every Blockscout request is unnecessary and surprising to callers. 
- Update tests and docs to prevent accidental reintroduction and to document the current configuration surface.

### Description
- Removed the `bs_api_key` field from `ServerConfig` in `blockscout_mcp_server/config.py` so the environment variable is no longer exposed.  
- Stopped injecting an `apikey` query parameter in `_make_blockscout_http_request` within `blockscout_mcp_server/tools/common.py` so requests only include the params callers pass.  
- Replaced the apikey-specific unit test with a guard test `test_make_blockscout_post_request_success_with_params_preserved` in `tests/tools/test_common_post_request.py` that asserts request params are preserved exactly.  
- Added `test_server_config_does_not_expose_bs_api_key` to `tests/test_config.py` to guard the config surface.  
- Removed template and documentation references: `.env.example`, `AGENTS.md`, `Dockerfile`, and the `.cursor/rules/110-new-mcp-tool.mdc` ServerConfig example.  
- Files changed: `blockscout_mcp_server/config.py`, `blockscout_mcp_server/tools/common.py`, `tests/tools/test_common_post_request.py`, `tests/test_config.py`, `.env.example`, `AGENTS.md`, `Dockerfile`, `.cursor/rules/110-new-mcp-tool.mdc`.

### Testing
- Ran targeted unit tests: `pytest tests/tools/test_common_post_request.py tests/test_config.py -v` and the modified tests passed.  
- Ran the full unit test suite: `pytest` — result: all unit tests passed (`537 passed`).  
- Ran integration suite: `pytest -m integration` — most integration tests passed, with a single external-service failure in `tests/integration/test_common_helpers.py::test_make_blockscout_post_request_eth_rpc` caused by an upstream `503 Service Unavailable` from `https://eth.blockscout.com/api/eth-rpc`, not by these changes.  
- Ran lint/format checks: `ruff check .` and `ruff format --check .` — both passed.  
- Performed a project search for leftover references to `BLOCKSCOUT_BS_API_KEY|bs_api_key|config.bs_api_key` and validated the new guard test is the intended presence.  

Closes #366

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1703c8e8f08323834b4a8ffc7b22e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Removed the `BLOCKSCOUT_BS_API_KEY` environment variable and related API key configuration field. This setting is no longer required or supported.

* **Chores**
  * Bumped version to `0.16.0.dev6`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/mcp-server/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->