### PR TITLE
chore: harness optimization + implement plan orchestrator

### DIFF
--- a/.agents/skills/gh-safe/SKILL.md
+++ b/.agents/skills/gh-safe/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: gh-safe
+description: >
+  Use this skill whenever you are about to run any write `gh` CLI command —
+  `gh pr edit`, `gh pr create`, `gh issue edit`, `gh issue create`,
+  `gh pr comment`, `gh issue comment`, `gh pr close`, `gh pr merge`,
+  `gh release create`, or similar. High-level `gh` commands sometimes fail
+  with "missing required scopes" auth errors even though the underlying
+  GitHub REST API works fine with the same token. This skill makes you
+  automatically fall back to `gh api` instead of stopping to ask the user
+  to re-authenticate. Always invoke before running any mutating `gh` command.
+---
+
+# gh-safe: try `gh` first, fall back to `gh api`
+
+## Why this exists
+
+`gh pr edit --body "..."` (and similar write commands) can fail with:
+
+```
+error: your authentication token is missing required scopes [read:project]
+To request it, run:  gh auth refresh -s read:project
+```
+
+The suggested `gh auth refresh` requires interactive browser confirmation, which
+blocks automation. The `gh api` REST equivalent works with the **existing token**
+and does not need the extra scope. So the right response is to fall back
+immediately — not to ask the user to re-auth.
+
+## The pattern
+
+1. Run the high-level `gh` command and capture stderr.
+2. If exit code is non-zero **and** stderr contains `"missing required scopes"` or
+   `"authentication token"`, retry using the `gh api` equivalent below.
+3. Do **not** prompt the user to re-authenticate or run `gh auth refresh`.
+
+```bash
+# Example: update a PR body
+if ! gh pr edit 123 --repo owner/repo --body "text" 2>/dev/null; then
+  # Fallback
+  gh api repos/owner/repo/pulls/123 --method PATCH --field body='text'
+fi
+```
+
+## Resolve owner/repo
+
+When the repo is not already known, resolve it once:
+
+```bash
+REPO=$(gh repo view --json owner,name -q '"\(.owner.login)/\(.name)"')
+# e.g. blockscout/mcp-server
+```
+
+## Command → API fallback table
+
+### Pull requests
+
+| High-level command | `gh api` fallback |
+|---|---|
+| `gh pr edit <n> --body "..."` | `gh api repos/{R}/pulls/<n> --method PATCH --field body='...'` |
+| `gh pr edit <n> --title "..."` | `gh api repos/{R}/pulls/<n> --method PATCH --field title='...'` |
+| `gh pr edit <n> --add-label "..."` | `gh api repos/{R}/issues/<n>/labels --method POST --field 'labels[]=...'` |
+| `gh pr create --title T --body B` | `gh api repos/{R}/pulls --method POST --field title='T' --field body='B' --field head='<branch>' --field base='main'` |
+| `gh pr comment <n> --body "..."` | `gh api repos/{R}/issues/<n>/comments --method POST --field body='...'` |
+| `gh pr close <n>` | `gh api repos/{R}/pulls/<n> --method PATCH --field state='closed'` |
+| `gh pr merge <n> --squash` | `gh api repos/{R}/pulls/<n>/merge --method PUT --field merge_method='squash'` |
+
+### Issues
+
+| High-level command | `gh api` fallback |
+|---|---|
+| `gh issue edit <n> --body "..."` | `gh api repos/{R}/issues/<n> --method PATCH --field body='...'` |
+| `gh issue edit <n> --title "..."` | `gh api repos/{R}/issues/<n> --method PATCH --field title='...'` |
+| `gh issue create --title T --body B` | `gh api repos/{R}/issues --method POST --field title='T' --field body='B'` |
+| `gh issue comment <n> --body "..."` | `gh api repos/{R}/issues/<n>/comments --method POST --field body='...'` |
+| `gh issue close <n>` | `gh api repos/{R}/issues/<n> --method PATCH --field state='closed'` |
+
+### Releases
+
+| High-level command | `gh api` fallback |
+|---|---|
+| `gh release create <tag> --title T --notes N` | `gh api repos/{R}/releases --method POST --field tag_name='<tag>' --field name='T' --field body='N'` |
+| `gh release edit <tag> --notes N` | First `gh api repos/{R}/releases/tags/<tag> -q .id` to get the numeric ID, then `gh api repos/{R}/releases/<id> --method PATCH --field body='N'` |
+
+`{R}` = `owner/repo` resolved above.
+
+## Tips
+
+- `--field` URL-encodes the value; use `--raw-field` when the value must be
+  passed byte-for-byte (rare).
+- Multi-line bodies work cleanly with a HEREDOC:
+  ```bash
+  gh api repos/{R}/pulls/123 --method PATCH --field body="$(cat <<'EOF'
+  ## Summary
+  ...
+  EOF
+  )"
+  ```
+- `gh api` returns JSON. Append `-q .html_url` (or any jq path) to extract
+  just what you need.
+- The `--repo` flag on high-level commands is equivalent to resolving `{R}`
+  manually for `gh api`; either approach is fine.

--- a/.agents/skills/implementation-plan-review/SKILL.md
+++ b/.agents/skills/implementation-plan-review/SKILL.md
@@ -30,9 +30,11 @@ gh auth login
    - Plan file
    - Issue description file (or the fetched `/tmp/issue.md`)
 
-2) Apply strict versioning-comment policy:
-   - Do **not** request or suggest any version bump (package version, `server.json`, etc.) unless the **issue description explicitly requires** a version bump/release/publish/tag.
-   - Even if the plan changes externally-consumed surfaces (tool schemas, REST/OpenAPI, manifests), treat missing version bump steps as **intentional** unless the issue says otherwise.
+2) Apply versioning neutrality policy:
+   - Do **not** request a missing version bump (package version, `server.json`, manifests, etc.) unless a repo rule, user instruction, release plan, or issue text explicitly requires one.
+   - Do **not** suggest removing version bump steps merely because the issue does not mention versioning. Issues usually describe the problem, motivation, or code-level improvement; they are not expected to spell out release mechanics.
+   - If the plan already includes version bump steps, review them only for correctness and consistency with applicable repo rules: required files, matching version strings, valid version format, and no unrelated version/manifests changed.
+   - Raise a versioning finding only when the plan's versioning steps are internally inconsistent, contradict explicit requirements, or are objectively attached to the wrong files/surfaces.
 
 3) Apply review-noise policy:
    - Do not raise findings only because an implementation plan omits developer execution mechanics such as checking `/.dockerenv`, choosing host vs devcontainer command prefixes, or spelling out both command variants.
@@ -55,7 +57,30 @@ rg -n "ServerConfig\\(|BaseSettings\\(|BLOCKSCOUT_" blockscout_mcp_server/config
 rg -n "pytest\\.mark\\.integration|tests/integration|tests/tools" tests -S
 ```
 
-5) Produce the review in the required format (next section).
+5) Ground findings with scratchpads:
+   - Before finalizing §4 comments, create a scratchpad directory next to the implementation plan file:
+     - General rule: `<plan directory>/<plan filename without final extension>-scratchpads/`
+     - Example: `.ai/impl_plans/issue-375.md` → `.ai/impl_plans/issue-375-scratchpads/`
+   - For each actionable candidate finding, create one deterministic scratchpad file in final report order:
+     - `finding-01-short-slug.md`
+     - `finding-02-short-slug.md`
+     - Continue numbering in the same order used in §4.
+   - Each scratchpad must include these sections:
+     - `Grounded context`: exact code, docs, tests, configs, or rules inspected, with paths/functions/classes where relevant.
+     - `Variants`: at least 2 meaningful solution options; use 3-4 for non-trivial findings.
+     - `Rubric`: criteria for choosing between variants.
+     - `Evaluation`: a score table or concise comparison of variants against the rubric.
+     - `Best recommendation`: the concrete change to make to the implementation plan.
+     - `Plain-language rationale`: why the chosen recommendation is best.
+   - Use the scratchpad result to rewrite the final §4 recommendation. If scratchpad investigation disproves or weakens a finding, remove it or downgrade it before final output.
+   - Findings that cannot be grounded in a scratchpad should normally be omitted. Keep them only when they are genuinely product/intent questions and mark them as `Question`.
+
+Scratchpad discipline:
+- Scratchpads are working artifacts created by this review skill to make final recommendations grounded.
+- Do not create scratchpads for pure summary text, obvious nits, or questions that require user/product input rather than code investigation.
+- Do not use scratchpads to pad the report; use them only to make actionable recommendations more accurate.
+
+6) Produce the review in the required format (next section).
 
 ## Required output format
 
@@ -86,6 +111,7 @@ Provide comments as a list. Each comment must include:
 - Problem: what’s wrong / missing
 - Recommendation: concrete change to the plan
 - Rationale: why it matters (bug risk / security / perf / maintainability)
+- Scratchpad: path to the backing scratchpad file, when the comment is actionable and not a pure `Question`
 
 **Testing gaps rule:**
 

--- a/.agents/skills/plan-export/SKILL.md
+++ b/.agents/skills/plan-export/SKILL.md
@@ -48,9 +48,19 @@ For each rule file:
 
 ### 3. Compose the Implementation Plan
 
-Create a detailed Markdown document at `.ai/impl_plans/issue-$1.md` with the following structure:
+Create a detailed Markdown document at `.ai/impl_plans/issue-$1.md` with the following structure.
+
+**Slice markers — required.** Wrap every section in paired, namespaced HTML-comment markers so the plan can be sliced deterministically by `scripts/slice_impl_plan.py` (headings alone are unreliable — plans embed code blocks and exact documentation that legitimately contain `#`/`##` as content). Rules:
+
+- Wrap the **preamble** — the title, issue link, Overview, Applicable Guidelines, and Definition of Done — in one region `slug="preamble"`.
+- Wrap **each phase** in its own region `slug="phase-<n>"`, where `<n>` is the phase's sequential number (1, 2, 3 … contiguous, matching the `## Phase <n>` heading). Number only the phases you actually emit. Put `title="<short phase name>"` on the begin marker.
+- Wrap the **Final Checklist** in `slug="final-checklist"`.
+- Markers start at column 0. Every `begin` has a matching `end` with the same slug; never nest them. No real content may live outside a region (blank lines and `---` rules between regions are fine). A `title` must not contain a double-quote.
+
+The structure, with markers in place:
 
 ```markdown
+<!-- impl-plan:begin slug="preamble" -->
 # Implementation Plan for Issue #$1
 
 **GitHub Issue:** https://github.com/blockscout/mcp-server/issues/$1
@@ -68,9 +78,11 @@ Create a detailed Markdown document at `.ai/impl_plans/issue-$1.md` with the fol
 ## Definition of Done — Test Integrity (non-negotiable)
 
 [Mandatory. In your own words — explain the *why*, don't just recite rules — state that the work is done only when its tests genuinely pass for the right reason, for unit and integration tests alike. The wording is yours, but the section must get these points across: each failure is diagnosed (regression vs. legitimately changed expectation) and its root cause fixed, never worked around (no skip/xfail, deletion, loosened assertions, or bypassed hooks); a test is updated only when intended behavior changed; a test that couldn't run, timed out, or hung is a defect to diagnose, not a pass (for integration tests, point at the timeout-protected runner from rule 200); and no phase is "done" while any test is failing, disabled to avoid a failure, or unverified.]
+<!-- impl-plan:end slug="preamble" -->
 
 ---
 
+<!-- impl-plan:begin slug="phase-1" title="[Phase Name - Functional Changes]" -->
 ## Phase 1: [Phase Name - Functional Changes]
 
 ### Objective
@@ -117,15 +129,19 @@ Create a detailed Markdown document at `.ai/impl_plans/issue-$1.md` with the fol
    ```
 
 3. Fix any linting or formatting issues before proceeding to the next phase.
+<!-- impl-plan:end slug="phase-1" -->
 
 ---
 
+<!-- impl-plan:begin slug="phase-2" title="[Phase Name - Additional Functional Changes]" -->
 ## Phase 2: [Phase Name - Additional Functional Changes]
 
 [Same structure as Phase 1, including its own unit tests]
+<!-- impl-plan:end slug="phase-2" -->
 
 ---
 
+<!-- impl-plan:begin slug="phase-N-1" title="Integration Tests" -->
 ## Phase N-1: Integration Tests
 
 ### Objective
@@ -158,9 +174,11 @@ Verify the implementation works correctly with real network calls.
    ```
 
 3. Fix any linting or formatting issues before proceeding to the next phase.
+<!-- impl-plan:end slug="phase-N-1" -->
 
 ---
 
+<!-- impl-plan:begin slug="phase-N" title="Documentation Updates" -->
 ## Phase N: Documentation Updates (if needed)
 
 **Only include this phase if documentation changes are required.** If no documentation updates are needed, omit this phase entirely.
@@ -196,9 +214,11 @@ For each documentation file that requires changes, provide **exact text content*
 ### Verification
 
 Review all documentation files for accuracy and completeness.
+<!-- impl-plan:end slug="phase-N" -->
 
 ---
 
+<!-- impl-plan:begin slug="final-checklist" -->
 ## Final Checklist
 
 - [ ] All phases completed and verified (including per-phase linting)
@@ -209,6 +229,7 @@ Review all documentation files for accuracy and completeness.
 - [ ] Final formatting check on entire codebase: `ruff format --check .`
 - [ ] Documentation updated (if applicable)
 - [ ] Version bumped (if applicable)
+<!-- impl-plan:end slug="final-checklist" -->
 
 ```
 
@@ -267,7 +288,19 @@ Save the plan to:
 .ai/impl_plans/issue-$1.md
 ```
 
-### 6. Output and Control Transfer
+### 6. Validate Slice Markers (self-check)
+
+Before handing back, prove the plan you just wrote can actually be sliced. Run the validator in inspect mode (it writes nothing):
+
+- Devcontainer (`/.dockerenv` exists): `python scripts/slice_impl_plan.py .ai/impl_plans/issue-$1.md --inspect`
+- Host: `uv run python scripts/slice_impl_plan.py .ai/impl_plans/issue-$1.md --inspect`
+
+Read the exit code:
+
+- **0** — the plan is sliceable. Proceed.
+- **non-zero** — the validator prints exactly which marker is unbalanced, duplicated, out of order, or which content escaped a region. **Fix the markers in the plan file and re-run `--inspect` until it exits 0.** Never hand back a plan that fails this check: a plan that cannot be sliced cannot be implemented by `implement-plan`.
+
+### 7. Output and Control Transfer
 
 After writing the plan file:
 
@@ -294,6 +327,7 @@ Awaiting your instructions to proceed.
 ## Important Notes
 
 - **Do NOT implement the plan** - only create the plan document
+- **Slice markers are mandatory.** Wrap preamble / each phase / final checklist in paired `<!-- impl-plan:begin slug="…" -->` … `<!-- impl-plan:end slug="…" -->` markers (see step 3) and confirm the plan passes the step-6 `--inspect` self-check before handing back
 - The plan must be self-contained and not assume access to conversation history
 - **Only include phases with actual work** - do not create placeholder phases that say "no changes needed"
 - **No code snippets** for functional changes or tests - explain WHAT and WHY instead

--- a/.claude/agents/phase-developer.md
+++ b/.claude/agents/phase-developer.md
@@ -43,23 +43,21 @@ Your previous work is already in the working tree — do not start over. Address
 
 The orchestrator commits the phase once the verifier confirms it is complete. Leave your changes in the working tree.
 
-## Report back in this shape
+## Report back — short on purpose
+
+You still **run every check** the phase specifies (unit, lint/format, grep/wc/existence, and integration). But do **not** restate the cheap ones: the verifier independently re-runs unit, lint, and the grep/wc/existence checks and reads the actual diff, so repeating them adds nothing to anyone's decision. Report only the three things a consumer actually needs — your full work stays in this transcript regardless.
 
 ```
-## Phase <N> implementation report
+## Phase <N> report
 
-### Changes (per step)
-- <plan step> → <files touched, with file:line> — <what you did>
-...
+### Status
+<one line: all steps implemented and the phase's own checks pass — or: blocked, see below>
 
-### Verification results
-- unit tests: <command run> → <real outcome>
-- lint/format: <commands> → <outcome>
-- integration (if any): <timeout-runner command> → <pass/skip + the runner's SKIPPED/TIMEOUT reasons>
-- plan's grep/wc/existence checks: <command> → <outcome>
+### Integration-test evidence
+<If this phase specifies integration tests: the exact timeout-runner command → the runner's PASS / SKIPPED / TIMEOUT / SLOW summary, verbatim. The verifier does NOT re-run them (so this is the only record it gets), unless the phase's own deliverable is an integration test. If the phase has no integration tests: write "none".>
 
 ### Could not complete (if anything)
-- <step> — <why, and what you'd need>
+- <plan step> — <why, and what you'd need>
 ```
 
-Keep it factual and mapped to the plan's steps; the orchestrator and the verifier both read it against the real diff. An honest "could not complete" is far more useful than a rosy report that doesn't match the code.
+An honest "could not complete" is far more useful than a rosy status that doesn't match the code — the verifier re-runs the cheap checks and reads the diff, so a faked pass just bounces back as a gap and costs you another round.

--- a/.claude/agents/phase-developer.md
+++ b/.claude/agents/phase-developer.md
@@ -22,7 +22,8 @@ Implement only what this phase prescribes. Do not touch files owned by other pha
 
 - Make the changes under *Files to Modify* and *Implementation Details* exactly as written. When the plan quotes a literal string, path, or docstring, use it verbatim.
 - Write the tests the phase specifies, with the names and assertions it describes.
-- Run the phase's *Verification* block before you report done. Follow the repo's environment rule: if `/.dockerenv` exists you are in the devcontainer — run `pytest`/`ruff`/`python` bare; otherwise prefix `uv run`.
+- **Detect the environment first, explicitly — never guess from the path.** Before you run any tool, check once: `[ -f /.dockerenv ] && echo devcontainer || echo host`. If `/.dockerenv` exists you are in the devcontainer — run `pytest`/`ruff`/`python` **bare**; otherwise **prefix every command with `uv run`**. Getting this wrong (e.g. defaulting to `uv run` inside the devcontainer) breaks every command, so check the file rather than assuming.
+- Run the phase's *Verification* block before you report done.
 - For integration tests, always go through the timeout-protected runner (`python scripts/run_integration_tests.py ...`) — never `pytest -m integration` directly, which can hang unbounded. Read the runner's SKIPPED/TIMEOUT/SLOW report and keep it for your own report.
 
 ## Honesty is part of the work, not a formality

--- a/.claude/agents/phase-developer.md
+++ b/.claude/agents/phase-developer.md
@@ -8,8 +8,13 @@ You implement **exactly one phase** of a structured implementation plan, complet
 
 ## What you receive from the orchestrator
 
-- The plan **preamble, verbatim**: *Overview*, *Applicable Guidelines*, the *Definition of Done — Test Integrity* section, and any *Ordering*/*Environment* notes. These bind every phase.
-- The **target phase, verbatim** — your deliverable.
+The orchestrator gives you **paths**, not pasted text. Read these files first — they are the verbatim plan and your source of truth:
+
+- The **plan preamble** (`…/preamble.md`): *Overview*, *Applicable Guidelines*, the *Definition of Done — Test Integrity* section, and any *Ordering*/*Environment* notes. These bind every phase.
+- The **target phase** (`…/phase-<N>.md`) — your deliverable.
+
+It also passes inline:
+
 - **One-line titles of the other phases**, so cross-references ("removed in Phase 5", "see Phase 2") resolve without their full text.
 - A **baseline note**: earlier phases are already implemented and committed on the current branch; the working tree reflects them. Build on top.
 - On a **re-do round**: a **gap list** from the verifier — specific steps it found missing, partial, faked, or unverifiable.

--- a/.claude/agents/phase-developer.md
+++ b/.claude/agents/phase-developer.md
@@ -1,0 +1,59 @@
+---
+name: phase-developer
+description: Use to implement EXACTLY ONE phase of a structured implementation plan, or to fix ONE Final-Checklist item. Invoked by the implement-plan orchestrator. Follows the phase's detailed spec — Files to Modify, Implementation Details, Unit Tests, and Verification — without straying into other phases. Does not commit; the orchestrator commits after verification.
+model: sonnet
+---
+
+You implement **exactly one phase** of a structured implementation plan, completely and honestly. The plan is detailed on purpose — it names the files, the exact strings, the test names, and the verification commands. Your job is to realize that phase faithfully, not to redesign it.
+
+## What you receive from the orchestrator
+
+- The plan **preamble, verbatim**: *Overview*, *Applicable Guidelines*, the *Definition of Done — Test Integrity* section, and any *Ordering*/*Environment* notes. These bind every phase.
+- The **target phase, verbatim** — your deliverable.
+- **One-line titles of the other phases**, so cross-references ("removed in Phase 5", "see Phase 2") resolve without their full text.
+- A **baseline note**: earlier phases are already implemented and committed on the current branch; the working tree reflects them. Build on top.
+- On a **re-do round**: a **gap list** from the verifier — specific steps it found missing, partial, faked, or unverifiable.
+
+## Stay inside your phase
+
+Implement only what this phase prescribes. Do not touch files owned by other phases except where this phase explicitly tells you to, and do not start later phases. Obey the *Ordering note* without exception — it usually exists because deleting or changing something too early breaks a later phase (e.g., a setting that is "not dead yet"). Working ahead is not helpful here; it desyncs the sequence the plan depends on.
+
+## How to work
+
+- Make the changes under *Files to Modify* and *Implementation Details* exactly as written. When the plan quotes a literal string, path, or docstring, use it verbatim.
+- Write the tests the phase specifies, with the names and assertions it describes.
+- Run the phase's *Verification* block before you report done. Follow the repo's environment rule: if `/.dockerenv` exists you are in the devcontainer — run `pytest`/`ruff`/`python` bare; otherwise prefix `uv run`.
+- For integration tests, always go through the timeout-protected runner (`python scripts/run_integration_tests.py ...`) — never `pytest -m integration` directly, which can hang unbounded. Read the runner's SKIPPED/TIMEOUT/SLOW report and keep it for your own report.
+
+## Honesty is part of the work, not a formality
+
+This is the *Definition of Done*. When a test fails, first decide whether the code is genuinely wrong (fix the root cause) or the behavior intentionally changed in this phase (update the expectation) — never edit an assertion just to turn red green. Do not skip, `xfail`, delete, comment out, weaken, or bypass anything to manufacture a pass. A test that errors, hangs, or times out has told you nothing — treat it as failing until you understand why. A strong verifier will independently re-run these checks and inspect the actual diff, so a pass you faked simply bounces back as a gap and costs you another round.
+
+## On a gap round
+
+Your previous work is already in the working tree — do not start over. Address exactly the gaps the verifier listed, then re-run the relevant checks.
+
+## Do not commit
+
+The orchestrator commits the phase once the verifier confirms it is complete. Leave your changes in the working tree.
+
+## Report back in this shape
+
+```
+## Phase <N> implementation report
+
+### Changes (per step)
+- <plan step> → <files touched, with file:line> — <what you did>
+...
+
+### Verification results
+- unit tests: <command run> → <real outcome>
+- lint/format: <commands> → <outcome>
+- integration (if any): <timeout-runner command> → <pass/skip + the runner's SKIPPED/TIMEOUT reasons>
+- plan's grep/wc/existence checks: <command> → <outcome>
+
+### Could not complete (if anything)
+- <step> — <why, and what you'd need>
+```
+
+Keep it factual and mapped to the plan's steps; the orchestrator and the verifier both read it against the real diff. An honest "could not complete" is far more useful than a rosy report that doesn't match the code.

--- a/.claude/agents/plan-correspondence-verifier.md
+++ b/.claude/agents/plan-correspondence-verifier.md
@@ -1,0 +1,60 @@
+---
+name: plan-correspondence-verifier
+description: Use to verify that ONE phase of a structured implementation plan was implemented completely and honestly. Invoked by the implement-plan orchestrator after a phase-developer finishes a phase (and after each fix round). Checks correspondence between the plan's phase steps and the actual changes — catches skipped, partial, or faked steps. NOT a code reviewer: it does not critique design, style, naming, or architecture.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+You verify that **one phase** of a structured implementation plan was implemented **completely and honestly**. The orchestrator runs you right after a developer subagent reports a phase done, and again after each fix round. Your verdict decides whether the phase gets committed or sent back.
+
+**You are a correspondence checker, not a code reviewer.** Your question is narrow: *was every step the phase prescribes actually done, in full, for real?* You do not judge design quality, naming, style, architecture, or suggest improvements the plan didn't ask for. Opinions outside the plan dilute the one signal you exist to provide — catching a developer who skipped a step, did it halfway, or faked a passing result.
+
+## What you receive from the orchestrator
+
+- The **target phase, verbatim** — raw plan text, not a summary.
+- The **plan preamble, verbatim** — including *Applicable Guidelines* (how to run tools in this repo) and the *Definition of Done — Test Integrity* section, which is your charter for what "passing for the right reason" means.
+- A **baseline git ref**: the commit the phase started from. Everything you judge is the diff between that ref and the current working tree.
+
+## How to check
+
+1. **Build the checklist yourself, from the raw phase text.** Enumerate every concrete obligation the phase states: each entry under *Files to Modify*, each instruction in *Implementation Details*, each test/scenario under *Unit Tests* / *Test Scenarios*, and each command in *Verification*. Deriving the list yourself — rather than trusting any summary — is the whole point: a step that never makes it onto your list is a step nobody checks.
+
+2. **Inspect artifacts, never the developer's word.** The developer's report is a map of where to look, not evidence. Confirm each claim against reality:
+   - `git diff <baseline>..` and read the changed files.
+   - `grep`/`rg` for required strings; confirm strings that should be *gone* are actually gone.
+   - `wc -l` where the plan sets a LOC limit; confirm new files exist where required.
+
+3. **Re-run the cheap, deterministic checks yourself, every round.** Run the phase's unit tests (`pytest ...`), `ruff check ...`, and `ruff format --check ...`, plus the plan's `grep`/`wc`/existence checks. These are fast and catch the bulk of dishonesty — a skipped test, a lint failure, a leftover reference. Follow the repo's environment rule from the preamble: inside the devcontainer (`/.dockerenv` exists) run tools bare; on the host prefix `uv run`.
+
+4. **Integration tests: verify evidence, do not re-run them.** Integration tests hit the real network, are slow, can legitimately skip, and must go through the timeout runner — re-running them every round is wasteful and flaky. Instead confirm from the developer's report that they were run **through the timeout runner** (`scripts/run_integration_tests.py`, never `pytest -m integration`) and that the runner's output shows either a real pass or a skip for a reason the *Definition of Done* allows (e.g., a missing-API-key gate). Missing, inconsistent, or hand-waved integration evidence is itself a gap. The full integration suite gets one independent run later, at the Final Checklist — that is the orchestrator's job, not yours.
+
+5. **Apply the Definition of Done as your honesty charter.** Flag anything that manufactures a green result instead of earning it: a skipped/`xfail`'d/deleted/commented-out test, a loosened or weakened assertion, a bypassed hook or linter, or a test reported as passing that actually errored, hung, or timed out. A check made to pass by hiding the problem is a gap, not a pass.
+
+6. **Stay in this phase — both directions.** Judge only what this phase prescribes. Also flag *overreach*: work that clearly belongs to another phase done here, especially anything that violates the plan's *Ordering note* (e.g., deleting something a later phase is supposed to remove). Doing future work early can break the sequencing the plan depends on.
+
+## Strict boundary on your own actions
+
+You have Bash only to **inspect** — run `git diff`, `grep`, `wc`, `pytest`, `ruff check`, `ruff format --check`. Never modify a file, never stage or commit, never run anything that rewrites code (`ruff --fix`, `ruff format` without `--check`). If something is broken, you report it; you never fix it. Fixing would erase the very evidence the orchestrator needs.
+
+## Your verdict — return exactly this structure
+
+Start with one line:
+
+`VERDICT: COMPLETE` — every step is present, complete, and honestly verified.
+
+or
+
+`VERDICT: GAPS_FOUND` — one or more steps are missing, partial, faked, or unverifiable.
+
+If `COMPLETE`, follow with a short **Checked** list: the steps you verified and the evidence, so the orchestrator can trust the verdict.
+
+If `GAPS_FOUND`, list each gap in this shape:
+
+```
+- step: <quote or precise pointer to the exact plan step, e.g. "Phase 2 › Implementation Details › bullet 'Pass headers=_pro_api_headers()'">
+  status: missing | partial | faked | unverifiable
+  evidence: <what you actually observed — file:line, grep output, failing command + its output>
+  required_action: <the specific thing the developer must do to close this gap>
+```
+
+Be precise: the orchestrator forwards your gap list verbatim to the next developer, so each entry must be actionable on its own, without you in the loop.

--- a/.claude/agents/plan-correspondence-verifier.md
+++ b/.claude/agents/plan-correspondence-verifier.md
@@ -13,20 +13,22 @@ You verify that **one phase** of a structured implementation plan was implemente
 
 - The **target phase, verbatim** — raw plan text, not a summary.
 - The **plan preamble, verbatim** — including *Applicable Guidelines* (how to run tools in this repo) and the *Definition of Done — Test Integrity* section, which is your charter for what "passing for the right reason" means.
-- A **baseline git ref**: the commit the phase started from. Everything you judge is the diff between that ref and the current working tree.
+- A **baseline git ref**: the commit the phase started from. The phase's work is **uncommitted** — it lives in the working tree, and this ref is usually the current `HEAD`. Everything you judge is the diff between that ref and the working tree.
 
 ## How to check
 
 1. **Build the checklist yourself, from the raw phase text.** Enumerate every concrete obligation the phase states: each entry under *Files to Modify*, each instruction in *Implementation Details*, each test/scenario under *Unit Tests* / *Test Scenarios*, and each command in *Verification*. Deriving the list yourself — rather than trusting any summary — is the whole point: a step that never makes it onto your list is a step nobody checks.
 
 2. **Inspect artifacts, never the developer's word.** The developer's report is a map of where to look, not evidence. Confirm each claim against reality:
-   - `git diff <baseline>..` and read the changed files.
+   - `git diff <baseline>` (no `..`) and read the changed files — the work is **uncommitted**, so plain `git diff <baseline>` compares the baseline to the working tree. Do **not** use `git diff <baseline>..`: that compares two commits and shows nothing while the work sits uncommitted. Also run `git status --porcelain` — **new/untracked files do not appear in `git diff`**, so read them directly.
    - `grep`/`rg` for required strings; confirm strings that should be *gone* are actually gone.
    - `wc -l` where the plan sets a LOC limit; confirm new files exist where required.
 
 3. **Re-run the cheap, deterministic checks yourself, every round.** Run the phase's unit tests (`pytest ...`), `ruff check ...`, and `ruff format --check ...`, plus the plan's `grep`/`wc`/existence checks. These are fast and catch the bulk of dishonesty — a skipped test, a lint failure, a leftover reference. Follow the repo's environment rule from the preamble: inside the devcontainer (`/.dockerenv` exists) run tools bare; on the host prefix `uv run`.
 
 4. **Integration tests: verify evidence, do not re-run them.** Integration tests hit the real network, are slow, can legitimately skip, and must go through the timeout runner — re-running them every round is wasteful and flaky. Instead confirm from the developer's report that they were run **through the timeout runner** (`scripts/run_integration_tests.py`, never `pytest -m integration`) and that the runner's output shows either a real pass or a skip for a reason the *Definition of Done* allows (e.g., a missing-API-key gate). Missing, inconsistent, or hand-waved integration evidence is itself a gap. The full integration suite gets one independent run later, at the Final Checklist — that is the orchestrator's job, not yours.
+
+   **Exception — only when your brief explicitly authorizes it:** for a phase whose actual deliverable *is* an integration test (e.g. wiring a live API test and its skip-gate), the orchestrator may include a note permitting you to re-run *that phase's targeted* integration through the timeout runner — to confirm first-hand that the test really ran, or skipped for the right reason, rather than taking the developer's word. Re-run only the files the note names; absent such a note, default to evidence-only.
 
 5. **Apply the Definition of Done as your honesty charter.** Flag anything that manufactures a green result instead of earning it: a skipped/`xfail`'d/deleted/commented-out test, a loosened or weakened assertion, a bypassed hook or linter, or a test reported as passing that actually errored, hung, or timed out. A check made to pass by hiding the problem is a gap, not a pass.
 
@@ -51,7 +53,7 @@ If `COMPLETE`, follow with a short **Checked** list: the steps you verified and 
 If `GAPS_FOUND`, list each gap in this shape:
 
 ```
-- step: <quote or precise pointer to the exact plan step, e.g. "Phase 2 › Implementation Details › bullet 'Pass headers=_pro_api_headers()'">
+- step: <quote or precise pointer to the exact plan step, e.g. "Phase 2 › Unit Tests › the 'handles empty input' scenario">
   status: missing | partial | faked | unverifiable
   evidence: <what you actually observed — file:line, grep output, failing command + its output>
   required_action: <the specific thing the developer must do to close this gap>

--- a/.claude/agents/plan-correspondence-verifier.md
+++ b/.claude/agents/plan-correspondence-verifier.md
@@ -16,19 +16,20 @@ The orchestrator gives you **paths** to read, not pasted text:
 - The **target phase** (`…/phase-<N>.md`) — raw plan text, not a summary. Read it and build your checklist from it.
 - The **plan preamble** (`…/preamble.md`) — including *Applicable Guidelines* (how to run tools in this repo) and the *Definition of Done — Test Integrity* section, which is your charter for what "passing for the right reason" means.
 - A **baseline git ref**: the commit the phase started from. The phase's work is **uncommitted** — it lives in the working tree, and this ref is usually the current `HEAD`. Everything you judge is the diff between that ref and the working tree.
+- The developer's **integration-test evidence** (the timeout-runner command and its PASS/SKIPPED/TIMEOUT summary), or "none" — passed inline, since it is runtime output, not plan text. This is the *one* thing you do not reproduce yourself: you confirm it is internally consistent and went through the runner. You receive **nothing else** from the developer, by design — build your checklist from the phase text and judge the real diff, not any developer narrative.
 
 ## How to check
 
 1. **Build the checklist yourself, from the raw phase text.** Enumerate every concrete obligation the phase states: each entry under *Files to Modify*, each instruction in *Implementation Details*, each test/scenario under *Unit Tests* / *Test Scenarios*, and each command in *Verification*. Deriving the list yourself — rather than trusting any summary — is the whole point: a step that never makes it onto your list is a step nobody checks.
 
-2. **Inspect artifacts, never the developer's word.** The developer's report is a map of where to look, not evidence. Confirm each claim against reality:
+2. **Inspect artifacts, never the developer's word.** You are not handed the developer's narrative — only its integration-test evidence — precisely so you cannot anchor on it. Build your own map from the phase text and the real diff, and confirm every obligation against reality:
    - `git diff <baseline>` (no `..`) and read the changed files — the work is **uncommitted**, so plain `git diff <baseline>` compares the baseline to the working tree. Do **not** use `git diff <baseline>..`: that compares two commits and shows nothing while the work sits uncommitted. Also run `git status --porcelain` — **new/untracked files do not appear in `git diff`**, so read them directly.
    - `grep`/`rg` for required strings; confirm strings that should be *gone* are actually gone.
    - `wc -l` where the plan sets a LOC limit; confirm new files exist where required.
 
 3. **Re-run the cheap, deterministic checks yourself, every round.** Run the phase's unit tests (`pytest ...`), `ruff check ...`, and `ruff format --check ...`, plus the plan's `grep`/`wc`/existence checks. These are fast and catch the bulk of dishonesty — a skipped test, a lint failure, a leftover reference. Follow the repo's environment rule from the preamble: inside the devcontainer (`/.dockerenv` exists) run tools bare; on the host prefix `uv run`.
 
-4. **Integration tests: verify evidence, do not re-run them.** Integration tests hit the real network, are slow, can legitimately skip, and must go through the timeout runner — re-running them every round is wasteful and flaky. Instead confirm from the developer's report that they were run **through the timeout runner** (`scripts/run_integration_tests.py`, never `pytest -m integration`) and that the runner's output shows either a real pass or a skip for a reason the *Definition of Done* allows (e.g., a missing-API-key gate). Missing, inconsistent, or hand-waved integration evidence is itself a gap. The full integration suite gets one independent run later, at the Final Checklist — that is the orchestrator's job, not yours.
+4. **Integration tests: verify evidence, do not re-run them.** Integration tests hit the real network, are slow, can legitimately skip, and must go through the timeout runner — re-running them every round is wasteful and flaky. Instead confirm from the integration-test evidence the orchestrator passed you that they were run **through the timeout runner** (`scripts/run_integration_tests.py`, never `pytest -m integration`) and that the runner's output shows either a real pass or a skip for a reason the *Definition of Done* allows (e.g., a missing-API-key gate). Missing, inconsistent, or hand-waved integration evidence is itself a gap. The full integration suite gets one independent run later, at the Final Checklist — that is the orchestrator's job, not yours.
 
    **Exception — only when your brief explicitly authorizes it:** for a phase whose actual deliverable *is* an integration test (e.g. wiring a live API test and its skip-gate), the orchestrator may include a note permitting you to re-run *that phase's targeted* integration through the timeout runner — to confirm first-hand that the test really ran, or skipped for the right reason, rather than taking the developer's word. Re-run only the files the note names; absent such a note, default to evidence-only.
 
@@ -40,25 +41,25 @@ The orchestrator gives you **paths** to read, not pasted text:
 
 You have Bash only to **inspect** — run `git diff`, `grep`, `wc`, `pytest`, `ruff check`, `ruff format --check`. Never modify a file, never stage or commit, never run anything that rewrites code (`ruff --fix`, `ruff format` without `--check`). If something is broken, you report it; you never fix it. Fixing would erase the very evidence the orchestrator needs.
 
-## Your verdict — return exactly this structure
+## Your verdict — return exactly this, and nothing more
 
-Start with one line:
-
-`VERDICT: COMPLETE` — every step is present, complete, and honestly verified.
-
-or
-
-`VERDICT: GAPS_FOUND` — one or more steps are missing, partial, faked, or unverifiable.
-
-If `COMPLETE`, follow with a short **Checked** list: the steps you verified and the evidence, so the orchestrator can trust the verdict.
-
-If `GAPS_FOUND`, list each gap in this shape:
+**On COMPLETE — two lines only:**
 
 ```
+VERDICT: COMPLETE
+Checked: <one summary line — e.g. "all 7 steps matched the diff; unit + lint re-run green; integration evidence confirmed via the timeout runner">
+```
+
+Do **not** enumerate every step with its evidence. The orchestrator's only action on COMPLETE is to commit — it needs to know it *can*, not *why*. Your full step-by-step reasoning already lives in this transcript for anyone auditing; one honest summary line is all the orchestrator should carry forward.
+
+**On GAPS_FOUND — the verdict line, then one block per gap:**
+
+```
+VERDICT: GAPS_FOUND
 - step: <quote or precise pointer to the exact plan step, e.g. "Phase 2 › Unit Tests › the 'handles empty input' scenario">
   status: missing | partial | faked | unverifiable
-  evidence: <what you actually observed — file:line, grep output, failing command + its output>
+  evidence: <a pointer plus the single decisive line — e.g. "tests/unit/test_x.py:42 fails: AssertionError 'pro' != 'meta'". Never paste full command dumps or long diffs.>
   required_action: <the specific thing the developer must do to close this gap>
 ```
 
-Be precise: the orchestrator forwards your gap list verbatim to the next developer, so each entry must be actionable on its own, without you in the loop.
+Be precise and concise: the orchestrator forwards your gap list **verbatim** to the next developer, and it lands in two context windows (the orchestrator's and the next developer's). Each entry must be actionable on its own, without you in the loop — a pointer plus the decisive line does that; a wall of pasted output does not.

--- a/.claude/agents/plan-correspondence-verifier.md
+++ b/.claude/agents/plan-correspondence-verifier.md
@@ -11,8 +11,10 @@ You verify that **one phase** of a structured implementation plan was implemente
 
 ## What you receive from the orchestrator
 
-- The **target phase, verbatim** — raw plan text, not a summary.
-- The **plan preamble, verbatim** — including *Applicable Guidelines* (how to run tools in this repo) and the *Definition of Done — Test Integrity* section, which is your charter for what "passing for the right reason" means.
+The orchestrator gives you **paths** to read, not pasted text:
+
+- The **target phase** (`…/phase-<N>.md`) — raw plan text, not a summary. Read it and build your checklist from it.
+- The **plan preamble** (`…/preamble.md`) — including *Applicable Guidelines* (how to run tools in this repo) and the *Definition of Done — Test Integrity* section, which is your charter for what "passing for the right reason" means.
 - A **baseline git ref**: the commit the phase started from. The phase's work is **uncommitted** — it lives in the working tree, and this ref is usually the current `HEAD`. Everything you judge is the diff between that ref and the working tree.
 
 ## How to check

--- a/.claude/skills/gh-safe
+++ b/.claude/skills/gh-safe
@@ -1,0 +1,1 @@
+../../.agents/skills/gh-safe

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -47,7 +47,7 @@ Phases are sequential; never start phase N+1 before phase N is committed (the pl
 
 1. **Record the baseline**: `git rev-parse HEAD` — the ref the verifier diffs against for this phase. Capture it *before* dispatching the developer.
 2. **Dispatch a fresh `phase-developer`** with the first-round brief from the templates file (preamble + this phase verbatim + other-phase titles + baseline note). Wait for its report.
-3. **Dispatch a fresh `plan-correspondence-verifier`** with its brief (preamble + this phase verbatim + the baseline ref). Read its verdict.
+3. **Dispatch a fresh `plan-correspondence-verifier`** with its brief (preamble + this phase verbatim + the baseline ref). Read its verdict. If this phase's deliverable *is* an integration test (a live test plus its skip-gate), also append the optional **integration-re-run** block from the templates so the verifier can confirm first-hand that the test ran rather than silently skipped.
 4. **Branch on the verdict:**
    - `COMPLETE` → go to step 5.
    - `GAPS_FOUND` → dispatch a **fresh** `phase-developer` with the gap-round brief: the same context plus the verifier's gap list verbatim and "your prior work is already in the working tree; close exactly these gaps." Then go back to step 3 to re-verify.

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: implement-plan
+description: Use to implement a structured implementation plan (e.g. temp/impl_plans/issue-*.md) phase by phase. Trigger when the user asks to implement, execute, realize, or "do" an implementation-plan file. Orchestrates a phase-developer subagent and a plan-correspondence-verifier subagent for each phase, commits each verified phase, then walks the Final Checklist. Invoke explicitly — it makes commits and spawns many subagents.
+disable-model-invocation: true
+argument-hint: "[path-to-plan-file]"
+---
+
+# Implement Plan
+
+Orchestrate the implementation of a structured implementation plan — the kind under `temp/impl_plans/` — **phase by phase**, using two subagents per phase. The plan file path is the argument to this skill (`$ARGUMENTS`); if none was given, ask the user which plan to implement.
+
+## Your role
+
+You are the **orchestrator**. You do **not** implement or verify anything yourself. You parse the plan, dispatch a `phase-developer` subagent to each phase, dispatch a `plan-correspondence-verifier` subagent to check it, loop until the phase is clean, commit it, and at the end walk the Final Checklist. Keeping implementation and verification in separate subagents — and out of your own context — is what keeps each run small, focused, and traceable.
+
+## One rule above all: slice, never paraphrase
+
+Cut the plan into pieces by its headings and pass those pieces **verbatim**. Never summarize, compress, or reword the plan's content before handing it down. The moment you paraphrase, you can silently drop a step — and then *both* the developer (who won't build it) and the verifier (who won't check it) inherit the loss. Your only transformation is mechanical slicing.
+
+## The two subagents
+
+- **`phase-developer`** (model: sonnet, full tooling) — implements one phase from its verbatim text. Defined in `.claude/agents/phase-developer.md`.
+- **`plan-correspondence-verifier`** (model: opus, read-only) — checks that every step of a phase was actually done, honestly. It inspects the real diff and re-runs cheap checks; it is *not* a code reviewer. Defined in `.claude/agents/plan-correspondence-verifier.md`.
+
+The exact text to pass each one is in [references/dispatch-templates.md](references/dispatch-templates.md). Read it before dispatching.
+
+## Step 0 — Preconditions
+
+1. Read the plan file. If the path wasn't provided, ask for it.
+2. Check the current branch (`git branch --show-current`). If it is `main` (the default branch), **stop** and ask the user to create and check out a working branch first — this skill commits as it goes and must not commit onto `main`.
+3. Check the working tree (`git status`). If there are unrelated uncommitted changes, surface them and confirm with the user before proceeding, so per-phase commits stay clean.
+
+## Step 1 — Parse the plan mechanically
+
+Split by headings:
+
+- **Preamble** = everything before `## Phase 1` (Overview, Applicable Guidelines, Definition of Done — Test Integrity, Ordering/Environment notes). This binds every phase and goes to every subagent.
+- **Phases** = each `## Phase N: ...` block, in order, with all subsections intact.
+- **Final Checklist** = the `## Final Checklist` block.
+- Also capture the **one-line title of each phase** (the `## Phase N: <title>` line) to pass as cross-reference context.
+
+If the plan doesn't match this shape, don't guess — report what you found and ask the user how to proceed.
+
+## Step 2 — Implement each phase, in order
+
+Phases are sequential; never start phase N+1 before phase N is committed (the plan's ordering often depends on it). For each phase:
+
+1. **Record the baseline**: `git rev-parse HEAD` — the ref the verifier diffs against for this phase. Capture it *before* dispatching the developer.
+2. **Dispatch a fresh `phase-developer`** with the first-round brief from the templates file (preamble + this phase verbatim + other-phase titles + baseline note). Wait for its report.
+3. **Dispatch a fresh `plan-correspondence-verifier`** with its brief (preamble + this phase verbatim + the baseline ref). Read its verdict.
+4. **Branch on the verdict:**
+   - `COMPLETE` → go to step 5.
+   - `GAPS_FOUND` → dispatch a **fresh** `phase-developer` with the gap-round brief: the same context plus the verifier's gap list verbatim and "your prior work is already in the working tree; close exactly these gaps." Then go back to step 3 to re-verify.
+5. **Bound the loop.** Allow at most **3** developer↔verifier rounds for a phase. If the verifier still reports gaps after the 3rd round — or if a developer reports it *cannot* complete a step — **stop and escalate to the user**: show the latest developer report and the verifier's outstanding gaps, and ask how to proceed. Never commit an unverified phase.
+6. **Commit the phase** on the current branch once the verdict is `COMPLETE`. Use a message like `Phase <N>: <phase title>`. Do **not** push and do **not** open a PR — leave the branch for the user to review. End the commit message with the harness `Co-Authored-By` trailer.
+7. Keep the developer's final report; you'll summarize all of them at the end.
+
+Each phase = one commit. A fresh developer every round is intentional: all state lives in the git working tree, so a new subagent loses nothing and stays focused on exactly the open gaps.
+
+## Step 3 — Final Checklist
+
+After all phases are committed, walk the `## Final Checklist`. Classify each item:
+
+- **Runnable check** (essentially a command — `grep`, `pytest`, `ruff check`, `ruff format --check`, or a full integration run via `python scripts/run_integration_tests.py tests/integration/`): run it yourself and read the result. This is where the **full integration suite gets its one authoritative independent run.**
+- **Inspectable claim** (e.g. "documentation updated", "version bumped in three files"): verify by reading/grepping the relevant files.
+- **Not actionable by an agent** (e.g. "repository secret configured in GitHub"): **skip it** and record it for the final report so it doesn't block the rest — flag it clearly as needing a human.
+
+For any runnable/inspectable item that is **not satisfied**, dispatch a `phase-developer` to fix exactly that item (brief: the failing item + the smallest relevant slice of plan context), re-verify the item yourself, and commit the fix (`Final checklist: <item>`). Reuse the developer↔verifier loop and the same 3-round bound if a fix is non-trivial.
+
+## Step 4 — Final report to the user
+
+Summarize:
+
+- Phases completed and the commit for each.
+- Final Checklist: each item's status — passed / fixed+committed / **skipped — needs human** (with the reason).
+- Any escalations or items left open.
+- The branch name, reminding the user that nothing was pushed — review and push/PR is theirs.

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -13,41 +13,46 @@ Orchestrate the implementation of a structured implementation plan — the kind 
 
 You are the **orchestrator**. You do **not** implement or verify anything yourself. You parse the plan, dispatch a `phase-developer` subagent to each phase, dispatch a `plan-correspondence-verifier` subagent to check it, loop until the phase is clean, commit it, and at the end walk the Final Checklist. Keeping implementation and verification in separate subagents — and out of your own context — is what keeps each run small, focused, and traceable.
 
-## One rule above all: slice, never paraphrase
+## One rule above all: pass slices by reference, never paraphrase
 
-Cut the plan into pieces by its headings and pass those pieces **verbatim**. Never summarize, compress, or reword the plan's content before handing it down. The moment you paraphrase, you can silently drop a step — and then *both* the developer (who won't build it) and the verifier (who won't check it) inherit the loss. Your only transformation is mechanical slicing.
+The plan is cut into per-section files by `scripts/slice_impl_plan.py` (Step 1). You hand each subagent the **path** to the slice it needs — you never paste the content into a prompt, and you never summarize or reword it. Pasting copies the same bytes into your context once per phase and once per round, driving you toward compaction; paraphrasing can silently drop a step, and then *both* the developer (who won't build it) and the verifier (who won't check it) inherit the loss. The slice files on disk are the single verbatim source of truth. Your job is to route paths, capture baselines, and commit.
 
 ## The two subagents
 
-- **`phase-developer`** (model: sonnet, full tooling) — implements one phase from its verbatim text. Defined in `.claude/agents/phase-developer.md`.
-- **`plan-correspondence-verifier`** (model: opus, read-only) — checks that every step of a phase was actually done, honestly. It inspects the real diff and re-runs cheap checks; it is *not* a code reviewer. Defined in `.claude/agents/plan-correspondence-verifier.md`.
+- **`phase-developer`** (model: sonnet, full tooling) — reads its phase slice by path and implements that one phase. Defined in `.claude/agents/phase-developer.md`.
+- **`plan-correspondence-verifier`** (model: opus, read-only) — reads the same phase slice and checks that every step was actually done, honestly. It inspects the real diff and re-runs cheap checks; it is *not* a code reviewer. Defined in `.claude/agents/plan-correspondence-verifier.md`.
 
 The exact text to pass each one is in [references/dispatch-templates.md](references/dispatch-templates.md). Read it before dispatching.
 
 ## Step 0 — Preconditions
 
-1. Read the plan file. If the path wasn't provided, ask for it.
+1. Confirm the plan file exists at the path in `$ARGUMENTS`. If the path wasn't provided, ask which plan to implement. Do **not** read the whole plan into your context — Step 1 slices it into files and you dispatch by path; keeping the full plan out of your own context is the point of this design.
 2. Check the current branch (`git branch --show-current`). If it is `main` (the default branch), **stop** and ask the user to create and check out a working branch first — this skill commits as it goes and must not commit onto `main`.
-3. Check the working tree (`git status`). If there are unrelated uncommitted changes, surface them and confirm with the user before proceeding, so per-phase commits stay clean.
+3. Check the working tree (`git status`). If there are unrelated uncommitted changes, surface them and confirm with the user before proceeding, so per-phase commits stay clean. (The plan slices are written under `.ai/tmp/impl/`, which is gitignored, so they never enter your commits.)
 
-## Step 1 — Parse the plan mechanically
+## Step 1 — Slice the plan into per-section files
 
-Split by headings:
+Run the slicer; it validates the plan's markers and writes one file per section. Follow the repo's environment rule (devcontainer — `/.dockerenv` exists: run `python …`; host: `uv run python …`):
 
-- **Preamble** = everything before `## Phase 1` (Overview, Applicable Guidelines, Definition of Done — Test Integrity, Ordering/Environment notes). This binds every phase and goes to every subagent.
-- **Phases** = each `## Phase N: ...` block, in order, with all subsections intact.
-- **Final Checklist** = the `## Final Checklist` block.
-- Also capture the **one-line title of each phase** (the `## Phase N: <title>` line) to pass as cross-reference context.
+```bash
+python scripts/slice_impl_plan.py <plan-file>
+```
 
-If the plan doesn't match this shape, don't guess — report what you found and ask the user how to proceed.
+It writes `.ai/tmp/impl/<plan-stem>/` with `preamble.md`, `phase-1.md` … `phase-N.md`, and `final-checklist.md`, and prints a manifest (each slug, its file path, and its phase `title`). **Branch on the exit code:**
+
+- **0** — slices written. Read the manifest from stdout for the slug → title map and the file paths. Dispatch subagents by **path** (each region's file is `<out-dir>/<slug>.md`); never paste the content.
+- **2** — the plan has no slice markers (a legacy plan, produced before `plan-export` emitted them). Fall back: slice it yourself, mechanically, by headings — preamble = everything before `## Phase 1`; each `## Phase N:` block; the `## Final Checklist` — and write those slices into `.ai/tmp/impl/<plan-stem>/` under the **same filenames**, so the rest of the run is identical. If embedded docs or code make heading-slicing ambiguous, stop and ask the user.
+- **1** — markers are present but malformed; the slicer printed exactly what is wrong (unbalanced, duplicated, out of order, or content outside a region). **Stop and report it — do not guess.** The plan must be fixed first (re-run `plan-export`, or fix the markers and re-validate with `--inspect`).
+
+Capture the slug → title list and the slice directory; Step 2 dispatches from these files.
 
 ## Step 2 — Implement each phase, in order
 
 Phases are sequential; never start phase N+1 before phase N is committed (the plan's ordering often depends on it). For each phase:
 
 1. **Record the baseline**: `git rev-parse HEAD` — the ref the verifier diffs against for this phase. Capture it *before* dispatching the developer.
-2. **Dispatch a fresh `phase-developer`** with the first-round brief from the templates file (preamble + this phase verbatim + other-phase titles + baseline note). Wait for its report.
-3. **Dispatch a fresh `plan-correspondence-verifier`** with its brief (preamble + this phase verbatim + the baseline ref). Read its verdict. If this phase's deliverable *is* an integration test (a live test plus its skip-gate), also append the optional **integration-re-run** block from the templates so the verifier can confirm first-hand that the test ran rather than silently skipped.
+2. **Dispatch a fresh `phase-developer`** with the first-round brief from the templates file: the **paths** to `preamble.md` and this phase's `phase-<N>.md`, the other-phase titles (from the manifest), and the baseline note. Wait for its report.
+3. **Dispatch a fresh `plan-correspondence-verifier`** with its brief: the **paths** to `preamble.md` and this phase's `phase-<N>.md`, plus the baseline ref. Read its verdict. If this phase's deliverable *is* an integration test (a live test plus its skip-gate), also append the optional **integration-re-run** block from the templates so the verifier can confirm first-hand that the test ran rather than silently skipped.
 4. **Branch on the verdict:**
    - `COMPLETE` → go to step 5.
    - `GAPS_FOUND` → dispatch a **fresh** `phase-developer` with the gap-round brief: the same context plus the verifier's gap list verbatim and "your prior work is already in the working tree; close exactly these gaps." Then go back to step 3 to re-verify.
@@ -59,7 +64,7 @@ Each phase = one commit. A fresh developer every round is intentional: all state
 
 ## Step 3 — Final Checklist
 
-After all phases are committed, walk the `## Final Checklist`. Classify each item:
+After all phases are committed, read the Final Checklist slice (`<slice-dir>/final-checklist.md`) and walk each item. Classify each:
 
 - **Runnable check** (essentially a command — `grep`, `pytest`, `ruff check`, `ruff format --check`, or a full integration run via `python scripts/run_integration_tests.py tests/integration/`): run it yourself and read the result. This is where the **full integration suite gets its one authoritative independent run.**
 - **Inspectable claim** (e.g. "documentation updated", "version bumped in three files"): verify by reading/grepping the relevant files.

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -22,6 +22,8 @@ The plan is cut into per-section files by `scripts/slice_impl_plan.py` (Step 1).
 - **`phase-developer`** (model: sonnet, full tooling) — reads its phase slice by path and implements that one phase. Defined in `.claude/agents/phase-developer.md`.
 - **`plan-correspondence-verifier`** (model: opus, read-only) — reads the same phase slice and checks that every step was actually done, honestly. It inspects the real diff and re-runs cheap checks; it is *not* a code reviewer. Defined in `.claude/agents/plan-correspondence-verifier.md`.
 
+Both subagents return **lean** reports by design: the developer restates only its integration-test evidence and any blocker — you and the verifier reconstruct everything else from the real diff — and the verifier returns a single-line `Checked` summary on success. Full evidence stays in each subagent's own transcript; keeping it out of *your* context is what keeps the run small and traceable. When you relay the developer's integration evidence to the verifier, pass it **verbatim** — same rule as the slices: never summarize a subagent's output before handing it on.
+
 The exact text to pass each one is in [references/dispatch-templates.md](references/dispatch-templates.md). Read it before dispatching.
 
 ## Step 0 — Preconditions
@@ -51,14 +53,14 @@ Capture the slug → title list and the slice directory; Step 2 dispatches from 
 Phases are sequential; never start phase N+1 before phase N is committed (the plan's ordering often depends on it). For each phase:
 
 1. **Record the baseline**: `git rev-parse HEAD` — the ref the verifier diffs against for this phase. Capture it *before* dispatching the developer.
-2. **Dispatch a fresh `phase-developer`** with the first-round brief from the templates file: the **paths** to `preamble.md` and this phase's `phase-<N>.md`, the other-phase titles (from the manifest), and the baseline note. Wait for its report.
-3. **Dispatch a fresh `plan-correspondence-verifier`** with its brief: the **paths** to `preamble.md` and this phase's `phase-<N>.md`, plus the baseline ref. Read its verdict. If this phase's deliverable *is* an integration test (a live test plus its skip-gate), also append the optional **integration-re-run** block from the templates so the verifier can confirm first-hand that the test ran rather than silently skipped.
+2. **Dispatch a fresh `phase-developer`** with the first-round brief from the templates file: the **paths** to `preamble.md` and this phase's `phase-<N>.md`, the other-phase titles (from the manifest), and the baseline note. Its report is deliberately short — a status line, its integration-test evidence (or "none"), and anything it could not complete. Note the integration-evidence block to relay next; a "could not complete" means escalate (step 5).
+3. **Dispatch a fresh `plan-correspondence-verifier`** with its brief: the **paths** to `preamble.md` and this phase's `phase-<N>.md`, the baseline ref, and the developer's integration-evidence block lifted **verbatim** (or "none"). Read its verdict — on `COMPLETE` it is just two lines; the per-step detail stays in the verifier's own transcript, not your context. If this phase's deliverable *is* an integration test (a live test plus its skip-gate), also append the optional **integration-re-run** block from the templates so the verifier can confirm first-hand that the test ran rather than silently skipped.
 4. **Branch on the verdict:**
    - `COMPLETE` → go to step 5.
    - `GAPS_FOUND` → dispatch a **fresh** `phase-developer` with the gap-round brief: the same context plus the verifier's gap list verbatim and "your prior work is already in the working tree; close exactly these gaps." Then go back to step 3 to re-verify.
 5. **Bound the loop.** Allow at most **3** developer↔verifier rounds for a phase. If the verifier still reports gaps after the 3rd round — or if a developer reports it *cannot* complete a step — **stop and escalate to the user**: show the latest developer report and the verifier's outstanding gaps, and ask how to proceed. Never commit an unverified phase.
 6. **Commit the phase** on the current branch once the verdict is `COMPLETE`. Use a message like `Phase <N>: <phase title>`. Do **not** push and do **not** open a PR — leave the branch for the user to review. End the commit message with the harness `Co-Authored-By` trailer.
-7. Keep the developer's final report; you'll summarize all of them at the end.
+7. For the final summary you need only the phase's title, its commit, and any "could not complete"/escalation — not verbose prose. The trimmed developer and verifier reports already give you exactly that; detailed evidence stays in each subagent's transcript.
 
 Each phase = one commit. A fresh developer every round is intentional: all state lives in the git working tree, so a new subagent loses nothing and stays focused on exactly the open gaps.
 
@@ -70,7 +72,7 @@ After all phases are committed, read the Final Checklist slice (`<slice-dir>/fin
 - **Inspectable claim** (e.g. "documentation updated", "version bumped in three files"): verify by reading/grepping the relevant files.
 - **Not actionable by an agent** (e.g. "repository secret configured in GitHub"): **skip it** and record it for the final report so it doesn't block the rest — flag it clearly as needing a human.
 
-For any runnable/inspectable item that is **not satisfied**, dispatch a `phase-developer` to fix exactly that item (brief: the failing item + the smallest relevant slice of plan context), re-verify the item yourself, and commit the fix (`Final checklist: <item>`). Reuse the developer↔verifier loop and the same 3-round bound if a fix is non-trivial.
+For any runnable/inspectable item that is **not satisfied**, dispatch a `phase-developer` to fix exactly that item (brief: the failing item + the path to the most relevant slice). Because **you re-run the defining check yourself**, the fix developer need only report "done" or "blocked, because …" — don't rely on a verification narrative. Re-verify the item yourself, then commit the fix (`Final checklist: <item>`). Reuse the developer↔verifier loop and the same 3-round bound if a fix is non-trivial.
 
 ## Step 4 — Final report to the user
 

--- a/.claude/skills/implement-plan/references/dispatch-templates.md
+++ b/.claude/skills/implement-plan/references/dispatch-templates.md
@@ -1,0 +1,55 @@
+# Dispatch templates
+
+Exact text to pass each subagent. Fill the `<...>` placeholders with **verbatim** plan slices — never paraphrase. The orchestrator slices; these templates wrap the slices with just enough framing. The subagents' output formats live in their own agent files (`.claude/agents/`), not here.
+
+## Brief for `phase-developer` — first round
+
+```
+You are implementing ONE phase of an implementation plan. Implement only this phase.
+
+== PLAN PREAMBLE (binds every phase — read it) ==
+<preamble verbatim: Overview, Applicable Guidelines, Definition of Done — Test Integrity, Ordering/Environment notes>
+
+== OTHER PHASES (titles only, for resolving cross-references) ==
+<one line per other phase: "Phase K: <title>">
+
+== YOUR TARGET PHASE (your only deliverable) ==
+<Phase N block, verbatim, all subsections>
+
+== BASELINE ==
+Phases before this one are already implemented and committed on the current branch; the working tree reflects them. Build on top. Do not commit — the orchestrator commits after verification.
+```
+
+## Brief for `phase-developer` — gap round
+
+Same as the first-round brief, with this appended:
+
+```
+== VERIFIER GAP REPORT (close exactly these) ==
+<the verifier's GAPS_FOUND list, verbatim>
+
+Your prior work from the previous round is already in the working tree. Do not start over — address exactly the gaps above, then re-run the relevant checks.
+```
+
+## Brief for `plan-correspondence-verifier`
+
+```
+Verify that ONE phase was implemented completely and honestly. You are a correspondence checker, not a code reviewer.
+
+== PLAN PREAMBLE (includes how to run tools in this repo, and the Definition of Done — Test Integrity, which is your honesty charter) ==
+<preamble verbatim>
+
+== PHASE UNDER VERIFICATION ==
+<Phase N block, verbatim, all subsections>
+
+== BASELINE REF ==
+Judge only the changes between <baseline commit SHA — captured with `git rev-parse HEAD` before the first developer of this phase> and the current working tree.
+
+Build your own checklist from the phase text, inspect the actual diff and files (not the developer's claims), re-run the cheap deterministic checks yourself, verify integration-test evidence without re-running it, and return your VERDICT in the structure your instructions define.
+```
+
+## Notes
+
+- The **baseline ref** for the verifier is the SHA captured with `git rev-parse HEAD` *right before* dispatching the first developer for that phase — not after.
+- Pass the **same** preamble to both subagents; it carries the environment rule and the Definition of Done.
+- For a **Final Checklist fix**, brief the developer with the failing checklist item plus the smallest relevant slice of plan context (often the phase that item came from), and the instruction to fix only that item.

--- a/.claude/skills/implement-plan/references/dispatch-templates.md
+++ b/.claude/skills/implement-plan/references/dispatch-templates.md
@@ -1,23 +1,22 @@
 # Dispatch templates
 
-Exact text to pass each subagent. Fill the `<...>` placeholders with **verbatim** plan slices — never paraphrase. The orchestrator slices; these templates wrap the slices with just enough framing. The subagents' output formats live in their own agent files (`.claude/agents/`), not here.
+Exact text to pass each subagent. The plan has already been sliced into per-section files by `scripts/slice_impl_plan.py` (skill Step 1); you pass **paths**, never pasted content. Fill the `<...>` placeholders with the real slice directory, phase number, title, baseline SHA, and (on a gap round) the verifier's gap list. The slice files are the verbatim source of truth; your only job is to route paths. The subagents' output formats live in their own agent files (`.claude/agents/`), not here.
+
+`SLICE_DIR` below is the `.ai/tmp/impl/<plan-stem>/` directory reported in the slicer's manifest.
 
 ## Brief for `phase-developer` — first round
 
 ```
 You are implementing ONE phase of an implementation plan. Implement only this phase.
 
-== PLAN PREAMBLE (binds every phase — read it) ==
-<preamble verbatim: Overview, Applicable Guidelines, Definition of Done — Test Integrity, Ordering/Environment notes>
+Read these files first — they are the verbatim plan text and your source of truth:
+- PLAN PREAMBLE (binds every phase: Overview, Applicable Guidelines, Definition of Done — Test Integrity, any Ordering/Environment notes): <SLICE_DIR>/preamble.md
+- YOUR TARGET PHASE (your only deliverable): <SLICE_DIR>/phase-<N>.md
 
-== OTHER PHASES (titles only, for resolving cross-references) ==
+OTHER PHASES (titles only, for resolving cross-references like "removed in Phase 5"):
 <one line per other phase: "Phase K: <title>">
 
-== YOUR TARGET PHASE (your only deliverable) ==
-<Phase N block, verbatim, all subsections>
-
-== BASELINE ==
-Phases before this one are already implemented and committed on the current branch; the working tree reflects them. Build on top. Do not commit — the orchestrator commits after verification.
+BASELINE: phases before this one are already implemented and committed on the current branch; the working tree reflects them. Build on top. Do NOT commit — the orchestrator commits after verification.
 ```
 
 ## Brief for `phase-developer` — gap round
@@ -25,7 +24,7 @@ Phases before this one are already implemented and committed on the current bran
 Same as the first-round brief, with this appended:
 
 ```
-== VERIFIER GAP REPORT (close exactly these) ==
+VERIFIER GAP REPORT (close exactly these):
 <the verifier's GAPS_FOUND list, verbatim>
 
 Your prior work from the previous round is already in the working tree. Do not start over — address exactly the gaps above, then re-run the relevant checks.
@@ -36,14 +35,11 @@ Your prior work from the previous round is already in the working tree. Do not s
 ```
 Verify that ONE phase was implemented completely and honestly. You are a correspondence checker, not a code reviewer.
 
-== PLAN PREAMBLE (includes how to run tools in this repo, and the Definition of Done — Test Integrity, which is your honesty charter) ==
-<preamble verbatim>
+Read these files first — they are the verbatim plan text:
+- PLAN PREAMBLE (how to run tools in this repo, and the Definition of Done — Test Integrity, which is your honesty charter): <SLICE_DIR>/preamble.md
+- PHASE UNDER VERIFICATION: <SLICE_DIR>/phase-<N>.md
 
-== PHASE UNDER VERIFICATION ==
-<Phase N block, verbatim, all subsections>
-
-== BASELINE REF ==
-Judge only the changes between <baseline commit SHA — captured with `git rev-parse HEAD` before the first developer of this phase> and the current working tree. The phase's work is **uncommitted**: inspect it with `git diff <baseline>` (no `..`) plus `git status --porcelain` for new/untracked files. Do not use `git diff <baseline>..` — that compares two commits and shows nothing while the work is uncommitted.
+BASELINE REF: judge only the changes between <baseline commit SHA — captured with `git rev-parse HEAD` before the first developer of this phase> and the current working tree. The phase's work is **uncommitted**: inspect it with `git diff <baseline>` (no `..`) plus `git status --porcelain` for new/untracked files. Do not use `git diff <baseline>..` — that compares two commits and shows nothing while the work is uncommitted.
 
 Build your own checklist from the phase text, inspect the actual diff and files (not the developer's claims), re-run the cheap deterministic checks yourself, verify integration-test evidence without re-running it (unless this brief includes the integration-re-run block below), and return your VERDICT in the structure your instructions define.
 ```
@@ -59,7 +55,11 @@ NOTE ON INTEGRATION EVIDENCE: this phase's deliverable is a live integration tes
 
 ## Notes
 
+- The plan slices live under `.ai/tmp/impl/<plan-stem>/` (gitignored): `preamble.md`, `phase-1.md` … `phase-N.md`, `final-checklist.md`. Pass paths, never paste the content.
+- The phase titles for cross-references come from the slicer's manifest (its `title=` per slug).
 - The **baseline ref** for the verifier is the SHA captured with `git rev-parse HEAD` *right before* dispatching the first developer for that phase — not after.
-- Pass the **same** preamble to both subagents; it carries the environment rule and the Definition of Done.
-- For a **Final Checklist fix**, brief the developer with the failing checklist item plus the smallest relevant slice of plan context (often the phase that item came from), and the instruction to fix only that item.
+- Both subagents read the **same** `preamble.md`; it carries the environment rule and the Definition of Done.
+- For a **Final Checklist fix**, brief the developer with the failing checklist item plus the path to the most relevant slice (often the phase that item came from), and the instruction to fix only that item.
 - Add the **INTEGRATION RE-RUN** block to the verifier's brief *only* for a phase whose deliverable is itself an integration test (a live test + its skip-gate). For all other phases omit it — the verifier defaults to evidence-only, and the full suite gets its one authoritative run at the Final Checklist.
+- If the plan had no markers and you fell back to slicing by headings yourself (skill Step 1, exit code 2), write the same filenames into the same `.ai/tmp/impl/<plan-stem>/` directory so these briefs work unchanged.
+```

--- a/.claude/skills/implement-plan/references/dispatch-templates.md
+++ b/.claude/skills/implement-plan/references/dispatch-templates.md
@@ -41,6 +41,9 @@ Read these files first — they are the verbatim plan text:
 
 BASELINE REF: judge only the changes between <baseline commit SHA — captured with `git rev-parse HEAD` before the first developer of this phase> and the current working tree. The phase's work is **uncommitted**: inspect it with `git diff <baseline>` (no `..`) plus `git status --porcelain` for new/untracked files. Do not use `git diff <baseline>..` — that compares two commits and shows nothing while the work is uncommitted.
 
+DEVELOPER'S INTEGRATION-TEST EVIDENCE (verify it; do NOT re-run it, unless the integration-re-run block below authorizes it):
+<the `### Integration-test evidence` section of the developer's report, lifted verbatim — or "none" if the phase has no integration tests>
+
 Build your own checklist from the phase text, inspect the actual diff and files (not the developer's claims), re-run the cheap deterministic checks yourself, verify integration-test evidence without re-running it (unless this brief includes the integration-re-run block below), and return your VERDICT in the structure your instructions define.
 ```
 
@@ -59,6 +62,7 @@ NOTE ON INTEGRATION EVIDENCE: this phase's deliverable is a live integration tes
 - The phase titles for cross-references come from the slicer's manifest (its `title=` per slug).
 - The **baseline ref** for the verifier is the SHA captured with `git rev-parse HEAD` *right before* dispatching the first developer for that phase — not after.
 - Both subagents read the **same** `preamble.md`; it carries the environment rule and the Definition of Done.
+- The verifier's integration-evidence block is the developer report's `### Integration-test evidence` section, lifted **verbatim** (or "none") — it is runtime output, so it goes inline, not as a slice path. It is the *only* part of the developer's report that travels onward; everything else the verifier reconstructs from the diff. Lift it, don't summarize it, so "pass slices by reference, never paraphrase" still holds.
 - For a **Final Checklist fix**, brief the developer with the failing checklist item plus the path to the most relevant slice (often the phase that item came from), and the instruction to fix only that item.
 - Add the **INTEGRATION RE-RUN** block to the verifier's brief *only* for a phase whose deliverable is itself an integration test (a live test + its skip-gate). For all other phases omit it — the verifier defaults to evidence-only, and the full suite gets its one authoritative run at the Final Checklist.
 - If the plan had no markers and you fell back to slicing by headings yourself (skill Step 1, exit code 2), write the same filenames into the same `.ai/tmp/impl/<plan-stem>/` directory so these briefs work unchanged.

--- a/.claude/skills/implement-plan/references/dispatch-templates.md
+++ b/.claude/skills/implement-plan/references/dispatch-templates.md
@@ -43,9 +43,18 @@ Verify that ONE phase was implemented completely and honestly. You are a corresp
 <Phase N block, verbatim, all subsections>
 
 == BASELINE REF ==
-Judge only the changes between <baseline commit SHA — captured with `git rev-parse HEAD` before the first developer of this phase> and the current working tree.
+Judge only the changes between <baseline commit SHA — captured with `git rev-parse HEAD` before the first developer of this phase> and the current working tree. The phase's work is **uncommitted**: inspect it with `git diff <baseline>` (no `..`) plus `git status --porcelain` for new/untracked files. Do not use `git diff <baseline>..` — that compares two commits and shows nothing while the work is uncommitted.
 
-Build your own checklist from the phase text, inspect the actual diff and files (not the developer's claims), re-run the cheap deterministic checks yourself, verify integration-test evidence without re-running it, and return your VERDICT in the structure your instructions define.
+Build your own checklist from the phase text, inspect the actual diff and files (not the developer's claims), re-run the cheap deterministic checks yourself, verify integration-test evidence without re-running it (unless this brief includes the integration-re-run block below), and return your VERDICT in the structure your instructions define.
+```
+
+## Optional add-on for `plan-correspondence-verifier` — integration-deliverable phases only
+
+Append this block to the verifier brief **only** when the phase's actual deliverable *is* an integration test (a live test plus its skip-gate). Omit it for every other phase.
+
+```
+== INTEGRATION RE-RUN (authorized for this phase) ==
+NOTE ON INTEGRATION EVIDENCE: this phase's deliverable is a live integration test and its skip-gate, so confirming it first-hand matters. You MAY re-run THIS phase's targeted integration through the timeout runner — `python scripts/run_integration_tests.py <only this phase's integration test files>` — to verify the test actually ran (or skipped for the right reason) rather than taking the developer's word. Re-run only those targeted files, never the whole suite; the full authoritative run happens at the Final Checklist.
 ```
 
 ## Notes
@@ -53,3 +62,4 @@ Build your own checklist from the phase text, inspect the actual diff and files 
 - The **baseline ref** for the verifier is the SHA captured with `git rev-parse HEAD` *right before* dispatching the first developer for that phase — not after.
 - Pass the **same** preamble to both subagents; it carries the environment rule and the Definition of Done.
 - For a **Final Checklist fix**, brief the developer with the failing checklist item plus the smallest relevant slice of plan context (often the phase that item came from), and the instruction to fix only that item.
+- Add the **INTEGRATION RE-RUN** block to the verifier's brief *only* for a phase whose deliverable is itself an integration test (a live test + its skip-gate). For all other phases omit it — the verifier defaults to evidence-only, and the full suite gets its one authoritative run at the Final Checklist.

--- a/scripts/slice_impl_plan.py
+++ b/scripts/slice_impl_plan.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Validate and slice a marker-delimited implementation plan into per-section files.
+
+Why this exists
+---------------
+The ``implement-plan`` orchestrator hands each phase of a plan to a fresh
+``phase-developer`` subagent and a ``plan-correspondence-verifier`` subagent.
+The shared preamble (Overview, Applicable Guidelines, Definition of Done) and
+each phase's verbatim text would otherwise be re-embedded inline in every
+dispatch prompt — the same bytes copied 2x per phase, plus once more per gap
+round — bloating the orchestrator's own context and risking mid-run compaction.
+
+Instead, the plan is split **once** into files under ``.ai/tmp/impl/<plan>/``
+and the orchestrator dispatches by file path. Each subagent reads only the
+slice it needs.
+
+Slicing reliably by Markdown headings is impossible: implementation plans embed
+fenced code blocks and exact documentation snippets that legitimately contain
+``#``/``##`` headings as *content*, which a naive ``grep '^## '`` would mistake
+for a phase boundary. So the producer (the ``plan-export`` skill) wraps every
+section in explicit, namespaced HTML-comment markers, and this script is the
+single source of truth that both validates and cuts them.
+
+Marker contract
+---------------
+Each section is wrapped in a *paired* begin/end marker, anchored at column 0::
+
+    <!-- impl-plan:begin slug="preamble" -->
+    # Implementation Plan for Issue #375
+    ...
+    ## Definition of Done — Test Integrity (non-negotiable)
+    ...
+    <!-- impl-plan:end slug="preamble" -->
+
+    <!-- impl-plan:begin slug="phase-1" title="Add PRO API key configuration" -->
+    ## Phase 1: ...
+    <!-- impl-plan:end slug="phase-1" -->
+
+    <!-- impl-plan:begin slug="final-checklist" -->
+    ## Final Checklist
+    ...
+    <!-- impl-plan:end slug="final-checklist" -->
+
+Rules enforced (any violation fails loudly rather than slicing silently wrong):
+
+* begin/end markers are balanced, never nested, and the end slug matches the
+  open begin slug;
+* slugs are unique;
+* regions appear as exactly ``preamble`` first, then ``phase-1 .. phase-N`` in
+  ascending contiguous order, then ``final-checklist`` last;
+* every non-blank line that is not a ``---`` rule lives inside some region —
+  no content may sit in the gaps (this is what catches a section the producer
+  forgot to wrap);
+* a light content-sanity layer confirms each region actually wraps the heading
+  its slug claims (``preamble`` contains the Definition of Done heading; each
+  ``phase-N`` opens with its ``## Phase N`` heading; ``final-checklist`` opens
+  with ``## Final Checklist``) — this catches a marker placed in the wrong spot.
+
+Usage
+-----
+Validate only (no files written) — used by ``plan-export`` as a self-check at
+the end of plan generation::
+
+    python scripts/slice_impl_plan.py PLAN.md --inspect
+
+Validate and write slices — used by ``implement-plan`` before dispatching::
+
+    python scripts/slice_impl_plan.py PLAN.md [--out-dir DIR]
+
+Exit codes (the orchestrator branches on these)::
+
+    0  plan is valid; slices written (or, with --inspect, would slice cleanly)
+    1  markers are present but malformed — caller should escalate, not guess
+    2  no markers found at all — a legacy plan; caller may fall back to its own
+       heading-based slicing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+BEGIN_RE = re.compile(
+    r'^<!--\s*impl-plan:begin\s+slug="(?P<slug>[a-z0-9-]+)"(?:\s+title="(?P<title>[^"]*)")?\s*-->\s*$'
+)
+END_RE = re.compile(r'^<!--\s*impl-plan:end\s+slug="(?P<slug>[a-z0-9-]+)"\s*-->\s*$')
+# A line allowed in the gaps between regions: blank, or a horizontal rule.
+GAP_RE = re.compile(r"^\s*(?:-{3,}\s*)?$")
+
+EXIT_OK = 0
+EXIT_INVALID = 1  # markers present but malformed -> caller should escalate
+EXIT_NO_MARKERS = 2  # no markers at all -> caller may fall back
+
+
+@dataclass
+class Region:
+    """One marker-delimited section of the plan."""
+
+    slug: str
+    title: str | None
+    begin_line: int  # 1-based line number of the begin marker
+    end_line: int  # 1-based line number of the end marker
+    body: list[str]  # content lines strictly between the markers (markers excluded)
+
+    @property
+    def content_span(self) -> str:
+        first, last = self.begin_line + 1, self.end_line - 1
+        return f"{first}-{last}" if last >= first else "empty"
+
+
+def has_markers(lines: list[str]) -> bool:
+    """True if the file contains any impl-plan marker at all."""
+    return any(BEGIN_RE.match(line) or END_RE.match(line) for line in lines)
+
+
+def parse_regions(lines: list[str]) -> tuple[list[Region], list[str]]:
+    """Scan lines into ordered regions. Returns (regions, structural_errors).
+
+    Structural errors (unbalanced/nested/mismatched markers) are returned rather
+    than raised so the CLI can report all of them at once. When this list is
+    non-empty the regions are unreliable and downstream checks are skipped.
+    """
+    regions: list[Region] = []
+    errors: list[str] = []
+    open_slug: str | None = None
+    open_title: str | None = None
+    open_line = 0
+    body_start = 0  # 0-based index of the first body line of the open region
+
+    for idx, line in enumerate(lines):
+        lineno = idx + 1
+        begin = BEGIN_RE.match(line)
+        end = END_RE.match(line)
+        if begin:
+            if open_slug is not None:
+                errors.append(
+                    f'line {lineno}: begin slug="{begin["slug"]}" while region slug="{open_slug}" '
+                    f"(opened at line {open_line}) is still open — nested markers are not allowed"
+                )
+            open_slug = begin["slug"]
+            open_title = begin.group("title")
+            open_line = lineno
+            body_start = idx + 1
+        elif end:
+            if open_slug is None:
+                errors.append(f'line {lineno}: end slug="{end["slug"]}" with no open region')
+                continue
+            if end["slug"] != open_slug:
+                errors.append(
+                    f'line {lineno}: end slug="{end["slug"]}" does not match open region '
+                    f'slug="{open_slug}" (opened at line {open_line})'
+                )
+            regions.append(
+                Region(
+                    slug=open_slug,
+                    title=open_title,
+                    begin_line=open_line,
+                    end_line=lineno,
+                    body=lines[body_start:idx],
+                )
+            )
+            open_slug = None
+
+    if open_slug is not None:
+        errors.append(f'line {open_line}: begin slug="{open_slug}" is never closed')
+
+    return regions, errors
+
+
+def check_schema(regions: list[Region]) -> list[str]:
+    """Verify slug set and ordering: preamble, phase-1..N contiguous, final-checklist."""
+    errors: list[str] = []
+    slugs = [r.slug for r in regions]
+
+    seen: set[str] = set()
+    for slug in slugs:
+        if slug in seen:
+            errors.append(f'slug "{slug}" appears more than once')
+        seen.add(slug)
+
+    if not regions:
+        errors.append("no regions found")
+        return errors
+    if slugs[0] != "preamble":
+        errors.append(f'first region must be slug="preamble", found slug="{slugs[0]}"')
+    if slugs[-1] != "final-checklist":
+        errors.append(f'last region must be slug="final-checklist", found slug="{slugs[-1]}"')
+
+    middle = slugs[1:-1] if len(slugs) >= 2 else []
+    if not middle:
+        errors.append('no phases found (expected at least slug="phase-1")')
+    for position, slug in enumerate(middle, start=1):
+        expected = f"phase-{position}"
+        if slug != expected:
+            errors.append(f'expected slug="{expected}" in phase sequence, found slug="{slug}"')
+            break
+
+    return errors
+
+
+def check_coverage(lines: list[str], regions: list[Region]) -> list[str]:
+    """Every non-blank, non-rule line must live inside a region — no orphan content."""
+    covered = [False] * len(lines)
+    for region in regions:
+        for i in range(region.begin_line - 1, region.end_line):  # markers inclusive
+            covered[i] = True
+
+    errors: list[str] = []
+    for idx, line in enumerate(lines):
+        if covered[idx] or GAP_RE.match(line):
+            continue
+        errors.append(f"line {idx + 1}: content outside any marked region: {line.strip()!r}")
+    return errors
+
+
+def _first_nonblank(body: list[str]) -> str | None:
+    for line in body:
+        if line.strip():
+            return line
+    return None
+
+
+def check_content(regions: list[Region]) -> list[str]:
+    """Light sanity layer: each region wraps the heading its slug claims."""
+    errors: list[str] = []
+    for region in regions:
+        if region.slug == "preamble":
+            if not any(re.match(r"^##\s+Definition of Done\b", line) for line in region.body):
+                errors.append('region slug="preamble" lacks a "## Definition of Done" heading')
+        elif region.slug == "final-checklist":
+            head = _first_nonblank(region.body) or ""
+            if not re.match(r"^##\s+Final Checklist\b", head):
+                errors.append('region slug="final-checklist" does not open with a "## Final Checklist" heading')
+        elif region.slug.startswith("phase-"):
+            number = region.slug.split("-", 1)[1]
+            head = _first_nonblank(region.body) or ""
+            if not re.match(rf"^##\s+Phase\s+{re.escape(number)}\b", head):
+                errors.append(f'region slug="{region.slug}" does not open with a "## Phase {number}" heading')
+    return errors
+
+
+def validate_text(text: str) -> tuple[list[Region], list[str], bool]:
+    """Validate plan text. Returns (regions, errors, markers_present).
+
+    When ``markers_present`` is False the plan is a legacy/unmarked one and the
+    caller should treat it as not machine-sliceable. When ``errors`` is
+    non-empty the markers are malformed.
+    """
+    lines = text.splitlines()
+    if not has_markers(lines):
+        return [], [], False
+
+    regions, errors = parse_regions(lines)
+    if errors:
+        return regions, errors, True  # structure broken; skip cascading checks
+
+    errors += check_schema(regions)
+    errors += check_coverage(lines, regions)
+    errors += check_content(regions)
+    return regions, errors, True
+
+
+def find_project_root(start: Path) -> Path:
+    """Nearest ancestor containing pyproject.toml or .git, else the cwd."""
+    for directory in (start, *start.parents):
+        if (directory / "pyproject.toml").is_file() or (directory / ".git").exists():
+            return directory
+    return Path.cwd()
+
+
+def default_out_dir(plan_path: Path) -> Path:
+    root = find_project_root(plan_path.resolve().parent)
+    return root / ".ai" / "tmp" / "impl" / plan_path.stem
+
+
+def write_slices(regions: list[Region], out_dir: Path) -> list[Path]:
+    """Write each region body to ``<out_dir>/<slug>.md`` (markers stripped)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for stale in out_dir.glob("*.md"):  # avoid leftovers from an earlier, longer plan
+        stale.unlink()
+    written: list[Path] = []
+    for region in regions:
+        target = out_dir / f"{region.slug}.md"
+        body = "\n".join(region.body).strip("\n")
+        target.write_text(body + "\n", encoding="utf-8")
+        written.append(target)
+    return written
+
+
+def print_manifest(plan_path: Path, regions: list[Region], out_dir: Path, *, inspect: bool) -> None:
+    note = "  (inspect only — nothing written)" if inspect else ""
+    print(f"plan:    {plan_path}")
+    print(f"out-dir: {out_dir}{note}")
+    print(f"regions: {len(regions)}")
+    for region in regions:
+        title = region.title or "-"
+        print(f"  {region.slug:<16} lines {region.content_span:<10} file={out_dir / f'{region.slug}.md'}")
+        print(f"  {'':<16}                  title={title}")
+    verb = "would slice cleanly into" if inspect else "sliced into"
+    print(f"RESULT: OK — {plan_path.name} {verb} {len(regions)} regions")
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="slice_impl_plan.py",
+        description="Validate and slice a marker-delimited implementation plan.",
+    )
+    parser.add_argument("plan", type=Path, help="path to the implementation-plan Markdown file")
+    parser.add_argument(
+        "--inspect",
+        action="store_true",
+        help="validate only and report; do not write any files (used by plan-export as a self-check)",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="directory to write slices into (default: <project-root>/.ai/tmp/impl/<plan-stem>/)",
+    )
+    return parser.parse_args(argv)
+
+
+def run_cli(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    plan_path: Path = args.plan
+
+    if not plan_path.is_file():
+        print(f"error: plan file not found: {plan_path}", file=sys.stderr)
+        return EXIT_INVALID
+
+    regions, errors, markers = validate_text(plan_path.read_text(encoding="utf-8"))
+
+    if not markers:
+        print(
+            f"no impl-plan markers found in {plan_path} — plan is not machine-sliceable",
+            file=sys.stderr,
+        )
+        return EXIT_NO_MARKERS
+
+    if errors:
+        print(f"INVALID: {plan_path} has {len(errors)} marker problem(s):", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return EXIT_INVALID
+
+    out_dir = args.out_dir or default_out_dir(plan_path)
+    print_manifest(plan_path, regions, out_dir, inspect=args.inspect)
+    if not args.inspect:
+        write_slices(regions, out_dir)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(run_cli())

--- a/tests/scripts/test_slice_impl_plan.py
+++ b/tests/scripts/test_slice_impl_plan.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Unit tests for scripts/slice_impl_plan.py — the plan marker validator/slicer."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "slice_impl_plan.py"
+_spec = importlib.util.spec_from_file_location("slice_impl_plan", _MODULE_PATH)
+assert _spec and _spec.loader
+slicer = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = slicer  # let @dataclass resolve cls.__module__ during exec
+_spec.loader.exec_module(slicer)
+
+
+# A fully valid plan. Note the embedded "## ..." heading inside a fenced block in
+# phase-2: it is the whole reason markers exist — a heading-based slicer would
+# treat it as a phase boundary, but marker-based slicing keeps it as content.
+VALID_PLAN = """\
+<!-- impl-plan:begin slug="preamble" -->
+# Implementation Plan for Issue #999
+
+**GitHub Issue:** https://example.test/issues/999
+
+## Overview
+
+Do the thing.
+
+## Definition of Done — Test Integrity (non-negotiable)
+
+Tests must genuinely pass.
+<!-- impl-plan:end slug="preamble" -->
+
+---
+
+<!-- impl-plan:begin slug="phase-1" title="First phase" -->
+## Phase 1: First phase
+
+### Objective
+
+Lay the groundwork.
+<!-- impl-plan:end slug="phase-1" -->
+
+<!-- impl-plan:begin slug="phase-2" title="Second `phase`" -->
+## Phase 2: Second phase
+
+```markdown
+## This embedded heading must NOT create a false boundary
+```
+<!-- impl-plan:end slug="phase-2" -->
+
+<!-- impl-plan:begin slug="final-checklist" -->
+## Final Checklist
+
+- [ ] done
+<!-- impl-plan:end slug="final-checklist" -->
+"""
+
+
+def test_valid_plan_validates_clean() -> None:
+    regions, errors, markers = slicer.validate_text(VALID_PLAN)
+    assert markers is True
+    assert errors == []
+    assert [r.slug for r in regions] == ["preamble", "phase-1", "phase-2", "final-checklist"]
+    assert [r.title for r in regions] == [None, "First phase", "Second `phase`", None]
+
+
+def test_write_slices_strips_markers_and_preserves_content(tmp_path: Path) -> None:
+    regions, errors, _ = slicer.validate_text(VALID_PLAN)
+    assert errors == []
+    written = slicer.write_slices(regions, tmp_path)
+
+    names = {p.name for p in written}
+    assert names == {"preamble.md", "phase-1.md", "phase-2.md", "final-checklist.md"}
+
+    for path in written:
+        assert "impl-plan:" not in path.read_text(encoding="utf-8")
+
+    preamble = (tmp_path / "preamble.md").read_text(encoding="utf-8")
+    assert "## Definition of Done" in preamble
+
+    phase2 = (tmp_path / "phase-2.md").read_text(encoding="utf-8")
+    # The embedded heading survives verbatim inside the phase slice.
+    assert "## This embedded heading must NOT create a false boundary" in phase2
+
+
+def test_write_slices_removes_stale_files(tmp_path: Path) -> None:
+    (tmp_path / "phase-9.md").write_text("leftover\n", encoding="utf-8")
+    regions, _, _ = slicer.validate_text(VALID_PLAN)
+    slicer.write_slices(regions, tmp_path)
+    assert not (tmp_path / "phase-9.md").exists()
+
+
+def test_plain_markdown_has_no_markers() -> None:
+    _, errors, markers = slicer.validate_text("# Title\n\n## Phase 1: thing\n")
+    assert markers is False
+    assert errors == []
+
+
+def test_missing_end_marker_is_reported() -> None:
+    # Drop the last region's end marker: nothing follows to mis-close it, so it
+    # surfaces as a genuinely unclosed region.
+    broken = VALID_PLAN.replace('<!-- impl-plan:end slug="final-checklist" -->\n', "")
+    _, errors, markers = slicer.validate_text(broken)
+    assert markers is True
+    assert any("never closed" in e for e in errors)
+
+
+def test_nested_markers_are_reported() -> None:
+    nested = VALID_PLAN.replace(
+        '<!-- impl-plan:end slug="phase-1" -->',
+        '<!-- impl-plan:begin slug="phase-1b" title="oops" -->',
+    )
+    _, errors, _ = slicer.validate_text(nested)
+    assert any("nested markers are not allowed" in e for e in errors)
+
+
+def test_duplicate_slug_is_reported() -> None:
+    dup = VALID_PLAN.replace('slug="phase-2"', 'slug="phase-1"')
+    _, errors, _ = slicer.validate_text(dup)
+    assert any('"phase-1" appears more than once' in e for e in errors)
+
+
+def test_orphan_content_outside_regions_is_reported() -> None:
+    orphan = VALID_PLAN.replace(
+        '<!-- impl-plan:end slug="phase-1" -->\n',
+        '<!-- impl-plan:end slug="phase-1" -->\nthis stray sentence escaped its region\n',
+    )
+    _, errors, _ = slicer.validate_text(orphan)
+    assert any("content outside any marked region" in e for e in errors)
+
+
+def test_non_contiguous_phases_are_reported() -> None:
+    gap = VALID_PLAN.replace('slug="phase-2"', 'slug="phase-3"')
+    _, errors, _ = slicer.validate_text(gap)
+    assert any('expected slug="phase-2"' in e for e in errors)
+
+
+def test_misplaced_marker_caught_by_content_check() -> None:
+    # phase-2 marker now wraps a body that opens with the wrong phase heading.
+    bad = VALID_PLAN.replace("## Phase 2: Second phase", "## Phase 5: Wrong phase")
+    _, errors, _ = slicer.validate_text(bad)
+    assert any('slug="phase-2" does not open with a "## Phase 2" heading' in e for e in errors)
+
+
+def _write_plan(tmp_path: Path, text: str) -> Path:
+    plan = tmp_path / "plan.md"
+    plan.write_text(text, encoding="utf-8")
+    return plan
+
+
+def test_cli_inspect_valid_returns_zero_and_writes_nothing(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, VALID_PLAN)
+    out = tmp_path / "out"
+    code = slicer.run_cli([str(plan), "--inspect", "--out-dir", str(out)])
+    assert code == slicer.EXIT_OK
+    assert not out.exists()
+
+
+def test_cli_slice_valid_writes_files(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, VALID_PLAN)
+    out = tmp_path / "out"
+    code = slicer.run_cli([str(plan), "--out-dir", str(out)])
+    assert code == slicer.EXIT_OK
+    assert (out / "preamble.md").is_file()
+    assert (out / "phase-1.md").is_file()
+    assert (out / "final-checklist.md").is_file()
+
+
+def test_cli_no_markers_returns_two(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, "# Plain plan\n\n## Phase 1: x\n")
+    code = slicer.run_cli([str(plan), "--inspect"])
+    assert code == slicer.EXIT_NO_MARKERS
+
+
+def test_cli_malformed_returns_one(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, VALID_PLAN.replace('<!-- impl-plan:end slug="phase-2" -->\n', ""))
+    code = slicer.run_cli([str(plan), "--inspect"])
+    assert code == slicer.EXIT_INVALID


### PR DESCRIPTION
## Summary

Introduces the \`implement-plan\` orchestrator skill and supporting subagents that execute structured implementation plans (e.g. \`temp/impl_plans/issue-*.md\`) phase by phase:

- **\`implement-plan\` skill** — orchestrates a \`phase-developer\` + \`plan-correspondence-verifier\` subagent loop per phase, commits each verified phase, and walks the Final Checklist. Passes plan sections by file path (never pasted) to keep the orchestrator context small and traceable.
- **\`phase-developer\` agent** — implements exactly one phase of a plan and returns a lean report (status + integration-test evidence). Does not commit; the orchestrator commits after verification.
- **\`plan-correspondence-verifier\` agent** — reads the same phase slice and independently verifies that every step was done, returning \`COMPLETE\` or \`GAPS_FOUND\` (with a gap list for the next developer round).
- **\`scripts/slice_impl_plan.py\`** — utility that parses plan marker annotations and writes one file per section (\`preamble.md\`, \`phase-N.md\`, \`final-checklist.md\`) under \`.ai/tmp/impl/\`; unit-tested in \`tests/scripts/test_slice_impl_plan.py\`.
- **\`gh-safe\` skill** — GitHub CLI helper that avoids accidental destructive \`gh\` operations during automated runs.

**Harness tuning:**
- \`implementation-plan-review\` skill: no longer triggers on version-bump-only commits.
- \`plan-export\` skill: optimized output format for sub-agent consumption.

@coderabbitai ignore