### PR TITLE
Route contract reads through the Blockscout PRO API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,16 +12,19 @@ BLOCKSCOUT_BS_TIMEOUT=120.0
 BLOCKSCOUT_BENS_TIMEOUT=30.0
 BLOCKSCOUT_CHAINSCOUT_TIMEOUT=15.0
 
-# PRO API base URL — serves two purposes:
+# PRO API base URL — serves three purposes:
 #   * its /api/json/config endpoint (no API key required) determines the authoritative set of supported chains and their URLs;
-#   * its /services/metadata/... endpoint provides address metadata tags and requires an API key (see BLOCKSCOUT_PRO_API_KEY below).
+#   * its /services/metadata/... endpoint provides address metadata tags and requires an API key (see BLOCKSCOUT_PRO_API_KEY below);
+#   * its /{chain_id}/json-rpc gateway serves read_contract's eth_call requests and requires an API key.
 # Override the base URL only for testing against a non-production PRO API instance.
 BLOCKSCOUT_PRO_API_BASE_URL="https://api.blockscout.com"
 BLOCKSCOUT_PRO_API_CONFIG_REFRESH_RETRY_SECONDS=30
 BLOCKSCOUT_PRO_API_CONFIG_TIMEOUT=15.0
 BLOCKSCOUT_PRO_API_CONFIG_TTL_SECONDS=300
-# Blockscout PRO API key (prefix "proapi_"). Required for address-metadata enrichment in get_address_info.
-# When unset, metadata is omitted gracefully (the field is null and a note is added). Generate one at https://dev.blockscout.com.
+# Blockscout PRO API key (prefix "proapi_"). Powers two features:
+#   * address-metadata enrichment in get_address_info — when unset, metadata is omitted gracefully (the field is null and a note is added);
+#   * read_contract — eth_call is routed through the PRO API JSON-RPC gateway, which requires the key; when unset, read_contract fails fast and makes no network call.
+# Generate one at https://dev.blockscout.com.
 BLOCKSCOUT_PRO_API_KEY=""
 BLOCKSCOUT_CHAIN_CACHE_TTL_SECONDS=1800
 BLOCKSCOUT_CHAINS_LIST_TTL_SECONDS=300

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ mcp-server/
 │       │   └── test___unlock_blockchain_analysis__.py  # Unit tests for __unlock_blockchain_analysis__
 │       ├── search/             # Tests for search-related MCP tools
 │       │   └── test_lookup_token_by_symbol.py  # Unit tests for lookup_token_by_symbol
+│       ├── test_chain_support.py     # Unit tests for the ensure_chain_supported helper
 │       ├── test_common.py            # Unit tests for shared tool utilities
 │       ├── test_common_truncate.py   # Unit tests for truncation helpers
 │       ├── test_common_post_request.py   # Unit tests for POST request helper

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV BLOCKSCOUT_BS_TIMEOUT="120.0"
 ENV BLOCKSCOUT_BS_REQUEST_MAX_RETRIES="3"
 ENV BLOCKSCOUT_BENS_URL="https://bens.services.blockscout.com"
 ENV BLOCKSCOUT_BENS_TIMEOUT="30.0"
+ENV BLOCKSCOUT_PRO_API_BASE_URL="https://api.blockscout.com"
 # ENV BLOCKSCOUT_PRO_API_KEY="" # Intentionally not set: pass at runtime to avoid embedding the PRO API key in the image
 ENV BLOCKSCOUT_METADATA_TIMEOUT="30.0"
 ENV BLOCKSCOUT_CHAINSCOUT_URL="https://chains.blockscout.com"

--- a/README.md
+++ b/README.md
@@ -357,6 +357,15 @@ docker run --rm -p 8000:8000 ghcr.io/blockscout/mcp-server:latest python -m bloc
 
 **Note:** When running in HTTP mode with Docker, use `--http-host 0.0.0.0` to bind to all interfaces so the server is accessible from outside the container.
 
+**With a Blockscout PRO API Key:**
+
+Pass the key at runtime with `-e` rather than baking it into the image (see [Blockscout PRO API Key](#blockscout-pro-api-key)):
+
+```bash
+docker run --rm -p 8000:8000 -e BLOCKSCOUT_PRO_API_KEY=proapi_your_key_here \
+  ghcr.io/blockscout/mcp-server:latest python -m blockscout_mcp_server --http --http-host 0.0.0.0
+```
+
 **Stdio Mode:** The default stdio mode is designed for use with MCP hosts/clients (like Claude Desktop, Cursor) and doesn't make sense to run directly with Docker without an MCP client managing the communication.
 
 ### Testing with Claude Desktop

--- a/README.md
+++ b/README.md
@@ -217,9 +217,14 @@ To customize the leading part of the `User-Agent` header used for RPC requests,
 set the `BLOCKSCOUT_MCP_USER_AGENT` environment variable (defaults to
 "Blockscout MCP"). The server version is appended automatically.
 
-### Blockscout PRO API Key (optional — enables address metadata)
+### Blockscout PRO API Key
 
-`get_address_info` enriches an address with public tags and name metadata fetched from the Blockscout PRO API metadata endpoint, which requires an API key. The key is **optional**: without it the server still runs, the metadata request is skipped entirely (no call is made to the PRO API), and the `metadata` field is returned as `null` together with a note explaining it was unavailable. Set the key to enable public-tag enrichment.
+The Blockscout PRO API key powers two features:
+
+- **Address metadata** (`get_address_info`): enriches an address with public tags and name metadata fetched from the Blockscout PRO API metadata endpoint. This is **optional** — without a key the server still runs, the metadata request is skipped entirely (no call is made to the PRO API), and the `metadata` field is returned as `null` together with a note explaining it was unavailable.
+- **Contract reads** (`read_contract`): `eth_call` is routed through the Blockscout PRO API JSON-RPC gateway, which **requires** a key. Without one, `read_contract` fails fast with a clear error and makes no network call; all other tools continue to work.
+
+Set the key to enable public-tag enrichment and contract reads.
 
 To obtain one, create an account at https://dev.blockscout.com (the free tier does not require a credit card) and generate an API key in the portal; keys are prefixed `proapi_`. Provide it to the server via the `BLOCKSCOUT_PRO_API_KEY` environment variable — exported in your shell or placed in a gitignored `.env` file in the project root. Never commit the key or embed it in a client-shipped binary; when running via Docker, pass it at runtime (e.g. `-e BLOCKSCOUT_PRO_API_KEY=...`) rather than baking it into the image.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -341,10 +341,12 @@ This architecture provides the flexibility of a multi-protocol server without th
    - **Conditional fields**: Optional details (like transaction value or method name) are only included when present and meaningful.
 
 4. **Async Web3 Connection Pool**:
-   - The server uses a custom `AsyncHTTPProviderBlockscout` and `Web3Pool` to interact with Blockscout's JSON-RPC interface.
-   - Connection pooling reuses TCP connections, reducing latency and resource usage.
+   - The server uses a custom `AsyncHTTPProviderBlockscout` and `Web3Pool` to perform `eth_call` requests through the Blockscout PRO API JSON-RPC gateway (`https://api.blockscout.com/{chain_id}/json-rpc`) rather than per-chain public RPC endpoints.
+   - Requests authenticate with the Blockscout PRO API key as a `Bearer` token. When no key is configured, contract reads fail fast with a clear error before any network call is made.
+   - Chain support is validated independently of instance URL resolution, against the authoritative PRO API chain configuration.
    - The provider ensures request IDs never start at zero and normalizes parameters to lists for Blockscout compatibility.
-   - A shared `aiohttp` session enforces global and per-host connection limits to prevent overload.
+   - Because all chains target a single gateway host, the pool maintains one shared `aiohttp` session whose connector enforces a global per-host connection limit across every chain.
+   - Credit-exhaustion and rate-limit responses are currently treated the same as general service unavailability.
 
 5. **PRO API Chain Alignment**:
 
@@ -869,6 +871,8 @@ This server exposes a tool for on-chain smart contract read-only state access. I
 #### read_contract
 
 - **RPC used**: `eth_call`.
+- **RPC transport**: `eth_call` is issued through the Blockscout PRO API JSON-RPC gateway at `https://api.blockscout.com/{chain_id}/json-rpc`, authenticated with the PRO API key as a `Bearer` token. The same key that enables address metadata enables contract reads across all supported chains.
+- **API key requirement**: A configured `BLOCKSCOUT_PRO_API_KEY` is required. Without it the tool fails fast with a clear error and makes no network call. Credit-exhaustion and rate-limit responses currently surface as general request failures.
 - **Implementation**: Uses Web3.py for ABI-based input encoding and output decoding. This leverages Web3's well-tested argument handling and return value decoding.
 - **ABI requirement**: Accepts the ABI of the specific function variant to call (a single ABI object for that function signature). This avoids ambiguity when contracts overload function names.
 - **Function name**: The `function_name` parameter must match the `name` field in the provided function ABI. Although redundant, it is kept intentionally to improve LLM tool-selection behavior and may be removed later.
@@ -898,3 +902,4 @@ This server exposes a tool for on-chain smart contract read-only state access. I
 - Write operations are not supported; `eth_call` does not change state.
 - No caller context (`from`) or gas simulation tuning is provided.
 - Multi-function ABI arrays are not accepted for `read_contract`; provide exactly the ABI item for the intended function signature.
+- Requires a Blockscout PRO API key (`BLOCKSCOUT_PRO_API_KEY`); contract reads are unavailable when it is not configured.

--- a/TESTING.md
+++ b/TESTING.md
@@ -78,6 +78,7 @@ The project also includes a suite of integration tests that verify live connecti
 - **Real Network Calls:** Unlike unit tests, these tests require an active internet connection.
 - **`@pytest.mark.integration`:** Each integration test is marked with a custom `pytest` marker, allowing them to be run separately from unit tests.
 - **Excluded by Default:** To keep the default test run fast and offline-friendly, integration tests are **excluded** by default (as configured in `pytest.ini`).
+- **PRO API key for some tests:** A subset of integration tests requires a Blockscout PRO API key. The `read_contract` integration tests issue `eth_call` through the PRO API JSON-RPC gateway, and the address-metadata test calls the PRO metadata endpoint; both are **skipped** (not failed) when `BLOCKSCOUT_PRO_API_KEY` is unset. A skip here means the key is missing in the environment, not that the test passed.
 
 ### Running Integration Tests
 

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.16.0.dev9"
+__version__ = "0.16.0.dev10"

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -98,6 +98,25 @@ async def ensure_pro_api_config() -> dict[str, str]:
             raise
 
 
+async def ensure_chain_supported(chain_id: str) -> None:
+    """Validate that a chain ID is supported by the Blockscout API.
+
+    Obtains the chain map via :func:`ensure_pro_api_config` (inheriting its
+    caching, stale-snapshot fallback, and refresh-cooldown behaviour) and
+    raises :class:`ChainNotFoundError` when the chain is absent.
+
+    Args:
+        chain_id: The chain identifier to validate.
+
+    Raises:
+        ChainNotFoundError: If the chain ID is not present in the supported
+            chain map returned by :func:`ensure_pro_api_config`.
+    """
+    chain_urls = await ensure_pro_api_config()
+    if chain_id not in chain_urls:
+        raise ChainNotFoundError(f"Chain ID '{chain_id}' is not supported by the Blockscout API.")
+
+
 async def get_blockscout_base_url(chain_id: str) -> str:
     current_time = time.monotonic()
     cached_entry = chain_cache.get(chain_id)

--- a/blockscout_mcp_server/web3_pool.py
+++ b/blockscout_mcp_server/web3_pool.py
@@ -19,6 +19,7 @@ appended automatically.
 
 from __future__ import annotations
 
+import asyncio
 from itertools import count
 from typing import Any
 
@@ -137,12 +138,12 @@ class AsyncHTTPProviderBlockscout(AsyncHTTPProvider):
 
 
 class Web3Pool:
-    """Manage pooled ``AsyncWeb3`` instances with shared sessions.
+    """Manage pooled ``AsyncWeb3`` instances with a single shared session.
 
     Each unique combination of chain and non-secret headers gets its own
-    ``AsyncWeb3`` instance backed by a shared ``aiohttp.ClientSession``.
-    Reusing these connections avoids the overhead of establishing new TCP
-    handshakes for every contract call.
+    ``AsyncWeb3`` instance.  All providers share one ``aiohttp.ClientSession``
+    so the per-host connection limit becomes a true global cap now that every
+    chain's JSON-RPC traffic targets the same host (``api.blockscout.com``).
 
     Auth headers (``Authorization``) are intentionally excluded from cache
     keys and resolved at request time on every call (including cache hits), so
@@ -151,7 +152,30 @@ class Web3Pool:
 
     def __init__(self) -> None:
         self._pool: dict[tuple[str, tuple[tuple[str, str], ...]], AsyncWeb3] = {}
-        self._sessions: dict[tuple[str, tuple[tuple[str, str], ...]], aiohttp.ClientSession] = {}
+        self._session: aiohttp.ClientSession | None = None
+        self._session_lock: asyncio.Lock = asyncio.Lock()
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Return the shared session, lazily creating it if necessary.
+
+        Uses a double-checked pattern under an ``asyncio.Lock`` so two
+        concurrent first-callers cannot create two separate sessions.
+        """
+        if self._session is not None and not self._session.closed:
+            return self._session
+        async with self._session_lock:
+            # Re-check inside the lock in case another coroutine created it
+            # while this one was waiting to acquire.
+            if self._session is None or self._session.closed:
+                self._session = aiohttp.ClientSession(
+                    # With a single host the global ``limit`` and the
+                    # per-host ``limit_per_host`` are the same cap.
+                    connector=aiohttp.TCPConnector(
+                        limit=config.rpc_pool_per_host,
+                        limit_per_host=config.rpc_pool_per_host,
+                    )
+                )
+        return self._session
 
     async def get(self, chain_id: str, headers: dict[str, str] | None = None) -> AsyncWeb3:
         # Fail fast when no PRO API key is configured — no network call should be
@@ -175,11 +199,14 @@ class Web3Pool:
         hdr_items = tuple(sorted(combined_headers.items()))
         key = (chain_id, hdr_items)
 
+        session = await self._get_session()
+
         if key in self._pool:
             w3 = self._pool[key]
             # Refresh auth headers on every call — including cache hits — so a
             # rotated key takes effect immediately without requiring a new provider.
             w3.provider.set_request_headers(_request_headers(hdr_items))
+            w3.provider.set_pooled_session(session)
             return w3
 
         endpoint = f"{config.pro_api_base_url}/{chain_id}/json-rpc"
@@ -191,19 +218,10 @@ class Web3Pool:
                 "timeout": config.rpc_request_timeout,
             },
         )
+        provider.set_pooled_session(session)
         w3 = AsyncWeb3(provider)
 
-        session = aiohttp.ClientSession(
-            # The connector speaks to a single host so ``limit`` matches ``limit_per_host``.
-            connector=aiohttp.TCPConnector(
-                limit=config.rpc_pool_per_host,
-                limit_per_host=config.rpc_pool_per_host,
-            )
-        )
-        provider.set_pooled_session(session)
-
         self._pool[key] = w3
-        self._sessions[key] = session
         return w3
 
     async def close(self) -> None:
@@ -212,14 +230,13 @@ class Web3Pool:
                 await w3.provider.disconnect()
             except Exception:
                 pass
-        for sess in list(self._sessions.values()):
-            if not sess.closed:
-                try:
-                    await sess.close()
-                except Exception:
-                    pass
+        if self._session is not None and not self._session.closed:
+            try:
+                await self._session.close()
+            except Exception:
+                pass
+        self._session = None
         self._pool.clear()
-        self._sessions.clear()
 
 
 WEB3_POOL = Web3Pool()

--- a/blockscout_mcp_server/web3_pool.py
+++ b/blockscout_mcp_server/web3_pool.py
@@ -28,11 +28,28 @@ from web3.providers.rpc import AsyncHTTPProvider
 
 from blockscout_mcp_server.config import config
 from blockscout_mcp_server.constants import SERVER_VERSION
-from blockscout_mcp_server.tools.common import get_blockscout_base_url
+from blockscout_mcp_server.tools.common import ensure_chain_supported
 
-DEFAULT_HEADERS = {
-    "User-Agent": f"{config.mcp_user_agent}/{SERVER_VERSION} (+pool)",
-}
+
+def _default_headers() -> dict[str, str]:
+    """Return the default User-Agent headers, read at call time."""
+    return {
+        "User-Agent": f"{config.mcp_user_agent}/{SERVER_VERSION} (+pool)",
+    }
+
+
+def _request_headers(hdr_items: tuple[tuple[str, str], ...]) -> dict[str, str]:
+    """Build full request headers from non-secret cache-key items.
+
+    Copies the non-secret header items and appends ``Authorization: Bearer
+    <key>`` only when ``config.pro_api_key`` is non-empty (never send a bare
+    ``Bearer``).  The ``Authorization`` header is therefore never stored in
+    cache keys; it is resolved at request time on every call.
+    """
+    headers = dict(hdr_items)
+    if config.pro_api_key:
+        headers["Authorization"] = f"Bearer {config.pro_api_key}"
+    return headers
 
 
 class AsyncHTTPProviderBlockscout(AsyncHTTPProvider):
@@ -48,6 +65,10 @@ class AsyncHTTPProviderBlockscout(AsyncHTTPProvider):
     sequential ID. The :meth:`set_pooled_session` method allows an externally
     managed ``aiohttp.ClientSession`` to be reused for all requests, enabling
     connection pooling and fine-grained timeout control.
+
+    The :meth:`set_request_headers` method replaces the provider's request
+    headers at runtime, enabling credential rotation without creating a new
+    provider instance.
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -59,6 +80,15 @@ class AsyncHTTPProviderBlockscout(AsyncHTTPProvider):
 
     def set_pooled_session(self, session: aiohttp.ClientSession) -> None:
         self.pooled_session = session
+
+    def set_request_headers(self, headers: dict[str, str]) -> None:
+        """Replace the provider's request headers.
+
+        Mirrors :meth:`set_pooled_session` as a hook for the pool to refresh
+        credentials at request time (including on cache hits) without creating
+        a new provider instance.
+        """
+        self._request_kwargs["headers"] = headers
 
     async def _make_http_request(self, session: aiohttp.ClientSession, rpc_dict: dict[str, Any]) -> dict[str, Any]:
         """Perform the HTTP request using the given session.
@@ -109,10 +139,14 @@ class AsyncHTTPProviderBlockscout(AsyncHTTPProvider):
 class Web3Pool:
     """Manage pooled ``AsyncWeb3`` instances with shared sessions.
 
-    Each unique combination of chain and headers gets its own ``AsyncWeb3``
-    instance backed by a shared ``aiohttp.ClientSession``. Reusing these
-    connections avoids the overhead of establishing new TCP handshakes for
-    every contract call.
+    Each unique combination of chain and non-secret headers gets its own
+    ``AsyncWeb3`` instance backed by a shared ``aiohttp.ClientSession``.
+    Reusing these connections avoids the overhead of establishing new TCP
+    handshakes for every contract call.
+
+    Auth headers (``Authorization``) are intentionally excluded from cache
+    keys and resolved at request time on every call (including cache hits), so
+    a rotated key takes effect immediately without creating a new provider.
     """
 
     def __init__(self) -> None:
@@ -120,21 +154,40 @@ class Web3Pool:
         self._sessions: dict[tuple[str, tuple[tuple[str, str], ...]], aiohttp.ClientSession] = {}
 
     async def get(self, chain_id: str, headers: dict[str, str] | None = None) -> AsyncWeb3:
-        combined_headers = dict(DEFAULT_HEADERS)
+        # Fail fast when no PRO API key is configured — no network call should be
+        # made when the gateway is guaranteed to reject the request.
+        if not config.pro_api_key:
+            raise ValueError(
+                "Blockscout PRO API key is not configured (set BLOCKSCOUT_PRO_API_KEY); "
+                "contract reads via the PRO API gateway are disabled."
+            )
+
+        # Validate the chain before constructing anything.
+        await ensure_chain_supported(chain_id)
+
+        # Build non-secret headers for the cache key.  Strip any caller-supplied
+        # Authorization so credentials never enter internal dictionaries.
+        combined_headers = _default_headers()
         if headers:
-            combined_headers.update(headers)
+            for k, v in headers.items():
+                if k.lower() != "authorization":
+                    combined_headers[k] = v
         hdr_items = tuple(sorted(combined_headers.items()))
         key = (chain_id, hdr_items)
-        if key in self._pool:
-            return self._pool[key]
 
-        base_url = await get_blockscout_base_url(chain_id)
-        endpoint = f"{base_url}/api/eth-rpc"
+        if key in self._pool:
+            w3 = self._pool[key]
+            # Refresh auth headers on every call — including cache hits — so a
+            # rotated key takes effect immediately without requiring a new provider.
+            w3.provider.set_request_headers(_request_headers(hdr_items))
+            return w3
+
+        endpoint = f"{config.pro_api_base_url}/{chain_id}/json-rpc"
 
         provider = AsyncHTTPProviderBlockscout(
             endpoint_uri=endpoint,
             request_kwargs={
-                "headers": dict(hdr_items),
+                "headers": _request_headers(hdr_items),
                 "timeout": config.rpc_request_timeout,
             },
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.16.0.dev9"
+version = "0.16.0.dev10"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.16.0.dev9",
+  "version": "0.16.0.dev10",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/integration/contract/test_read_contract_real.py
+++ b/tests/integration/contract/test_read_contract_real.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from eth_utils import to_checksum_address
 
+from blockscout_mcp_server.config import config
 from blockscout_mcp_server.models import ContractReadData, ToolResponse
 from blockscout_mcp_server.tools.contract.read_contract import read_contract
 from blockscout_mcp_server.web3_pool import WEB3_POOL
@@ -70,6 +71,7 @@ async def _invoke(mock_ctx, function_name: str, args: str) -> Any:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_integration(mock_ctx):
     address = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
     abi = {
@@ -100,6 +102,7 @@ async def test_read_contract_integration(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_decodes_tuple_result(mock_ctx):
     """Verify that tuple-based return values are decoded correctly."""
     address = "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6"
@@ -146,6 +149,7 @@ async def test_read_contract_decodes_tuple_result(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testInt(mock_ctx):
     # @see Web3PyTestContract.sol -> testInt()
     res = await _invoke(mock_ctx, "testInt", json.dumps([-42]))
@@ -154,6 +158,7 @@ async def test_read_contract_sepolia_testInt(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testUint(mock_ctx):
     # @see Web3PyTestContract.sol -> testUint()
     res = await _invoke(mock_ctx, "testUint", json.dumps([12345]))
@@ -163,6 +168,7 @@ async def test_read_contract_sepolia_testUint(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testAddress(mock_ctx):
     # @see Web3PyTestContract.sol -> testAddress()
     addr = "0x742d35cc6634c0532925a3b8d98d8e35ce02e52a"
@@ -172,6 +178,7 @@ async def test_read_contract_sepolia_testAddress(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testBytes(mock_ctx):
     # @see Web3PyTestContract.sol -> testBytes()
     data = "0x64617461"
@@ -186,6 +193,7 @@ async def test_read_contract_sepolia_testBytes(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testBool(mock_ctx):
     # @see Web3PyTestContract.sol -> testBool()
     res = await _invoke(mock_ctx, "testBool", json.dumps([True]))
@@ -194,6 +202,7 @@ async def test_read_contract_sepolia_testBool(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testUintArray(mock_ctx):
     # @see Web3PyTestContract.sol -> testUintArray()
     res = await _invoke(mock_ctx, "testUintArray", json.dumps([[1, 2, 3, 4, 5]]))
@@ -204,6 +213,7 @@ async def test_read_contract_sepolia_testUintArray(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testAddressArray(mock_ctx):
     # @see Web3PyTestContract.sol -> testAddressArray()
     addr1 = "0x742d35cc6634c0532925a3b8d98d8e35ce02e52a"
@@ -214,6 +224,7 @@ async def test_read_contract_sepolia_testAddressArray(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testBytesArray(mock_ctx):
     # @see Web3PyTestContract.sol -> testBytesArray()
     data1 = "0x64617461"
@@ -224,6 +235,7 @@ async def test_read_contract_sepolia_testBytesArray(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testSimpleStruct(mock_ctx):
     # @see Web3PyTestContract.sol -> testSimpleStruct()
     res = await _invoke(
@@ -239,6 +251,7 @@ async def test_read_contract_sepolia_testSimpleStruct(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testNestedStruct(mock_ctx):
     # @see Web3PyTestContract.sol -> testNestedStruct()
     addr1 = "0x742d35cc6634c0532925a3b8d98d8e35ce02e52a"
@@ -256,6 +269,7 @@ async def test_read_contract_sepolia_testNestedStruct(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testStructArray(mock_ctx):
     # @see Web3PyTestContract.sol -> testStructArray()
     res = await _invoke(
@@ -269,6 +283,7 @@ async def test_read_contract_sepolia_testStructArray(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testArrayStruct(mock_ctx):
     # @see Web3PyTestContract.sol -> testArrayStruct()
     addr1 = "0x742d35cc6634c0532925a3b8d98d8e35ce02e52a"
@@ -288,6 +303,7 @@ async def test_read_contract_sepolia_testArrayStruct(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testMultipleParams(mock_ctx):
     # @see Web3PyTestContract.sol -> testMultipleParams()
     addr = "0x8ba1f109551bd432803012645ff1c26ad3dbebf9"
@@ -301,6 +317,7 @@ async def test_read_contract_sepolia_testMultipleParams(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testFixedArray(mock_ctx):
     # @see Web3PyTestContract.sol -> testFixedArray()
     res = await _invoke(mock_ctx, "testFixedArray", json.dumps([[10, 20, 30]]))
@@ -311,6 +328,7 @@ async def test_read_contract_sepolia_testFixedArray(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testBytes32(mock_ctx):
     # @see Web3PyTestContract.sol -> testBytes32()
     value = "0x" + "1234567890abcdef" * 4
@@ -324,6 +342,7 @@ async def test_read_contract_sepolia_testBytes32(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testString(mock_ctx):
     # @see Web3PyTestContract.sol -> testString()
     res = await _invoke(mock_ctx, "testString", json.dumps(["World"]))
@@ -333,6 +352,7 @@ async def test_read_contract_sepolia_testString(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
 async def test_read_contract_sepolia_testEnum(mock_ctx):
     # @see Web3PyTestContract.sol -> testEnum()
     res = await _invoke(mock_ctx, "testEnum", json.dumps([0]))

--- a/tests/integration/test_common_helpers.py
+++ b/tests/integration/test_common_helpers.py
@@ -8,6 +8,7 @@ import pytest
 from blockscout_mcp_server.config import config
 from blockscout_mcp_server.tools.common import (
     ChainNotFoundError,
+    ensure_chain_supported,
     get_blockscout_base_url,
     make_bens_request,
     make_blockscout_request,
@@ -204,3 +205,27 @@ async def test_get_blockscout_base_url_for_pro_api_only_chain():
 async def test_get_blockscout_base_url_for_chainscout_only_chain():
     with pytest.raises(ChainNotFoundError):
         await get_blockscout_base_url("17000")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ensure_chain_supported_for_known_chain():
+    """
+    Confirms that ensure_chain_supported does not raise for a well-known chain.
+    """
+
+    async def run_check():
+        await ensure_chain_supported("1")
+
+    await retry_on_network_error(run_check, action_description="ensure_chain_supported known chain")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ensure_chain_supported_for_bogus_chain():
+    """
+    Confirms that ensure_chain_supported raises ChainNotFoundError for an
+    obviously-unsupported chain id.
+    """
+    with pytest.raises(ChainNotFoundError):
+        await ensure_chain_supported("99999999")

--- a/tests/test_web3_pool.py
+++ b/tests/test_web3_pool.py
@@ -259,3 +259,100 @@ async def test_ensure_chain_supported_is_awaited_with_chain_id():
         await pool.get("42161")
 
     mock_ensure.assert_awaited_once_with("42161")
+
+
+@pytest.mark.asyncio
+async def test_different_chains_share_one_session():
+    """Two get() calls for different chain ids create ClientSession exactly once."""
+    pool = Web3Pool()
+    mock_session = MagicMock()
+    mock_session.closed = False
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "blockscout_mcp_server.web3_pool.aiohttp.ClientSession",
+            return_value=mock_session,
+        ) as mock_session_cls,
+        patch.object(config, "pro_api_key", "test-key"),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        w3_chain1 = await pool.get("1")
+        w3_chain2 = await pool.get("137")
+
+    # ClientSession must be constructed exactly once across both calls
+    mock_session_cls.assert_called_once()
+    # But the two chains produce distinct provider instances
+    assert w3_chain1 is not w3_chain2
+    assert w3_chain1.provider.endpoint_uri == "https://api.blockscout.com/1/json-rpc"
+    assert w3_chain2.provider.endpoint_uri == "https://api.blockscout.com/137/json-rpc"
+
+
+@pytest.mark.asyncio
+async def test_same_chain_returns_same_provider():
+    """get() for the same chain id twice returns the same provider instance."""
+    pool = Web3Pool()
+    mock_session = MagicMock()
+    mock_session.closed = False
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "blockscout_mcp_server.web3_pool.aiohttp.ClientSession",
+            return_value=mock_session,
+        ),
+        patch.object(config, "pro_api_key", "test-key"),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        w3_first = await pool.get("1")
+        w3_second = await pool.get("1")
+
+    assert w3_first is w3_second
+
+
+@pytest.mark.asyncio
+async def test_close_clears_session_and_new_get_creates_fresh_session():
+    """close() closes the shared session; a subsequent get() lazily creates a new one."""
+    pool = Web3Pool()
+
+    first_session = MagicMock()
+    first_session.closed = False
+    first_session.close = AsyncMock()
+
+    second_session = MagicMock()
+    second_session.closed = False
+    second_session.close = AsyncMock()
+
+    session_side_effects = [first_session, second_session]
+
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "blockscout_mcp_server.web3_pool.aiohttp.ClientSession",
+            side_effect=session_side_effects,
+        ) as mock_session_cls,
+        patch.object(config, "pro_api_key", "test-key"),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        await pool.get("1")
+
+        # Simulate close
+        await pool.close()
+
+        # After close, session field must be reset and pool cleared
+        assert pool._session is None
+        assert len(pool._pool) == 0
+        first_session.close.assert_awaited_once()
+
+        # A subsequent get() must create a brand-new session
+        await pool.get("1")
+
+    assert mock_session_cls.call_count == 2
+    assert pool._session is second_session

--- a/tests/test_web3_pool.py
+++ b/tests/test_web3_pool.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
+from blockscout_mcp_server.config import config
 from blockscout_mcp_server.web3_pool import (
     AsyncHTTPProviderBlockscout,
     Web3Pool,
@@ -17,18 +18,20 @@ async def test_web3_pool_reuses_instances():
     mock_session.closed = False
     with (
         patch(
-            "blockscout_mcp_server.web3_pool.get_blockscout_base_url",
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
             new_callable=AsyncMock,
-            return_value="https://example.org",
-        ) as mock_get_url,
+        ) as mock_ensure,
         patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", return_value=mock_session) as mock_session_cls,
+        patch.object(config, "pro_api_key", "test-key"),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
     ):
         w3_first = await pool.get("1")
         w3_second = await pool.get("1")
     assert w3_first is w3_second
-    mock_get_url.assert_called_once_with("1")
+    mock_ensure.assert_called_with("1")
+    assert mock_ensure.call_count == 2
     mock_session_cls.assert_called_once()
-    assert w3_first.provider.endpoint_uri == "https://example.org/api/eth-rpc"
+    assert w3_first.provider.endpoint_uri == "https://api.blockscout.com/1/json-rpc"
 
 
 @pytest.mark.asyncio
@@ -55,14 +58,14 @@ async def test_get_merges_default_headers():
     mock_session.closed = False
     with (
         patch(
-            "blockscout_mcp_server.web3_pool.get_blockscout_base_url",
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
             new_callable=AsyncMock,
-            return_value="https://example.org",
         ),
         patch(
             "blockscout_mcp_server.web3_pool.aiohttp.ClientSession",
             return_value=mock_session,
         ),
+        patch.object(config, "pro_api_key", "test-key"),
     ):
         w3 = await pool.get("1", headers={"X-Test": "abc"})
     hdrs = w3.provider._request_kwargs["headers"]
@@ -95,3 +98,164 @@ async def test_make_http_request_uses_headers_and_timeout():
     timeout = kwargs["timeout"]
     assert isinstance(timeout, aiohttp.ClientTimeout)
     assert timeout.total == 10
+
+
+@pytest.mark.asyncio
+async def test_auth_header_in_request_headers_not_in_cache_key():
+    """Provider request headers contain Authorization; pool cache key does not."""
+    pool = Web3Pool()
+    mock_session = MagicMock()
+    mock_session.closed = False
+    api_key = "my-secret-key"
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ),
+        patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", return_value=mock_session),
+        patch.object(config, "pro_api_key", api_key),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        w3 = await pool.get("1")
+
+    # Provider request headers must include Authorization
+    hdrs = w3.provider._request_kwargs["headers"]
+    assert hdrs.get("Authorization") == f"Bearer {api_key}"
+
+    # No cache key in the pool should contain the Authorization value
+    for key in pool._pool:
+        _chain_id, hdr_items = key
+        for hdr_name, hdr_val in hdr_items:
+            assert hdr_name.lower() != "authorization", "Authorization found in cache key name"
+            assert api_key not in hdr_val, "API key found in cache key value"
+
+
+@pytest.mark.asyncio
+async def test_key_rotation_refreshes_auth_on_cache_hit():
+    """Key rotation takes effect on the next call even when the provider is cached."""
+    pool = Web3Pool()
+    mock_session = MagicMock()
+    mock_session.closed = False
+    first_key = "first-token"
+    second_key = "second-token"
+
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ),
+        patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", return_value=mock_session),
+        patch.object(config, "pro_api_key", first_key),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        w3_first = await pool.get("1")
+
+    # Rotate the key and call get() again for the same chain
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ),
+        patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", return_value=mock_session),
+        patch.object(config, "pro_api_key", second_key),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        w3_second = await pool.get("1")
+
+    # Same provider instance (cache hit)
+    assert w3_first is w3_second
+
+    # Auth header must reflect the second (rotated) key
+    hdrs = w3_second.provider._request_kwargs["headers"]
+    assert hdrs.get("Authorization") == f"Bearer {second_key}"
+    assert f"Bearer {first_key}" not in hdrs.get("Authorization", "")
+
+    # Cache key must not contain either token
+    for key in pool._pool:
+        _chain_id, hdr_items = key
+        for hdr_name, hdr_val in hdr_items:
+            assert hdr_name.lower() != "authorization"
+            assert first_key not in hdr_val
+            assert second_key not in hdr_val
+
+
+@pytest.mark.asyncio
+async def test_caller_authorization_is_sanitized():
+    """Caller-supplied Authorization is replaced by config key; X-Test is preserved."""
+    pool = Web3Pool()
+    mock_session = MagicMock()
+    mock_session.closed = False
+    config_key = "config-api-key"
+    caller_token = "caller-secret"
+
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ),
+        patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", return_value=mock_session),
+        patch.object(config, "pro_api_key", config_key),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        w3 = await pool.get("1", headers={"Authorization": f"Bearer {caller_token}", "X-Test": "abc"})
+
+    # No cache key should contain the caller's token or an Authorization entry
+    for key in pool._pool:
+        _chain_id, hdr_items = key
+        for hdr_name, hdr_val in hdr_items:
+            assert hdr_name.lower() != "authorization", "Authorization found in cache key"
+            assert caller_token not in hdr_val, "Caller token found in cache key value"
+
+    # Provider request headers must carry the config key, not the caller token
+    hdrs = w3.provider._request_kwargs["headers"]
+    assert hdrs.get("Authorization") == f"Bearer {config_key}"
+    assert caller_token not in hdrs.get("Authorization", "")
+
+    # Custom X-Test header must be preserved in both cache key and request headers
+    assert hdrs.get("X-Test") == "abc"
+    found_x_test_in_key = False
+    for key in pool._pool:
+        _chain_id, hdr_items = key
+        for hdr_name, hdr_val in hdr_items:
+            if hdr_name == "X-Test" and hdr_val == "abc":
+                found_x_test_in_key = True
+    assert found_x_test_in_key, "X-Test header not found in cache key"
+
+
+@pytest.mark.asyncio
+async def test_no_key_raises_value_error():
+    """get() raises ValueError immediately when no PRO API key is configured."""
+    pool = Web3Pool()
+    ensure_mock = AsyncMock()
+    session_cls_mock = MagicMock()
+
+    with (
+        patch("blockscout_mcp_server.web3_pool.ensure_chain_supported", ensure_mock),
+        patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", session_cls_mock),
+        patch.object(config, "pro_api_key", ""),
+    ):
+        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+            await pool.get("1")
+
+    ensure_mock.assert_not_called()
+    session_cls_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_chain_supported_is_awaited_with_chain_id():
+    """ensure_chain_supported is called with the requested chain_id."""
+    pool = Web3Pool()
+    mock_session = MagicMock()
+    mock_session.closed = False
+    with (
+        patch(
+            "blockscout_mcp_server.web3_pool.ensure_chain_supported",
+            new_callable=AsyncMock,
+        ) as mock_ensure,
+        patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", return_value=mock_session),
+        patch.object(config, "pro_api_key", "some-key"),
+        patch.object(config, "pro_api_base_url", "https://api.blockscout.com"),
+    ):
+        await pool.get("42161")
+
+    mock_ensure.assert_awaited_once_with("42161")

--- a/tests/tools/contract/test_read_contract.py
+++ b/tests/tools/contract/test_read_contract.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from web3.exceptions import ContractLogicError
 
+from blockscout_mcp_server.config import config
 from blockscout_mcp_server.tools.common import ChainNotFoundError
 from blockscout_mcp_server.tools.contract.read_contract import read_contract
 
@@ -74,6 +75,31 @@ async def test_read_contract_chain_not_found(mock_ctx):
     mock_get.assert_called_once_with(chain_id)
     assert mock_ctx.report_progress.await_count == 1
     assert mock_ctx.info.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_read_contract_missing_pro_api_key_propagates_value_error(mock_ctx):
+    """Without a PRO API key, the real pool's ValueError must surface unchanged.
+
+    Unlike the other tests, this one does NOT mock ``WEB3_POOL.get`` — it drives
+    the real pool with an empty key so the tool's wiring (the ``WEB3_POOL.get``
+    call sits outside any try/except) is exercised end to end. This locks in the
+    user-facing contract: the clear "set BLOCKSCOUT_PRO_API_KEY" message is not
+    swallowed or rewrapped into a generic error.
+    """
+    abi = {"name": "foo", "type": "function", "inputs": [], "outputs": []}
+    with patch.object(config, "pro_api_key", ""):
+        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+            await read_contract(
+                chain_id="1",
+                address="0x0000000000000000000000000000000000000abc",
+                abi=abi,
+                function_name="foo",
+                ctx=mock_ctx,
+            )
+    # The fail-fast raise happens after the initial progress report but before
+    # any network/session work.
+    assert mock_ctx.report_progress.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_chain_support.py
+++ b/tests/tools/test_chain_support.py
@@ -5,7 +5,7 @@ import pytest
 
 from blockscout_mcp_server.tools.common import ChainNotFoundError, ensure_chain_supported
 
-pytestmark = pytest.mark.anyio
+pytestmark = pytest.mark.asyncio
 
 
 async def test_ensure_chain_supported_supported_chain():

--- a/tests/tools/test_chain_support.py
+++ b/tests/tools/test_chain_support.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from blockscout_mcp_server.tools.common import ChainNotFoundError, ensure_chain_supported
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_ensure_chain_supported_supported_chain():
+    """Supported chain: call completes without raising."""
+    with patch(
+        "blockscout_mcp_server.tools.common.ensure_pro_api_config",
+        AsyncMock(return_value={"1": "https://eth.blockscout.com"}),
+    ):
+        # Should not raise
+        await ensure_chain_supported("1")
+
+
+async def test_ensure_chain_supported_unsupported_chain():
+    """Unsupported chain: raises ChainNotFoundError with correct message."""
+    with patch(
+        "blockscout_mcp_server.tools.common.ensure_pro_api_config",
+        AsyncMock(return_value={"1": "https://eth.blockscout.com"}),
+    ):
+        with pytest.raises(ChainNotFoundError, match="Chain ID '99999' is not supported by the Blockscout API."):
+            await ensure_chain_supported("99999")
+
+
+async def test_ensure_chain_supported_delegates_to_ensure_pro_api_config():
+    """The helper relies on ensure_pro_api_config (it must be awaited)."""
+    mock_ensure = AsyncMock(return_value={"1": "https://eth.blockscout.com"})
+    with patch(
+        "blockscout_mcp_server.tools.common.ensure_pro_api_config",
+        mock_ensure,
+    ):
+        await ensure_chain_supported("1")
+        mock_ensure.assert_awaited_once()


### PR DESCRIPTION
Closes #378.

### Motivation

- Read-only contract calls (`read_contract` / `eth_call`) previously went to each chain's public, unauthenticated Blockscout RPC endpoint over a separate per-instance path, while address metadata already used the authenticated Blockscout PRO API. This change converges contract-state reads onto the same single, key-authenticated PRO API JSON-RPC gateway used elsewhere.
- A single authenticated surface spans all supported chains, applies one uniform Bearer-token scheme, and benefits from the gateway's credit accounting and rate limiting — aligning contract reads with the broader migration of the server's tools onto the PRO API.
- Because all RPC traffic now targets one gateway host, the connection pool's per-chain session model no longer matches reality and is simplified accordingly.

### Description

- **Phase 1 — Chain-support validation helper**: Added `ensure_chain_supported(chain_id)` to `tools/common.py`, decoupling chain-validity checks from instance-URL resolution. It reuses the cached PRO config (`ensure_pro_api_config`) and raises `ChainNotFoundError` for unsupported chains — a reusable building block for the rest of the PRO API migration. `get_blockscout_base_url` is left untouched.
- **Phase 2 — Route the pool through the PRO API gateway with auth**: `Web3Pool.get()` now builds the endpoint as `<pro_api_base_url>/<chain_id>/json-rpc`, validates the chain via `ensure_chain_supported`, and fails fast with a clear `ValueError` naming `BLOCKSCOUT_PRO_API_KEY` when no key is configured. `Authorization: Bearer <key>` is attached per request via `set_request_headers` on both cache-hit and cache-miss paths, so rotated credentials take effect immediately; any caller-supplied `Authorization` is stripped before the cache key is computed. Secrets never enter cache keys and credential-derived values are resolved at request time rather than frozen at startup.
- **Phase 3 — Collapse the pool onto a single shared session**: Replaced the per-chain `aiohttp.ClientSession` dict with a single, lazily-created shared session (double-checked `asyncio.Lock`, `TCPConnector(limit=…, limit_per_host=…)`) shared across all chains, since traffic now converges on one host. `close()` closes that single session and clears the provider pool.
- **Phase 4 — Integration tests**: Gated all live `read_contract` tests with `@pytest.mark.skipif(not config.pro_api_key, …)` so keyless environments skip cleanly, and added `ensure_chain_supported` integration tests (known chain succeeds; bogus chain raises `ChainNotFoundError`).
- **Phase 5 — Documentation updates**: Updated `SPEC.md` (Async Web3 Connection Pool section + `read_contract` RPC-transport / key-requirement bullets), `README.md` (PRO API key now powers two features), `TESTING.md`, and `.env.example`; added one `AGENTS.md` index line for the new test module. Consumer-facing interface docs (`API.md`, `gpt/*`, `llms.txt`) are intentionally untouched — tool signatures and return models are unchanged.
- **Phase 6 — Version bump**: Bumped to `0.16.0.dev10` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`; `mcpb/manifest.json` left unchanged.

### Testing

- Added unit tests: `tests/tools/test_chain_support.py` for `ensure_chain_supported` (supported / unsupported-raises / delegates to `ensure_pro_api_config`), and expanded `tests/test_web3_pool.py` covering auth-header-not-in-cache-key, key rotation refreshing auth on a cache hit, caller `Authorization` sanitization, no-key `ValueError`, a single shared session across chains, and session recreation after `close()`.
- Full default unit suite: **610 passed, 93 deselected**.
- Full integration suite via the timeout-protected runner (`scripts/run_integration_tests.py tests/integration/`): **93 passed, 0 failed, 0 skipped, 0 timed out** (a PRO API key was present, so the `read_contract` skip-gate did not fire).
- `ruff check .` and `ruff format --check .`: both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Blockscout PRO API key requirements: now required for contract reads with fail-fast behavior when missing; powers both address metadata enrichment and contract read operations.

* **Documentation**
  * Clarified PRO API key purposes and authentication behavior across configuration guides and specifications.
  * Added guidance on skipped integration tests requiring PRO API configuration.

* **Tests**
  * Added integration test coverage for chain validation.
  * Gated PRO-dependent tests to skip when API key is unconfigured.

* **Chores**
  * Bumped version to `0.16.0.dev10`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->