### PR TITLE
Document optional topic filter for the address-logs instruction

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.16.0.dev18"
+__version__ = "0.16.0.dev19"

--- a/blockscout_mcp_server/tools/address/get_address_info.py
+++ b/blockscout_mcp_server/tools/address/get_address_info.py
@@ -163,7 +163,7 @@ async def get_address_info(
         "This is only the native coin balance. You MUST also call `get_tokens_by_address` to get the full portfolio.",
         (
             f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs` to get Logs Emitted by Address. "
-            "Optionally pass `query_params={'topic': '<32-byte hex>'}` to filter logs by a single topic."
+            "Optionally pass query_params={'topic': '<32-byte hex>'} to filter logs by a single topic."
         ),
         (
             f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history-by-day` "

--- a/blockscout_mcp_server/tools/address/get_address_info.py
+++ b/blockscout_mcp_server/tools/address/get_address_info.py
@@ -161,7 +161,10 @@ async def get_address_info(
     await report_and_log_progress(ctx, progress=2.0, total=2.0, message="Successfully fetched all address data.")
     instructions = [
         "This is only the native coin balance. You MUST also call `get_tokens_by_address` to get the full portfolio.",
-        (f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs` to get Logs Emitted by Address."),
+        (
+            f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs` to get Logs Emitted by Address. "
+            "Optionally pass `query_params={'topic': '<32-byte hex>'}` to filter logs by a single topic."
+        ),
         (
             f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history-by-day` "
             "to get daily native coin balance history."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.16.0.dev18"
+version = "0.16.0.dev19"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.16.0.dev18",
+  "version": "0.16.0.dev19",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/tools/address/test_get_address_info.py
+++ b/tests/tools/address/test_get_address_info.py
@@ -70,7 +70,11 @@ async def test_get_address_info_success_with_metadata(mock_ctx):
                 "This is only the native coin balance. You MUST also call `get_tokens_by_address` to get the full "
                 "portfolio."
             ),
-            (f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs` to get Logs Emitted by Address."),
+            (
+                f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs`"
+                " to get Logs Emitted by Address."
+                " Optionally pass `query_params={'topic': '<32-byte hex>'}` to filter logs by a single topic."
+            ),
             (
                 f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history-by-day` "
                 "to get daily native coin balance history."

--- a/tests/tools/address/test_get_address_info.py
+++ b/tests/tools/address/test_get_address_info.py
@@ -73,7 +73,7 @@ async def test_get_address_info_success_with_metadata(mock_ctx):
             (
                 f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs`"
                 " to get Logs Emitted by Address."
-                " Optionally pass `query_params={'topic': '<32-byte hex>'}` to filter logs by a single topic."
+                " Optionally pass query_params={'topic': '<32-byte hex>'} to filter logs by a single topic."
             ),
             (
                 f"Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/coin-balance-history-by-day` "


### PR DESCRIPTION
## What

Extends the address-logs follow-up instruction emitted by `get_address_info` with one concise clause documenting the optional `topic` query parameter:

> Use `direct_api_call` with endpoint `/api/v2/addresses/{address}/logs` to get Logs Emitted by Address. **Optionally pass `query_params={'topic': '<32-byte hex>'}` to filter logs by a single topic.**

Resolves [#406](https://github.com/blockscout/mcp-server/issues/406).

## Why

The `/addresses/{address}/logs` endpoint supports filtering logs by a single `topic`, but agents had no hint that the parameter exists. Adding one clause to the existing instruction surfaces the capability without bloating the guidance — the finer semantics (any-position matching, single-value-only, the 32-byte requirement, multi-topic behavior) are intentionally left out as noise for the majority of calls and are discoverable from upstream docs / the API's own validation errors.

## Changes

- **`blockscout_mcp_server/tools/address/get_address_info.py`** — appended the topic-filter clause to the address-logs instruction entry. The clause lives in a separate (non-f-string) adjacent string literal, so its literal `{ }` braces render correctly without doubling; the `{address}` interpolation in the f-string part is untouched. No other instruction, note, payload, or the docstring was changed.
- **`tests/tools/address/test_get_address_info.py`** — updated the pinned expected-instruction string in `test_get_address_info_success_with_metadata` to match the new wording verbatim.
- **Version bump** to `0.16.0.dev19` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`.

## Verification

- Unit suite: `pytest tests/tools/` — 407 passed.
- Integration (modified tool): `scripts/run_integration_tests.py tests/integration/address/test_get_address_info_real.py` — 2 passed, 0 skipped, 0 timed out.
- `ruff check .` and `ruff format --check .` — clean.
- No new integration test added: this change adds no field extraction, endpoint, or transformation, so a live assertion on instruction wording would only duplicate the unit test (per rule 220). The existing real-API test confirms the live data-extraction contract is intact.
- Confirmed no SPEC.md / AGENTS.md / API.md updates are needed — the instruction string lives only in tool source and its unit test.

## Reviewer notes

Implemented phase-by-phase via the implement-plan workflow; each phase was independently verified before commit. Phase 2 (integration verification) intentionally produced no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for filtering address-emitted logs by optional topic parameter in the address info tool.

* **Chores**
  * Version incremented to 0.16.0.dev19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->