### PR TITLE
chore: add pytest-timeout to prevent unit test hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     name: Run Unit Tests
     # The job will run on the latest version of Ubuntu
     runs-on: ubuntu-latest
+    # Backstop: if pytest-timeout fails to kill a hung test, don't let the
+    # job run for the full GitHub Actions default (6 hours).
+    timeout-minutes: 5
 
     # This creates a build matrix to test against multiple Python versions,
     # ensuring broad compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ blockscout-mcp-server = "blockscout_mcp_server.server:run_server_cli" # For CLI 
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
-    "pytest-cov>=4.0.0"
+    "pytest-cov>=4.0.0",
+    "pytest-timeout>=2.3.0"
 ]
 dev = [
     "ruff>=0.12.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 # pytest.ini
 [pytest]
 addopts = -m "not integration" --ignore=temp
+timeout = 10
 asyncio_default_fixture_loop_scope = function
 markers =
     integration: marks tests as integration tests (makes real network calls) 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,16 @@ import pytest
 
 from blockscout_mcp_server.config import config
 
+def pytest_collection_modifyitems(items):
+    """Disable pytest-timeout for integration tests.
+
+    Integration tests make real network calls that legitimately take 30-120s.
+    The subprocess runner (scripts/run_integration_tests.py) enforces its own
+    per-test wall-clock timeout instead.
+    """
+    for item in items:
+        item.add_marker(pytest.mark.timeout(0))
+
 
 @pytest.fixture(autouse=True)
 def reduce_internal_retries(monkeypatch):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,7 @@ import pytest
 
 from blockscout_mcp_server.config import config
 
+
 def pytest_collection_modifyitems(items):
     """Disable pytest-timeout for integration tests.
 


### PR DESCRIPTION
## Why

PR #370 protects **integration** tests from hanging (subprocess runner with per-test wall-clock timeout). But **unit** tests have zero hang protection — no pytest-timeout, no CI job timeout. A single frozen `anyio.sleep` or deadlocked lock lets a unit test block the suite (and CI) indefinitely.

This gap is not theoretical: commit `e8bbc7b` merged a time-mock test with an `anyio.sleep`-based concurrency test, causing `time.monotonic` to be patched globally and freezing the event loop. The test hung forever with no automatic kill.

## What

Three layers of defence, all mechanical — no production code or rule changes:

| Layer | File | Effect |
|-------|------|--------|
| **pytest-timeout** (10 s default) | `pytest.ini`, `pyproject.toml` | Kills any unit test that exceeds 10 s with a clear stack trace |
| **Integration override** | `tests/integration/conftest.py` | `pytest_collection_modifyitems` hook sets `timeout(0)` on every integration test so the 10 s limit doesn't interfere — those tests have their own subprocess timeout from #370 |
| **CI job backstop** | `.github/workflows/ci.yml` | `timeout-minutes: 5` caps the entire unit-test job in case pytest-timeout itself fails to fire |

## Note on `pytestmark` vs hook

`pytestmark = pytest.mark.timeout(0)` in `conftest.py` does **not** propagate to tests in other files — it only affects tests defined in the same module. The `pytest_collection_modifyitems` hook is used instead, which reliably applies the marker to every collected item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added timeout limits to test execution to prevent indefinite hanging and improve reliability.
  * Updated test infrastructure to properly handle timeouts for different test types.

* **Chores**
  * Updated test dependencies for enhanced test management capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/mcp-server/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->