### PR TITLE
Preserve query_params across address-logs pagination

### DIFF
--- a/.cursor/rules/112-direct-api-handlers.mdc
+++ b/.cursor/rules/112-direct-api-handlers.mdc
@@ -52,4 +52,16 @@ async def handle_my_endpoint(
 ```
 
 
+## Pagination and Filter Preservation
+
+If a handler paginates its response with `create_items_pagination` **and** its endpoint supports request-side filtering via `query_params`, the handler MUST forward the caller's `query_params` into `next_call_base_params` so the filter survives across pages. Add it under a nested `query_params` key, and only when the dict is non-empty:
+
+```python
+next_call_base_params = {"chain_id": chain_id, "endpoint_path": endpoint_path}
+if query_params:
+    next_call_base_params["query_params"] = query_params
+```
+
+This mirrors how the generic (no-handler) `direct_api_call` path re-attaches `query_params` to its own next call. Without it, the auto-generated `pagination.next_call` keeps only the position cursor and silently drops the filter, so the second and later pages return unfiltered data. In this case the `query_params` argument is genuinely used, so it must **not** carry a `# noqa: ARG001` marker. Handlers that do not paginate, or whose endpoint exposes no filtering parameter, may keep the `# noqa: ARG001` marker on `query_params`.
+
 - Handlers should set `content_text` in `build_tool_response(...)` to provide a concise human-readable summary for MCP `content` output.

--- a/.cursor/rules/112-direct-api-handlers.mdc
+++ b/.cursor/rules/112-direct-api-handlers.mdc
@@ -52,6 +52,8 @@ async def handle_my_endpoint(
 ```
 
 
+- Handlers should set `content_text` in `build_tool_response(...)` to provide a concise human-readable summary for MCP `content` output.
+
 ## Pagination and Filter Preservation
 
 If a handler paginates its response with `create_items_pagination` **and** its endpoint supports request-side filtering via `query_params`, the handler MUST forward the caller's `query_params` into `next_call_base_params` so the filter survives across pages. Add it under a nested `query_params` key, and only when the dict is non-empty:
@@ -63,5 +65,3 @@ if query_params:
 ```
 
 This mirrors how the generic (no-handler) `direct_api_call` path re-attaches `query_params` to its own next call. Without it, the auto-generated `pagination.next_call` keeps only the position cursor and silently drops the filter, so the second and later pages return unfiltered data. In this case the `query_params` argument is genuinely used, so it must **not** carry a `# noqa: ARG001` marker. Handlers that do not paginate, or whose endpoint exposes no filtering parameter, may keep the `# noqa: ARG001` marker on `query_params`.
-
-- Handlers should set `content_text` in `build_tool_response(...)` to provide a concise human-readable summary for MCP `content` output.

--- a/.cursor/rules/112-direct-api-handlers.mdc
+++ b/.cursor/rules/112-direct-api-handlers.mdc
@@ -61,7 +61,9 @@ If a handler paginates its response with `create_items_pagination` **and** its e
 ```python
 next_call_base_params = {"chain_id": chain_id, "endpoint_path": endpoint_path}
 if query_params:
-    next_call_base_params["query_params"] = query_params
+    next_call_base_params["query_params"] = dict(query_params)
 ```
+
+Use `dict(query_params)` rather than assigning the original dict directly: `create_items_pagination` only shallow-copies `next_call_base_params`, so without this copy the returned pagination params would alias the caller's dict.
 
 This mirrors how the generic (no-handler) `direct_api_call` path re-attaches `query_params` to its own next call. Without it, the auto-generated `pagination.next_call` keeps only the position cursor and silently drops the filter, so the second and later pages return unfiltered data. In this case the `query_params` argument is genuinely used, so it must **not** carry a `# noqa: ARG001` marker. Handlers that do not paginate, or whose endpoint exposes no filtering parameter, may keep the `# noqa: ARG001` marker on `query_params`.

--- a/API.md
+++ b/API.md
@@ -106,7 +106,7 @@ All error responses, regardless of the HTTP status code, return a JSON object wi
 
 ### Pagination
 
-For endpoints that return large datasets, the response will include a `pagination` object. To fetch the next page, you **must** use the `tool_name` and `params` from the `next_call` object to construct your next request. The `cursor` is an opaque string that contains all necessary information for the server.
+For endpoints that return large datasets, the response will include a `pagination` object. To fetch the next page, you **must** use the `tool_name` and `params` from the `next_call` object to construct your next request. The `cursor` is an opaque string that encodes the server's position within the result set, but it is not necessarily the only replay-relevant parameter: some endpoints (for example `direct_api_call` carrying a `query_params` filter) include additional parameters alongside the `cursor` that must be resent on every page. Always replay the **complete** `next_call.params` object verbatim — treat it, not the `cursor` alone, as the pagination replay contract.
 
 **Example Pagination Object:**
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -428,6 +428,8 @@ Credit-exhaustion responses on the PRO API *data path* are special-cased: the sh
     - **Improved Robustness**: It treats pagination as an atomic unit, preventing the AI from incorrectly constructing or omitting parameters for the next request.
     - **Simplified Tool Signatures**: Tool functions only need one optional `cursor: str` argument for pagination, keeping their schemas clean.
 
+    The cursor encodes the server's *position* within the result set, but it is not always the entire replay state. For endpoints that accept a request-side filter, the generated `pagination.next_call.params` carries that filter (for example `direct_api_call`'s `query_params`) alongside the cursor. Clients therefore replay the **complete** `params` object — it, not the cursor alone, is the pagination replay contract.
+
     **Mechanism:**
     When the Blockscout API returns a `next_page_params` dictionary, the server serializes this dictionary into a compact JSON string, which is then Base64URL-encoded. This creates a single, opaque, and URL-safe string that serves as the cursor for the next page.
 
@@ -459,6 +461,8 @@ Credit-exhaustion responses on the PRO API *data path* are special-cased: the sh
         }
       }
       ```
+
+    This example depicts an **unfiltered** call; when a request-side filter is supplied (via `query_params`), the same `params` object additionally carries the forwarded `query_params` alongside the cursor.
 
     **c) Response Slicing and Context-Aware Pagination:**
 
@@ -530,6 +534,8 @@ Credit-exhaustion responses on the PRO API *data path* are special-cased: the sh
 
     - **Dispatcher (`dispatcher.py`)**: This module contains logic to match an incoming `endpoint_path` to a specific handler function. It uses a self-registering pattern where handlers use a decorator to associate themselves with a URL path regex.
     - **Handlers (`handlers/`)**: Specialized response processors are located in the `blockscout_mcp_server/tools/direct_api/handlers/` directory. Each handler is responsible for transforming a raw JSON API response into a structured `ToolResponse` with a specific data model, applying logic like data truncation, field curation, and custom pagination.
+
+    When a specialized handler paginates a response for an endpoint that supports request-side filtering, it must carry the caller's `query_params` forward into the generated `pagination.next_call` alongside the opaque cursor. This keeps the generic, no-handler fallback and the handler path behaviorally consistent: a client that replays `pagination.next_call` verbatim continues to receive correctly filtered results on every page, rather than silently reverting to unfiltered data after the first page. Because the generic fallback encodes the upstream `next_page_params` into its cursor while specialized handlers build their cursor from per-item fields, the two paths can produce different cursor payloads; in both cases the complete `pagination.next_call` (the cursor plus any forwarded parameters), not the cursor alone, is the replay contract.
 
     If a matching handler is found, `direct_api_call` returns the rich, structured response from the handler. If no handler matches, it falls back to its default behavior of returning the raw, unprocessed JSON response wrapped in a generic `DirectApiData` model. When the API returns a JSON array instead of an object (as some endpoints like `/api/v2/main-page/blocks` do), the fallback path wraps the array into a `{"items": <array>}` dict before validation and sets pagination to `None`, since array-returning endpoints do not use Blockscout's `next_page_params` convention. This architecture allows for targeted enhancements while keeping the tool surface minimal and the system easily extensible.
 

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.16.0.dev18"
+__version__ = "0.16.0.dev19"

--- a/blockscout_mcp_server/tools/direct_api/direct_api_call.py
+++ b/blockscout_mcp_server/tools/direct_api/direct_api_call.py
@@ -146,7 +146,8 @@ async def direct_api_call(
                 "cursor": next_cursor,
             }
             if query_params:
-                next_call_params["query_params"] = query_params
+                # Defensive copy so the returned pagination params don't alias the caller's dict.
+                next_call_params["query_params"] = dict(query_params)
             pagination = PaginationInfo(next_call=NextCallInfo(tool_name="direct_api_call", params=next_call_params))
 
     await report_and_log_progress(

--- a/blockscout_mcp_server/tools/direct_api/handlers/address_logs_handler.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/address_logs_handler.py
@@ -26,7 +26,7 @@ async def handle_address_logs(
     response_json: dict[str, Any],
     chain_id: str,
     ctx: Context,  # noqa: ARG001 - reserved for future use in handlers
-    query_params: dict[str, Any] | None = None,  # noqa: ARG001 - not used by this endpoint but required by dispatcher
+    query_params: dict[str, Any] | None = None,  # supplied by the dispatcher
     **kwargs: Any,  # noqa: ARG001 - reserved for forward-compatible dispatcher context
 ) -> ToolResponse[list[AddressLogItem]]:
     """Process the raw JSON response for an address logs request."""
@@ -74,14 +74,18 @@ async def handle_address_logs(
             "See the `web3-dev` skill for how to call it.",
         ]
 
+    next_call_base_params: dict[str, Any] = {
+        "chain_id": chain_id,
+        "endpoint_path": f"/api/v2/addresses/{address}/logs",
+    }
+    if query_params:
+        next_call_base_params["query_params"] = query_params
+
     sliced_items, pagination = create_items_pagination(
         items=log_items_dicts,
         page_size=config.logs_page_size,
         tool_name="direct_api_call",
-        next_call_base_params={
-            "chain_id": chain_id,
-            "endpoint_path": f"/api/v2/addresses/{address}/logs",
-        },
+        next_call_base_params=next_call_base_params,
         cursor_extractor=extract_log_cursor_params,
     )
 

--- a/blockscout_mcp_server/tools/direct_api/handlers/address_logs_handler.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/address_logs_handler.py
@@ -79,7 +79,9 @@ async def handle_address_logs(
         "endpoint_path": f"/api/v2/addresses/{address}/logs",
     }
     if query_params:
-        next_call_base_params["query_params"] = query_params
+        # Defensive copy: create_items_pagination only shallow-copies next_call_base_params,
+        # so without this the returned pagination params would alias the caller's dict.
+        next_call_base_params["query_params"] = dict(query_params)
 
     sliced_items, pagination = create_items_pagination(
         items=log_items_dicts,

--- a/blockscout_mcp_server/tools/direct_api/handlers/transaction_logs_handler.py
+++ b/blockscout_mcp_server/tools/direct_api/handlers/transaction_logs_handler.py
@@ -26,7 +26,10 @@ async def handle_transaction_logs(
     response_json: dict[str, Any],
     chain_id: str,
     ctx: Context,  # noqa: ARG001 - reserved for future use in handlers
-    query_params: dict[str, Any] | None = None,  # noqa: ARG001 - not used by this endpoint but required by dispatcher
+    # This endpoint exposes no request-side filter (verified: passing `topic` returns 0 items
+    # even for a matching topic), so there is nothing to preserve across pagination. The argument
+    # is still required by the dispatcher signature, hence the ARG001 marker below is kept.
+    query_params: dict[str, Any] | None = None,  # noqa: ARG001
     **kwargs: Any,  # noqa: ARG001 - reserved for forward-compatible dispatcher context
 ) -> ToolResponse[list[TransactionLogItem]]:
     """Process the raw JSON response for a transaction logs request."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.16.0.dev18"
+version = "0.16.0.dev19"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.16.0.dev18",
+  "version": "0.16.0.dev19",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/integration/direct_api/test_address_logs_handler_real.py
+++ b/tests/integration/direct_api/test_address_logs_handler_real.py
@@ -103,3 +103,57 @@ async def test_direct_api_call_paginated_search_for_truncation(mock_ctx):
 
     if not found_truncated_log:
         pytest.skip(f"Could not find a truncated 'CallExecuted' log within the first {max_pages_to_check} pages.")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(not config.pro_api_key, reason="BLOCKSCOUT_PRO_API_KEY not configured")
+async def test_topic_filter_survives_pagination(mock_ctx):
+    """query_params topic filter must be carried forward into the next-page call."""
+    address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"  # WETH — heavily used, many Transfer logs
+    chain_id = "1"
+    endpoint_path = f"/api/v2/addresses/{address}/logs"
+    transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+    query_params = {"topic": transfer_topic}
+
+    first_page = await retry_on_network_error(
+        lambda: direct_api_call(
+            chain_id=chain_id,
+            endpoint_path=endpoint_path,
+            query_params=query_params,
+            ctx=mock_ctx,
+        ),
+        action_description="direct_api_call WETH Transfer logs first page",
+    )
+
+    assert isinstance(first_page.data, list)
+    assert first_page.data, "Expected at least one log item on page 1"
+    for item in first_page.data:
+        assert item.topics, f"Log item has no topics: {item}"
+        assert item.topics[0].lower() == transfer_topic.lower(), (
+            f"Page-1 item topic mismatch: expected {transfer_topic}, got {item.topics[0]}"
+        )
+
+    assert first_page.pagination is not None, "Expected pagination on page 1"
+    assert "query_params" in first_page.pagination.next_call.params, (
+        "query_params must be forwarded into next_call.params"
+    )
+    assert first_page.pagination.next_call.params["query_params"].get("topic") == transfer_topic, (
+        "topic filter must survive in next_call.params['query_params']"
+    )
+
+    second_page = await retry_on_network_error(
+        lambda: direct_api_call(**first_page.pagination.next_call.params, ctx=mock_ctx),
+        action_description="direct_api_call WETH Transfer logs second page (replayed next_call)",
+    )
+
+    assert isinstance(second_page.data, list)
+    assert second_page.data, "Expected at least one log item on page 2"
+    for item in second_page.data:
+        assert item.topics, f"Page-2 log item has no topics: {item}"
+        assert item.topics[0].lower() == transfer_topic.lower(), (
+            f"Page-2 item topic mismatch: expected {transfer_topic}, got {item.topics[0]}. "
+            "The topic filter was likely dropped from the next-page call."
+        )
+
+    assert first_page.data != second_page.data, "Page 1 and page 2 data must differ"

--- a/tests/tools/direct_api/handlers/test_address_logs_handler.py
+++ b/tests/tools/direct_api/handlers/test_address_logs_handler.py
@@ -255,6 +255,52 @@ async def test_handle_address_logs_pagination_filter_preserved(mock_ctx):
 
 
 @pytest.mark.asyncio
+async def test_handle_address_logs_pagination_query_params_not_aliased(mock_ctx):
+    """The returned pagination params must not alias the caller's query_params dict."""
+    address = "0x" + "8" * 40
+    topic = "0x" + "0" * 64
+    caller_query_params = {"topic": topic}
+    response_json = {
+        "items": [
+            {
+                "block_number": 19000001,
+                "transaction_hash": "0xtxA",
+                "topics": [topic],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 0,
+            },
+            {
+                "block_number": 19000000,
+                "transaction_hash": "0xtxB",
+                "topics": [topic],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 1,
+            },
+        ]
+    }
+
+    with patch.object(config, "logs_page_size", 1):
+        result = await handle_address_logs(
+            match=_build_match(address),
+            response_json=response_json,
+            chain_id="1",
+            ctx=mock_ctx,
+            query_params=caller_query_params,
+        )
+
+    assert result.pagination is not None
+    returned_query_params = result.pagination.next_call.params["query_params"]
+    assert returned_query_params == {"topic": topic}
+    assert returned_query_params is not caller_query_params
+
+    # Mutating the caller's dict afterwards must not leak into the response.
+    caller_query_params["topic"] = "0xmutated"
+    assert result.pagination.next_call.params["query_params"] == {"topic": topic}
+
+
+@pytest.mark.asyncio
 async def test_handle_address_logs_empty_items(mock_ctx):
     address = "0x" + "4" * 40
     response_json = {"items": []}

--- a/tests/tools/direct_api/handlers/test_address_logs_handler.py
+++ b/tests/tools/direct_api/handlers/test_address_logs_handler.py
@@ -136,6 +136,125 @@ async def test_handle_address_logs_truncation_notes(mock_ctx):
 
 
 @pytest.mark.asyncio
+async def test_handle_address_logs_pagination_no_filter_no_query_params_key(mock_ctx):
+    """No filter supplied → query_params key must NOT appear in next_call.params."""
+    address = "0x" + "5" * 40
+    response_json = {
+        "items": [
+            {
+                "block_number": 19000001,
+                "transaction_hash": "0xtxA",
+                "topics": ["0xtopic"],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 0,
+            },
+            {
+                "block_number": 19000000,
+                "transaction_hash": "0xtxB",
+                "topics": ["0xtopic"],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 1,
+            },
+        ]
+    }
+
+    with patch.object(config, "logs_page_size", 1):
+        result = await handle_address_logs(
+            match=_build_match(address),
+            response_json=response_json,
+            chain_id="1",
+            ctx=mock_ctx,
+        )
+
+    assert result.pagination is not None
+    assert "query_params" not in result.pagination.next_call.params
+
+
+@pytest.mark.asyncio
+async def test_handle_address_logs_pagination_empty_filter_no_query_params_key(mock_ctx):
+    """Empty filter dict → treated as no filter; query_params key must NOT appear."""
+    address = "0x" + "6" * 40
+    response_json = {
+        "items": [
+            {
+                "block_number": 19000001,
+                "transaction_hash": "0xtxA",
+                "topics": ["0xtopic"],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 0,
+            },
+            {
+                "block_number": 19000000,
+                "transaction_hash": "0xtxB",
+                "topics": ["0xtopic"],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 1,
+            },
+        ]
+    }
+
+    with patch.object(config, "logs_page_size", 1):
+        result = await handle_address_logs(
+            match=_build_match(address),
+            response_json=response_json,
+            chain_id="1",
+            ctx=mock_ctx,
+            query_params={},
+        )
+
+    assert result.pagination is not None
+    assert "query_params" not in result.pagination.next_call.params
+
+
+@pytest.mark.asyncio
+async def test_handle_address_logs_pagination_filter_preserved(mock_ctx):
+    """query_params filter is carried into next_call.params when pagination triggers."""
+    address = "0x" + "7" * 40
+    topic = "0x" + "0" * 64
+    response_json = {
+        "items": [
+            {
+                "block_number": 19000001,
+                "transaction_hash": "0xtxA",
+                "topics": [topic],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 0,
+            },
+            {
+                "block_number": 19000000,
+                "transaction_hash": "0xtxB",
+                "topics": [topic],
+                "data": "0xdata",
+                "decoded": None,
+                "index": 1,
+            },
+        ]
+    }
+
+    with patch.object(config, "logs_page_size", 1):
+        result = await handle_address_logs(
+            match=_build_match(address),
+            response_json=response_json,
+            chain_id="1",
+            ctx=mock_ctx,
+            query_params={"topic": topic},
+        )
+
+    assert result.pagination is not None
+    next_call = result.pagination.next_call
+    assert next_call.tool_name == "direct_api_call"
+    assert next_call.params["chain_id"] == "1"
+    assert next_call.params["endpoint_path"] == f"/api/v2/addresses/{address}/logs"
+    assert "cursor" in next_call.params
+    assert next_call.params["query_params"] == {"topic": topic}
+
+
+@pytest.mark.asyncio
 async def test_handle_address_logs_empty_items(mock_ctx):
     address = "0x" + "4" * 40
     response_json = {"items": []}


### PR DESCRIPTION
## What

Closes #405.

When address logs are retrieved through the `direct_api_call` tool with a query filter (e.g. `topic`), the filter was correctly applied to the first page but **silently dropped** from the auto-generated `pagination.next_call`. Replaying the next-page call verbatim (as the server instructs clients to do) therefore returned *unfiltered* data from page two onward.

This PR makes the specialized address-logs handler carry the caller's `query_params` forward into the generated next-page call, so a filtered query stays filtered across every page.

## Changes

- **`blockscout_mcp_server/tools/direct_api/handlers/address_logs_handler.py`** — the handler now actually uses its `query_params` argument: the pagination base params start from `{chain_id, endpoint_path}` and, only when `query_params` is truthy, add a nested `"query_params"` key (matching the shape the generic `direct_api_call` path already uses). The stale `# noqa: ARG001 - not used by this endpoint` comment is updated since the arg is now used.
- **Unit tests** (`tests/tools/direct_api/handlers/test_address_logs_handler.py`) — three scenarios: filter preserved across pages, no filter ⇒ no `query_params` key, empty filter (`{}`) treated as no filter.
- **Integration test** (`tests/integration/direct_api/test_address_logs_handler_real.py`) — a real-API test against WETH on Ethereum that fetches page 1 with a `topic` filter, replays `next_call.params`, and asserts page 2 is still filtered and differs from page 1. Gated by `@pytest.mark.skipif(not config.pro_api_key, ...)`.
- **Docs** — SPEC.md (opaque-cursor strategy + dispatcher sections), API.md (pagination replay contract), and `.cursor/rules/112-direct-api-handlers.mdc` (new "Pagination and Filter Preservation" section) updated to record the contract. `.cursor/AGENTS.md` checked per rule 900 and intentionally left unchanged (clarification within existing scope).
- **Version** bumped `0.16.0.dev18` → `0.16.0.dev19` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`.

## Testing

- Unit suite: **774 passed** (88 integration deselected).
- Integration suite via the timeout-protected runner (`scripts/run_integration_tests.py tests/integration/`): **88 passed, 0 skipped, 0 timed out** — including the new `test_topic_filter_survives_pagination`, confirmed end-to-end against live endpoints.
- `ruff check .` and `ruff format --check .`: clean.

## Reviewer notes

- The fix mirrors the nested-`query_params` shape produced by the generic `direct_api_call` pagination path; no shared pagination helpers were changed.
- `mcpb/manifest.json` version is intentionally **not** bumped (rule 135 — no `server`/`tools` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pagination to preserve query filters when fetching subsequent pages. Filters specified in initial requests are now correctly applied to all paginated results.

* **Documentation**
  * Updated pagination documentation to clarify that full request parameters, including filters, must be replayed for subsequent pages, not just cursor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->