### PR TITLE
Trim client-facing PRO API key not-configured error

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ set the `BLOCKSCOUT_MCP_USER_AGENT` environment variable (defaults to
 
 ### Blockscout PRO API Key
 
-The Blockscout PRO API key is required for Blockscout data access. Every data tool routes its requests through the authenticated Blockscout PRO API gateway, so without a key those tools fail fast with a clear, actionable error and make no network call.
+The Blockscout PRO API key is required for Blockscout data access. Every data tool routes its requests through the authenticated Blockscout PRO API gateway, so without an effective key those tools fail fast before making any upstream request.
 
 Set the key to enable all data access, public-tag enrichment, and contract reads.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -228,6 +228,8 @@ The key requirement is enforced as a single chokepoint: each PRO API entry point
 
 A malformed client key raises a distinct terminal error (no fallback); only the genuine absence of both a client key and a server key raises the not-configured error.
 
+When no server-side PRO API key is configured, the server logs a startup diagnostic naming `BLOCKSCOUT_PRO_API_KEY` for operators. Client-facing per-request errors report only that the requested feature is unavailable without authorization; they intentionally omit server-side remediation.
+
 **What does not require the key**
 
 - Chain discovery and validation read the PRO API *config* endpoint (`/api/json/config`) without authentication, so `get_chains_list` and chain-support checks work regardless of the key. Only *data access* is gated.

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.16.0.dev18"
+__version__ = "0.16.0.dev19"

--- a/blockscout_mcp_server/pro_api_key_context.py
+++ b/blockscout_mcp_server/pro_api_key_context.py
@@ -272,18 +272,22 @@ def require_pro_api_key(disabled_feature: str) -> str:
 
     Propagates ``ValueError`` from :func:`resolve_pro_api_key` for a malformed
     client key.  When both the client key and the server key are absent, raises
-    a ``ValueError`` whose message names ``BLOCKSCOUT_PRO_API_KEY`` and — when
-    client-supplied keys are enabled — the configured request header.  Callers
-    pass a short ``disabled_feature`` label ("data access", "address metadata",
-    "contract reads via the PRO API gateway") so the caller's context survives
-    without each call site duplicating the full sentence.
+    a ``ValueError`` with the minimal client-facing message:
+    ``PRO API key required for {disabled_feature}; not configured.``
+
+    The message intentionally names only the gated feature and contains no
+    operator-remediation instructions (no environment-variable name, no
+    "set … on the server", no request-header name).  Operator remediation lives
+    in the startup log and the documentation — not in the string returned to MCP
+    clients (LLM agents), who cannot act on server-side configuration advice.
+
+    Callers pass a short ``disabled_feature`` label ("data access", "address
+    metadata", "contract reads via the PRO API gateway") so the caller's context
+    survives without each call site duplicating the full sentence.
     """
     key = resolve_pro_api_key()
     if not key:
-        hint = "set BLOCKSCOUT_PRO_API_KEY"
-        if config.pro_api_key_header:
-            hint = f"set BLOCKSCOUT_PRO_API_KEY on the server, or send the {config.pro_api_key_header} request header"
-        raise ValueError(f"Blockscout PRO API key is not configured ({hint}); {disabled_feature} is disabled.")
+        raise ValueError(f"PRO API key required for {disabled_feature}; not configured.")
     return key
 
 

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -302,12 +302,14 @@ def main_command(
     Use --http to enable HTTP Streamable mode.
     Use --http and --rest to enable the REST API.
     """
+    # Normalize transport setting once; reused by the guard below and HTTP-mode detection.
+    mcp_transport = (config.mcp_transport or "stdio").lower()
+
     # Reject --rest without --http early, before any startup work (including the diagnostic).
-    if rest and not http and (config.mcp_transport or "stdio").lower() != "http":
+    if rest and not http and mcp_transport != "http":
         raise typer.BadParameter("The --rest flag can only be used with the --http flag.")
 
-    # Normalize transport setting and detect whether env var triggered HTTP mode.
-    mcp_transport = (config.mcp_transport or "stdio").lower()
+    # Detect whether the env var (not the CLI flag) triggered HTTP mode.
     env_triggered = not http and mcp_transport == "http"
 
     # Determine if we should run in HTTP mode based on CLI flag or environment variable.

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 import json
+import logging
 from functools import wraps
 from pathlib import Path
 from typing import Annotated
@@ -48,6 +49,17 @@ from blockscout_mcp_server.tools.transaction.get_transactions_by_address import 
     get_transactions_by_address,
 )
 from blockscout_mcp_server.web3_pool import WEB3_POOL
+
+logger = logging.getLogger(__name__)
+
+
+def _log_pro_api_key_status() -> None:
+    """Log the server-side PRO API key configuration state at startup."""
+    if config.pro_api_key:
+        logger.info("BLOCKSCOUT_PRO_API_KEY is configured; server-side PRO API key is available.")
+    else:
+        logger.info("BLOCKSCOUT_PRO_API_KEY is not configured; no server-side PRO API key is available.")
+
 
 # Compose the instructions string for the MCP server constructor
 
@@ -290,6 +302,10 @@ def main_command(
     Use --http to enable HTTP Streamable mode.
     Use --http and --rest to enable the REST API.
     """
+    # Reject --rest without --http early, before any startup work (including the diagnostic).
+    if rest and not http and (config.mcp_transport or "stdio").lower() != "http":
+        raise typer.BadParameter("The --rest flag can only be used with the --http flag.")
+
     # Normalize transport setting and detect whether env var triggered HTTP mode.
     mcp_transport = (config.mcp_transport or "stdio").lower()
     env_triggered = not http and mcp_transport == "http"
@@ -315,6 +331,9 @@ def main_command(
         final_http_port = config.port
 
     mcp.settings.transport_security = _resolve_transport_security(final_http_host)
+
+    # Emit a single startup diagnostic about the server-side PRO API key status.
+    _log_pro_api_key_status()
 
     if run_in_http:
         if rest:
@@ -347,8 +366,6 @@ def main_command(
 
         asgi_app.add_event_handler("shutdown", WEB3_POOL.close)
         uvicorn.run(asgi_app, host=final_http_host, port=final_http_port)
-    elif rest:
-        raise typer.BadParameter("The --rest flag can only be used with the --http flag.")
     else:
         # This is the original behavior: run in stdio mode
         mcp.run()

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -54,11 +54,23 @@ logger = logging.getLogger(__name__)
 
 
 def _log_pro_api_key_status() -> None:
-    """Log the server-side PRO API key configuration state at startup."""
+    """Log the server-side PRO API key configuration state at startup.
+
+    A missing server-side key is logged at WARNING — every expected deployment
+    configures one, so its absence is almost certainly an operator mistake and
+    must survive WARNING-level log filtering. The message distinguishes whether
+    client-supplied keys can still compensate or every PRO-gated data tool is
+    guaranteed to fail.
+    """
     if config.pro_api_key:
         logger.info("BLOCKSCOUT_PRO_API_KEY is configured; server-side PRO API key is available.")
+    elif not config.pro_api_key_header:
+        logger.warning(
+            "BLOCKSCOUT_PRO_API_KEY is not configured and client-provided keys are disabled; "
+            "every data tool requiring the PRO API will fail."
+        )
     else:
-        logger.info("BLOCKSCOUT_PRO_API_KEY is not configured; no server-side PRO API key is available.")
+        logger.warning("BLOCKSCOUT_PRO_API_KEY is not configured; no server-side PRO API key is available.")
 
 
 # Compose the instructions string for the MCP server constructor

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -227,7 +227,7 @@ async def make_blockscout_request(
         The JSON response as a dictionary. If the API returns a JSON null body, returns an empty dictionary {}.
 
     Raises:
-        ValueError: If BLOCKSCOUT_PRO_API_KEY is not configured
+        ValueError: If no effective PRO API key is configured (neither a server-side nor a client-supplied key)
         ChainNotFoundError: If the chain_id is not supported
         CreditsExhaustedError: If the PRO API returns HTTP 402 (credit allowance depleted)
         httpx.HTTPStatusError: If the HTTP request returns a non-402 error status code
@@ -280,7 +280,7 @@ async def make_blockscout_post_request(
         timeout: Optional override for the HTTP request timeout in seconds.
 
     Raises:
-        ValueError: If BLOCKSCOUT_PRO_API_KEY is not configured
+        ValueError: If no effective PRO API key is configured (neither a server-side nor a client-supplied key)
         ChainNotFoundError: If the chain_id is not supported
         CreditsExhaustedError: If the PRO API returns HTTP 402 (credit allowance depleted)
 
@@ -429,15 +429,17 @@ async def make_metadata_request(api_path: str, params: dict | None = None) -> di
     """
     Make an authenticated GET request to the Blockscout PRO API metadata endpoint.
 
-    Authenticates via the ``BLOCKSCOUT_PRO_API_KEY`` environment variable, sent
-    as a ``Bearer`` token scoped only to this request.  The ``User-Agent`` and
+    Authenticates via the effective PRO API key — either a client-supplied key
+    or the server-side ``BLOCKSCOUT_PRO_API_KEY`` environment variable — sent as
+    a ``Bearer`` token scoped only to this request.  The ``User-Agent`` and
     ``Accept`` headers are also attached here, not on the shared httpx client,
     so the key never leaks to other upstreams.
 
-    When no key is configured the request is skipped entirely: a ``ValueError``
-    is raised before any network call so the server never issues a request the
-    PRO API is guaranteed to reject. Callers treat this like any other
-    metadata failure (the ``metadata`` field is null with an explanatory note).
+    When no effective key is configured (neither a server-side nor a
+    client-supplied key) the request is skipped entirely: a ``ValueError`` is
+    raised before any network call so the server never issues a request the PRO
+    API is guaranteed to reject. Callers treat this like any other metadata
+    failure (the ``metadata`` field is null with an explanatory note).
 
     This helper routes through the shared ``_make_blockscout_http_request`` core
     and therefore inherits the same conservative GET retry policy
@@ -456,7 +458,8 @@ async def make_metadata_request(api_path: str, params: dict | None = None) -> di
         normalized to ``{}``.
 
     Raises:
-        ValueError: If ``BLOCKSCOUT_PRO_API_KEY`` is not configured
+        ValueError: If no effective PRO API key is configured (neither a server-side
+            ``BLOCKSCOUT_PRO_API_KEY`` nor a client-supplied key)
         CreditsExhaustedError: If the PRO API returns HTTP 402 (credit allowance depleted)
         httpx.HTTPStatusError: If the HTTP request returns a non-402 error status code
         httpx.TimeoutException: If the request times out (retried as a subclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.16.0.dev18"
+version = "0.16.0.dev19"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.16.0.dev18",
+  "version": "0.16.0.dev19",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/test_pro_api_key_http_transport.py
+++ b/tests/test_pro_api_key_http_transport.py
@@ -12,7 +12,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from starlette.testclient import TestClient
 
 from blockscout_mcp_server.config import config as server_config
-from blockscout_mcp_server.pro_api_key_context import pro_api_key_scope, resolve_pro_api_key
+from blockscout_mcp_server.pro_api_key_context import pro_api_key_scope, require_pro_api_key, resolve_pro_api_key
 
 _MCP_HEADERS = {
     "Accept": "application/json, text/event-stream",
@@ -84,3 +84,46 @@ def test_missing_client_header_falls_back_to_server_key(mcp_app):
         )
     assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
     assert _extract_text_result(response.text) == "server-key"
+
+
+def test_not_configured_error_terse_contract_over_http(monkeypatch):
+    """The model-facing JSON-RPC error text carries the new terse not-configured contract.
+
+    Proves the transport layer preserves the minimal message: the chokepoint tests in
+    test_require_pro_api_key.py pin the source string, but they do not exercise the
+    FastMCP wrapping path. This test is the literal #404 failure boundary.
+    """
+    monkeypatch.setattr(server_config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key", raising=False)
+    monkeypatch.setattr(server_config, "pro_api_key", "", raising=False)
+
+    mcp = FastMCP(
+        name="test-not-configured-transport",
+        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    )
+    mcp.settings.stateless_http = True
+    mcp.settings.json_response = True
+
+    @mcp.tool()
+    @pro_api_key_scope
+    async def needs_pro_key(ctx: Context) -> str:
+        """Tool that requires a PRO API key for data access."""
+        return require_pro_api_key("data access")
+
+    app = mcp.streamable_http_app()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            json=_build_tools_call_body("needs_pro_key"),
+            headers=_MCP_HEADERS,
+        )
+
+    assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
+    data = json.loads(response.text)
+    assert data["result"]["isError"] is True
+    error_text = data["result"]["content"][0]["text"]
+    assert "PRO API key required" in error_text
+    assert "data access" in error_text
+    assert "BLOCKSCOUT_PRO_API_KEY" not in error_text
+    assert "on the server" not in error_text
+    assert "Blockscout-MCP-Pro-Api-Key" not in error_text

--- a/tests/test_require_pro_api_key.py
+++ b/tests/test_require_pro_api_key.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Direct unit tests for the require_pro_api_key() chokepoint message contract.
+
+Kept in a new focused module because tests/test_pro_api_key_context.py (466 LOC)
+does not import require_pro_api_key and is already near the 500 LOC ceiling.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+from blockscout_mcp_server.config import config
+from blockscout_mcp_server.pro_api_key_context import (
+    _Absent,
+    _client_key_state,
+    _Valid,
+    require_pro_api_key,
+)
+
+# ---------------------------------------------------------------------------
+# ContextVar isolation helper (mirrored from tests/test_pro_api_key_context.py)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _set_key_state(state):
+    """Context manager that sets _client_key_state and resets it in finally."""
+    token = _client_key_state.set(state)
+    try:
+        yield
+    finally:
+        _client_key_state.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Exact-message contract (primary lock)
+# ---------------------------------------------------------------------------
+
+
+def test_require_pro_api_key_exact_message_data_access(monkeypatch):
+    """Full-string equality: label 'data access' produces the exact new terse message."""
+    monkeypatch.setattr(config, "pro_api_key", "", raising=False)
+    with _set_key_state(_Absent()):
+        with pytest.raises(ValueError) as exc_info:
+            require_pro_api_key("data access")
+    assert str(exc_info.value) == "PRO API key required for data access; not configured."
+
+
+def test_require_pro_api_key_exact_message_contract_reads(monkeypatch):
+    """Full-string equality: label 'contract reads via the PRO API gateway' produces the exact new terse message."""
+    monkeypatch.setattr(config, "pro_api_key", "", raising=False)
+    with _set_key_state(_Absent()):
+        with pytest.raises(ValueError) as exc_info:
+            require_pro_api_key("contract reads via the PRO API gateway")
+    assert str(exc_info.value) == "PRO API key required for contract reads via the PRO API gateway; not configured."
+
+
+# ---------------------------------------------------------------------------
+# Negative guard (defense in depth)
+# ---------------------------------------------------------------------------
+
+
+def test_require_pro_api_key_message_excludes_env_var_name(monkeypatch):
+    """The error message must not contain the environment variable name."""
+    monkeypatch.setattr(config, "pro_api_key", "", raising=False)
+    monkeypatch.setattr(config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key", raising=False)
+    with _set_key_state(_Absent()):
+        with pytest.raises(ValueError) as exc_info:
+            require_pro_api_key("data access")
+    message = str(exc_info.value)
+    assert "BLOCKSCOUT_PRO_API_KEY" not in message
+    assert "on the server" not in message
+    assert "Blockscout-MCP-Pro-Api-Key" not in message
+
+
+# ---------------------------------------------------------------------------
+# Happy path guard
+# ---------------------------------------------------------------------------
+
+
+def test_require_pro_api_key_returns_key_when_present(monkeypatch):
+    """When a non-empty server key is configured, require_pro_api_key returns it without raising."""
+    monkeypatch.setattr(config, "pro_api_key", "my-server-key", raising=False)
+    with _set_key_state(_Absent()):
+        result = require_pro_api_key("data access")
+    assert result == "my-server-key"
+
+
+def test_require_pro_api_key_returns_client_key_when_valid(monkeypatch):
+    """When a valid client key is in the ContextVar, require_pro_api_key returns it without raising."""
+    monkeypatch.setattr(config, "pro_api_key", "", raising=False)
+    with _set_key_state(_Valid(value="client-supplied-key")):
+        result = require_pro_api_key("data access")
+    assert result == "client-supplied-key"

--- a/tests/test_server_pro_api_key_logging.py
+++ b/tests/test_server_pro_api_key_logging.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Unit tests for the PRO API key startup diagnostic in server.py."""
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helper-content scenarios (direct calls to _log_pro_api_key_status)
+# ---------------------------------------------------------------------------
+
+
+def test_no_key_logs_info_with_env_var_name(caplog, monkeypatch):
+    """When pro_api_key is empty, the INFO log names BLOCKSCOUT_PRO_API_KEY."""
+    from blockscout_mcp_server import server
+
+    monkeypatch.setattr(server.config, "pro_api_key", "")
+
+    with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
+        server._log_pro_api_key_status()
+
+    assert any("BLOCKSCOUT_PRO_API_KEY" in r.message for r in caplog.records)
+
+
+def test_no_key_log_is_info_level(caplog, monkeypatch):
+    """When pro_api_key is empty, the record is emitted at INFO level."""
+    from blockscout_mcp_server import server
+
+    monkeypatch.setattr(server.config, "pro_api_key", "")
+
+    with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
+        server._log_pro_api_key_status()
+
+    matching = [r for r in caplog.records if "BLOCKSCOUT_PRO_API_KEY" in r.message]
+    assert matching, "Expected at least one log record mentioning BLOCKSCOUT_PRO_API_KEY"
+    assert all(r.levelname == "INFO" for r in matching)
+
+
+def test_no_key_log_does_not_mention_client_key_header(caplog, monkeypatch):
+    """When pro_api_key is empty, the log must not name the client-key header."""
+    from blockscout_mcp_server import server
+
+    monkeypatch.setattr(server.config, "pro_api_key", "")
+    monkeypatch.setattr(server.config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key")
+
+    with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
+        server._log_pro_api_key_status()
+
+    for record in caplog.records:
+        assert "Blockscout-MCP-Pro-Api-Key" not in record.message, "Log must not mention the client-key header name"
+        assert "clients may supply" not in record.message.lower(), "Log must not tell clients to supply their own key"
+        assert "supply" not in record.message.lower(), "Log must stay server-state-focused, not guide clients"
+
+
+def test_key_configured_logs_confirmation_without_key_value(caplog, monkeypatch):
+    """When pro_api_key is set, the log confirms it but does not reveal the value."""
+    from blockscout_mcp_server import server
+
+    dummy_key = "secret-key-do-not-log"
+    monkeypatch.setattr(server.config, "pro_api_key", dummy_key)
+
+    with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
+        server._log_pro_api_key_status()
+
+    assert caplog.records, "Expected at least one log record when key is configured"
+    for record in caplog.records:
+        assert dummy_key not in record.message, "The actual key value must never appear in the log"
+
+
+# ---------------------------------------------------------------------------
+# Startup-wiring scenarios (prove main_command calls the helper)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_settings():
+    """Ensure mcp settings are reset between tests to avoid state leakage."""
+    yield
+    # No-op: individual tests use patches that clean up automatically.
+
+
+def test_http_mode_calls_log_pro_api_key_status(monkeypatch):
+    """In HTTP mode, main_command calls _log_pro_api_key_status exactly once."""
+    from blockscout_mcp_server import server
+
+    mock_log_status = MagicMock()
+    monkeypatch.setattr(server, "_log_pro_api_key_status", mock_log_status)
+    monkeypatch.setattr(server.uvicorn, "run", MagicMock())
+
+    result = runner.invoke(server.cli_app, ["--http"])
+
+    assert result.exit_code == 0, f"CLI exited with non-zero code: {result.output}"
+    mock_log_status.assert_called_once()
+
+
+def test_stdio_mode_calls_log_pro_api_key_status(monkeypatch):
+    """In stdio mode, main_command calls _log_pro_api_key_status exactly once."""
+    import mcp.server.fastmcp
+
+    from blockscout_mcp_server import server
+
+    mock_log_status = MagicMock()
+    monkeypatch.setattr(server, "_log_pro_api_key_status", mock_log_status)
+    monkeypatch.setattr(mcp.server.fastmcp.FastMCP, "run", MagicMock())
+
+    result = runner.invoke(server.cli_app, [])
+
+    assert result.exit_code == 0, f"CLI exited with non-zero code: {result.output}"
+    mock_log_status.assert_called_once()
+
+
+def test_rejected_invocation_does_not_call_log_pro_api_key_status(monkeypatch):
+    """--rest without --http must fail and must NOT call _log_pro_api_key_status."""
+    from blockscout_mcp_server import server
+
+    mock_log_status = MagicMock()
+    monkeypatch.setattr(server, "_log_pro_api_key_status", mock_log_status)
+    # Also ensure mcp_transport is not "http" so the early guard fires
+    monkeypatch.setattr(server.config, "mcp_transport", "")
+
+    result = runner.invoke(server.cli_app, ["--rest"])
+
+    assert result.exit_code != 0, "Expected non-zero exit for --rest without --http"
+    # Strip ANSI color codes and verify the error message
+    output_clean = re.sub(r"\x1b\[[0-9;]*[mK]", "", result.output)
+    assert "The --rest flag can only be used with the --http flag." in output_clean
+    mock_log_status.assert_not_called()

--- a/tests/test_server_pro_api_key_logging.py
+++ b/tests/test_server_pro_api_key_logging.py
@@ -4,7 +4,6 @@
 import re
 from unittest.mock import MagicMock
 
-import pytest
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -15,11 +14,12 @@ runner = CliRunner()
 # ---------------------------------------------------------------------------
 
 
-def test_no_key_logs_info_with_env_var_name(caplog, monkeypatch):
-    """When pro_api_key is empty, the INFO log names BLOCKSCOUT_PRO_API_KEY."""
+def test_no_key_logs_warning_with_env_var_name(caplog, monkeypatch):
+    """When pro_api_key is empty, the startup diagnostic names BLOCKSCOUT_PRO_API_KEY."""
     from blockscout_mcp_server import server
 
     monkeypatch.setattr(server.config, "pro_api_key", "")
+    monkeypatch.setattr(server.config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key")
 
     with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
         server._log_pro_api_key_status()
@@ -27,18 +27,19 @@ def test_no_key_logs_info_with_env_var_name(caplog, monkeypatch):
     assert any("BLOCKSCOUT_PRO_API_KEY" in r.message for r in caplog.records)
 
 
-def test_no_key_log_is_info_level(caplog, monkeypatch):
-    """When pro_api_key is empty, the record is emitted at INFO level."""
+def test_no_key_log_is_warning_level(caplog, monkeypatch):
+    """When pro_api_key is empty, the record is emitted at WARNING level even with client keys enabled."""
     from blockscout_mcp_server import server
 
     monkeypatch.setattr(server.config, "pro_api_key", "")
+    monkeypatch.setattr(server.config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key")
 
     with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
         server._log_pro_api_key_status()
 
     matching = [r for r in caplog.records if "BLOCKSCOUT_PRO_API_KEY" in r.message]
     assert matching, "Expected at least one log record mentioning BLOCKSCOUT_PRO_API_KEY"
-    assert all(r.levelname == "INFO" for r in matching)
+    assert all(r.levelname == "WARNING" for r in matching)
 
 
 def test_no_key_log_does_not_mention_client_key_header(caplog, monkeypatch):
@@ -54,7 +55,21 @@ def test_no_key_log_does_not_mention_client_key_header(caplog, monkeypatch):
     for record in caplog.records:
         assert "Blockscout-MCP-Pro-Api-Key" not in record.message, "Log must not mention the client-key header name"
         assert "clients may supply" not in record.message.lower(), "Log must not tell clients to supply their own key"
-        assert "supply" not in record.message.lower(), "Log must stay server-state-focused, not guide clients"
+
+
+def test_no_key_and_client_keys_disabled_logs_warning(caplog, monkeypatch):
+    """When neither a server key nor the client-key header is configured, the diagnostic escalates to WARNING."""
+    from blockscout_mcp_server import server
+
+    monkeypatch.setattr(server.config, "pro_api_key", "")
+    monkeypatch.setattr(server.config, "pro_api_key_header", "")
+
+    with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
+        server._log_pro_api_key_status()
+
+    matching = [r for r in caplog.records if "BLOCKSCOUT_PRO_API_KEY" in r.message]
+    assert matching, "Expected at least one log record mentioning BLOCKSCOUT_PRO_API_KEY"
+    assert all(r.levelname == "WARNING" for r in matching), "Dead configuration must be logged at WARNING level"
 
 
 def test_key_configured_logs_confirmation_without_key_value(caplog, monkeypatch):
@@ -68,6 +83,9 @@ def test_key_configured_logs_confirmation_without_key_value(caplog, monkeypatch)
         server._log_pro_api_key_status()
 
     assert caplog.records, "Expected at least one log record when key is configured"
+    assert any("is configured" in r.message for r in caplog.records), (
+        "Expected a log record confirming the key is configured"
+    )
     for record in caplog.records:
         assert dummy_key not in record.message, "The actual key value must never appear in the log"
 
@@ -77,19 +95,14 @@ def test_key_configured_logs_confirmation_without_key_value(caplog, monkeypatch)
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(autouse=True)
-def _reset_mcp_settings():
-    """Ensure mcp settings are reset between tests to avoid state leakage."""
-    yield
-    # No-op: individual tests use patches that clean up automatically.
-
-
 def test_http_mode_calls_log_pro_api_key_status(monkeypatch):
     """In HTTP mode, main_command calls _log_pro_api_key_status exactly once."""
     from blockscout_mcp_server import server
 
     mock_log_status = MagicMock()
     monkeypatch.setattr(server, "_log_pro_api_key_status", mock_log_status)
+    # Pin the transport so ambient BLOCKSCOUT_MCP_TRANSPORT cannot change the code path
+    monkeypatch.setattr(server.config, "mcp_transport", "")
     monkeypatch.setattr(server.uvicorn, "run", MagicMock())
 
     result = runner.invoke(server.cli_app, ["--http"])
@@ -106,6 +119,9 @@ def test_stdio_mode_calls_log_pro_api_key_status(monkeypatch):
 
     mock_log_status = MagicMock()
     monkeypatch.setattr(server, "_log_pro_api_key_status", mock_log_status)
+    # Pin the transport so an ambient BLOCKSCOUT_MCP_TRANSPORT=http cannot divert
+    # this test into the HTTP path, where uvicorn.run is not mocked
+    monkeypatch.setattr(server.config, "mcp_transport", "")
     monkeypatch.setattr(mcp.server.fastmcp.FastMCP, "run", MagicMock())
 
     result = runner.invoke(server.cli_app, [])

--- a/tests/test_server_pro_api_key_logging.py
+++ b/tests/test_server_pro_api_key_logging.py
@@ -15,20 +15,7 @@ runner = CliRunner()
 
 
 def test_no_key_logs_warning_with_env_var_name(caplog, monkeypatch):
-    """When pro_api_key is empty, the startup diagnostic names BLOCKSCOUT_PRO_API_KEY."""
-    from blockscout_mcp_server import server
-
-    monkeypatch.setattr(server.config, "pro_api_key", "")
-    monkeypatch.setattr(server.config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key")
-
-    with caplog.at_level("INFO", logger="blockscout_mcp_server.server"):
-        server._log_pro_api_key_status()
-
-    assert any("BLOCKSCOUT_PRO_API_KEY" in r.message for r in caplog.records)
-
-
-def test_no_key_log_is_warning_level(caplog, monkeypatch):
-    """When pro_api_key is empty, the record is emitted at WARNING level even with client keys enabled."""
+    """When pro_api_key is empty, the startup diagnostic names BLOCKSCOUT_PRO_API_KEY at WARNING level."""
     from blockscout_mcp_server import server
 
     monkeypatch.setattr(server.config, "pro_api_key", "")

--- a/tests/test_web3_pool.py
+++ b/tests/test_web3_pool.py
@@ -295,7 +295,7 @@ async def test_no_key_raises_value_error():
         patch("blockscout_mcp_server.web3_pool.aiohttp.ClientSession", session_cls_mock),
         patch.object(config, "pro_api_key", ""),
     ):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await pool.get("1")
 
     ensure_mock.assert_not_called()

--- a/tests/tools/address/test_get_address_info_metadata.py
+++ b/tests/tools/address/test_get_address_info_metadata.py
@@ -145,7 +145,7 @@ async def test_get_address_info_fails_fast_when_no_key(mock_ctx, monkeypatch):
     chain_id = "1"
     address = "0x123abc"
 
-    missing_key_error = ValueError("BLOCKSCOUT_PRO_API_KEY is not set")
+    missing_key_error = ValueError("PRO API key required for data access; not configured.")
 
     with (
         patch(
@@ -160,7 +160,7 @@ async def test_get_address_info_fails_fast_when_no_key(mock_ctx, monkeypatch):
         mock_bs_request.side_effect = missing_key_error
         mock_meta_request.return_value = {}
 
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await get_address_info(chain_id=chain_id, address=address, ctx=mock_ctx)
 
 

--- a/tests/tools/contract/test_fetch_and_process_contract.py
+++ b/tests/tools/contract/test_fetch_and_process_contract.py
@@ -290,7 +290,7 @@ async def test_fetch_and_process_cache_hit_no_key_fails_closed(mock_ctx):
             return_value=cached,
         ) as mock_get,
     ):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await _fetch_and_process_contract("1", "0xAbC")
 
     mock_get.assert_not_called()

--- a/tests/tools/contract/test_read_contract.py
+++ b/tests/tools/contract/test_read_contract.py
@@ -84,12 +84,12 @@ async def test_read_contract_missing_pro_api_key_propagates_value_error(mock_ctx
     Unlike the other tests, this one does NOT mock ``WEB3_POOL.get`` — it drives
     the real pool with an empty key so the tool's wiring (the ``WEB3_POOL.get``
     call sits outside any try/except) is exercised end to end. This locks in the
-    user-facing contract: the clear "set BLOCKSCOUT_PRO_API_KEY" message is not
-    swallowed or rewrapped into a generic error.
+    user-facing contract: the minimal "PRO API key required for …; not configured."
+    message is not swallowed or rewrapped into a generic error.
     """
     abi = {"name": "foo", "type": "function", "inputs": [], "outputs": []}
     with patch.object(config, "pro_api_key", ""):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await read_contract(
                 chain_id="1",
                 address="0x0000000000000000000000000000000000000abc",

--- a/tests/tools/test_common_blockscout_request.py
+++ b/tests/tools/test_common_blockscout_request.py
@@ -300,7 +300,7 @@ async def test_make_blockscout_request_raises_when_no_pro_api_key(monkeypatch):
         raise AssertionError("No HTTP client should be created when PRO API key is absent")
 
     with patch("blockscout_mcp_server.tools.common._create_httpx_client", _fail):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await make_blockscout_request(chain_id="1", api_path="/api/v2/test")
 
 
@@ -315,7 +315,7 @@ async def test_make_blockscout_post_request_raises_when_no_pro_api_key(monkeypat
         raise AssertionError("No HTTP client should be created when PRO API key is absent")
 
     with patch("blockscout_mcp_server.tools.common._create_httpx_client", _fail):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await make_blockscout_post_request(chain_id="1", api_path="/json-rpc", json_body={})
 
 

--- a/tests/tools/test_common_blockscout_request_auth.py
+++ b/tests/tools/test_common_blockscout_request_auth.py
@@ -218,7 +218,7 @@ async def test_get_raises_not_configured_when_both_keys_absent(monkeypatch):
         patch("blockscout_mcp_server.tools.common._create_httpx_client", return_value=NeverCalledClient()),
         patch("blockscout_mcp_server.tools.common.ensure_chain_supported", AsyncMock()),
     ):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await make_blockscout_request(chain_id=_CHAIN_ID, api_path=_API_PATH)
 
 

--- a/tests/tools/test_common_metadata.py
+++ b/tests/tools/test_common_metadata.py
@@ -138,7 +138,7 @@ async def test_make_metadata_request_skips_network_when_no_key(monkeypatch):
         raise AssertionError("No HTTP client should be created when the PRO API key is absent")
 
     with patch("blockscout_mcp_server.tools.common._create_httpx_client", _fail_create_client):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await make_metadata_request("/services/metadata/api/v1/metadata", {"addresses": "0xabc"})
 
 

--- a/tests/tools/test_common_post_request.py
+++ b/tests/tools/test_common_post_request.py
@@ -422,7 +422,7 @@ async def test_post_raises_not_configured_when_both_keys_absent(monkeypatch):
         patch("blockscout_mcp_server.tools.common._create_httpx_client", return_value=NeverCalledPostClient()),
         patch("blockscout_mcp_server.tools.common.ensure_chain_supported", AsyncMock()),
     ):
-        with pytest.raises(ValueError, match="BLOCKSCOUT_PRO_API_KEY"):
+        with pytest.raises(ValueError, match="PRO API key required"):
             await make_blockscout_post_request("1", "/json-rpc", {"x": 1})
 
 


### PR DESCRIPTION
Closes #404.

## Why

The "PRO API key not configured" error returned to MCP clients embedded server-operator remediation (`set BLOCKSCOUT_PRO_API_KEY on the server, or send the … request header`). The actual recipient — an LLM agent / end user — cannot act on operator instructions, and the extra prose needlessly consumes model context. This change trims the client-facing error to a minimal, feature-gated signal and moves operator remediation to a startup log diagnostic instead.

No tool behavior, network path, or fail-fast semantics change — only the human-readable error text and a new startup log line.

**Decision recorded:** the error becomes a short human-readable sentence (terse prose), not a machine-readable structured error code. Target wording: `PRO API key required for {disabled_feature}; not configured.`

## What changed

- **Phase 1 — Trim the error message** (`pro_api_key_context.py`): `require_pro_api_key()` now raises `PRO API key required for {disabled_feature}; not configured.`, dropping the operator-remediation branch. Obsolete `match="BLOCKSCOUT_PRO_API_KEY"` test expectations were rewritten to the new contract (intentional behavior change, not a workaround). Added a focused chokepoint test module and an HTTP-transport test proving model-facing clients receive the terse message.
- **Phase 2 — Startup diagnostic** (`server.py`): added a `_log_pro_api_key_status()` helper that logs the server-side `BLOCKSCOUT_PRO_API_KEY` configuration status (never logging the key value), called once at startup after the `--rest`-without-`--http` guard. A configured key is confirmed at INFO; a missing key is logged at WARNING — expected deployments configure a server-side key, so its absence is almost certainly an operator mistake — with a distinct WARNING message when client-supplied keys are also disabled and every PRO-gated data tool is therefore guaranteed to fail. The operator-facing remediation now lives here rather than in the client error.
- **Phase 3 — Documentation** (`SPEC.md`, `README.md`, `tools/common.py` docstrings): documented the audience split, fixed stale "actionable error" wording in the README, and updated helper `Raises:` docstrings to effective-key framing.
- **Phase 4 — Version bump**: `0.16.0.dev18` → `0.16.0.dev19` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`.

## Review follow-up

- **Decision revised during review:** the missing-key diagnostic was originally logged at INFO; it is now WARNING in both missing-key cases (client-supplied keys enabled or disabled), so the dead or degraded configuration survives WARNING-level production log filtering.
- Hardened the diagnostic tests: removed a no-op autouse fixture, dropped an overly broad bare-`supply` negative assertion (keeping the header-name and `clients may supply` contract checks), asserted the positive "is configured" branch, and pinned `config.mcp_transport` in the CLI wiring tests so an ambient `BLOCKSCOUT_MCP_TRANSPORT` cannot divert them onto an unmocked code path.

## Testing

- `pytest tests/` — **785 passed, 0 skipped** (87 integration tests deselected).
- `ruff check .` and `ruff format --check .` — clean.
- Integration tests are not required for this change (no tool function, `tools/common.py` helper logic, or data-transformation change — only an error string, a startup log, and docs).

## Reviewer notes

- Each phase is a separate commit for easy review.
- The startup diagnostic logs the *presence* of the key only — the key value is never logged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server now logs diagnostic information about PRO API key configuration status during startup.

* **Bug Fixes**
  * Simplified and clarified error messages when PRO API keys are missing—now providing concise, user-friendly feedback instead of internal configuration details.

* **Documentation**
  * Updated specification and README clarifying PRO API key requirement handling and error messaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->