### PR TITLE
chore: bootstrap worktree via SessionStart hook

### DIFF
--- a/.claude/hooks/bootstrap-worktree.sh
+++ b/.claude/hooks/bootstrap-worktree.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SessionStart hook: bootstrap the Python environment for a git WORKTREE.
+#
+# A freshly created git worktree does not inherit a usable environment, all by
+# design:
+#   * .venv/  and  uv.lock  are gitignored, so they never propagate.
+#   * agent-skills/ is a git submodule, left uninitialized in a new worktree.
+# The Hatch build hook (hatch_build.py) bundles agent-skills/blockscout-analysis
+# into the wheel at build time, so the editable install — and therefore every
+# `uv run pytest|ruff|python` — FAILS with "Bundled skill entrypoint not found"
+# until the submodule is checked out.
+#
+# This hook performs that one-time setup automatically. It is deliberately
+# scoped to LINKED worktrees only (never the main working tree, which the
+# developer sets up normally) and is a fast, silent no-op once the worktree is
+# ready, so it is safe to run on every session start.
+#
+# No `set -e`: a bootstrap failure must not hard-block session startup. Problems
+# are detected explicitly and reported as context so the agent knows what to do.
+
+# --- Host-only. Inside the devcontainer dependencies are system-wide. --------
+[ -f /.dockerenv ] && exit 0
+
+command -v git >/dev/null 2>&1 || exit 0
+command -v uv  >/dev/null 2>&1 || exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$ROOT" || exit 0
+
+# --- Act only in a LINKED worktree, never the main working tree. -------------
+# In the main tree --git-common-dir and --git-dir resolve to the same path; in a
+# linked worktree --git-dir points at .git/worktrees/<name> while the common dir
+# stays at the main .git.
+common_abs="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)"
+git_abs="$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)"
+[ -n "$common_abs" ] && [ "$common_abs" = "$git_abs" ] && exit 0
+
+# --- Share the developer's local, gitignored files from the main worktree. ---
+# .env (secrets/config) and .claude/settings.local.json (local permissions) are
+# gitignored, so they don't propagate into a worktree. Symlink them to the main
+# checkout so every worktree shares one source of truth. Claude Code seeds a
+# *copy* of settings.local.json into each worktree at creation; replacing that
+# identical copy with a symlink is safe. A copy that has DIVERGED from main is
+# left untouched rather than clobbered, to avoid silent data loss.
+MAIN_ROOT="$(dirname "$common_abs")"
+if [ -d "$MAIN_ROOT" ] && [ "$MAIN_ROOT" != "$ROOT" ]; then
+    link_shared() {
+        local rel="$1" src="$MAIN_ROOT/$1"
+        [ -e "$src" ] || return 0                                   # main has nothing to share
+        [ -L "$rel" ] && [ "$(readlink "$rel")" = "$src" ] && return 0   # already linked → silent
+        if [ -f "$rel" ] && [ ! -L "$rel" ] && ! cmp -s "$rel" "$src"; then
+            echo "[worktree-bootstrap] Note: $rel differs from the main worktree's copy — left as-is (not symlinked)."
+            return 0
+        fi
+        mkdir -p "$(dirname "$rel")"
+        ln -snf "$src" "$rel" && echo "[worktree-bootstrap] Linked $rel from the main worktree."
+    }
+    link_shared .env
+    link_shared .claude/settings.local.json
+fi
+
+# --- Already bootstrapped? Fast, silent no-op. -------------------------------
+if [ -f agent-skills/blockscout-analysis/SKILL.md ] \
+    && [ -x .venv/bin/pytest ] && [ -x .venv/bin/ruff ] \
+    && .venv/bin/python -c "import blockscout_mcp_server" >/dev/null 2>&1; then
+    exit 0
+fi
+
+# --- Bootstrap. --------------------------------------------------------------
+echo "[worktree-bootstrap] Setting up this worktree's Python environment…"
+
+if [ ! -f agent-skills/blockscout-analysis/SKILL.md ]; then
+    if ! sub_out="$(git submodule update --init --recursive agent-skills 2>&1)"; then
+        echo "[worktree-bootstrap] WARNING: could not initialize the agent-skills submodule (network?):"
+        echo "$sub_out" | tail -n 3
+        echo "[worktree-bootstrap] Re-run '.claude/hooks/bootstrap-worktree.sh' once connectivity is restored."
+        exit 0
+    fi
+fi
+
+[ -x .venv/bin/python ] || uv venv >/dev/null 2>&1
+
+# [test] brings pytest + pytest-asyncio + pytest-cov + pytest-timeout;
+# [dev] brings ruff + PyYAML. -q keeps the package list out of session context.
+if ! install_out="$(uv pip install -q --python .venv -e ".[test,dev]" 2>&1)"; then
+    echo "[worktree-bootstrap] WARNING: editable install failed:"
+    echo "$install_out" | tail -n 5
+    echo "[worktree-bootstrap] Re-run '.claude/hooks/bootstrap-worktree.sh' to retry."
+    exit 0
+fi
+
+if .venv/bin/python -c "import blockscout_mcp_server" >/dev/null 2>&1; then
+    echo "[worktree-bootstrap] Done: worktree-local .venv ready ($(.venv/bin/pytest --version 2>&1 | head -n1), $(.venv/bin/ruff --version 2>&1)). Run tools with 'uv run <tool>' or '.venv/bin/<tool>'."
+else
+    echo "[worktree-bootstrap] WARNING: project still not importable after install. Re-run '.claude/hooks/bootstrap-worktree.sh'."
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,12 @@
         "hooks": [
           {
             "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}\"/.claude/hooks/bootstrap-worktree.sh",
+            "timeout": 300,
+            "statusMessage": "Bootstrapping worktree Python environment…"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/append_context.sh"
           }
         ]


### PR DESCRIPTION
## What

Adds a `SessionStart` hook that automatically bootstraps the Python environment when a session starts in a **git worktree** (not the main checkout).

- **New:** `.claude/hooks/bootstrap-worktree.sh`
- **Changed:** `.claude/settings.json` — wires the hook into `SessionStart` (matcher `startup|clear`), alongside the existing `append_context.sh`, with `timeout: 300`.

## Why

A freshly created worktree has no usable environment, all by design:

- `.venv/` and `uv.lock` are **gitignored**, so they never propagate from the main checkout.
- `agent-skills/` is a **git submodule**, left uninitialized in a new worktree.

The submodule is the real trap: the Hatch build hook (`hatch_build.py`) bundles `agent-skills/blockscout-analysis` into the wheel **at build time**, so the editable install — and therefore every `uv run pytest|ruff|python` — fails with `Bundled skill entrypoint not found` until the submodule is checked out. The result is a worktree that looks broken in a confusing way.

Previously each new worktree had to be bootstrapped by hand. A hook is the right tool because the work is purely mechanical and deterministic — no model judgment needed — so it should run reliably and automatically rather than depend on an agent remembering to do it.

## What the hook does

1. **Devcontainer guard** — `/.dockerenv` present → exit (deps are system-wide there).
2. **Linked-worktree guard** — runs only in a linked worktree; no-op in the main working tree.
3. **Share local files** — symlinks the developer's gitignored `.env` and `.claude/settings.local.json` from the main worktree so every worktree shares one source of truth. A local copy that has **diverged** from main is left untouched (no silent data loss).
4. **Already-bootstrapped check** — fast, silent no-op when the submodule, `.venv`, and tools are all present.
5. **Bootstrap** — initialize the submodule → `uv venv` → `uv pip install -q --python .venv -e ".[test,dev]"` → verify. Failures are reported as context rather than hard-blocking session startup.

## Notes for reviewers

- Verified end-to-end against throwaway worktrees: fresh bootstrap, idempotent re-run (silent), main-vs-linked detection, and all three symlink cases (absent → linked, identical copy → relinked, diverged copy → left untouched).
- **Implication of the `settings.local.json` symlink:** once linked, local permission grants written during a worktree session land in the main worktree's file and become shared across all worktrees. This is the intended "single source of truth" behavior.
- Takes effect on the **next** session start (settings are read at startup); both the hook script and the `settings.json` change must be on the base branch for future worktrees to pick it up.
- The hook deliberately keeps output minimal (`-q` install) so the package list doesn't flood session context.


@coderabbitai ignore