### PR TITLE
Document required PRO API key in client setup docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -45,15 +45,12 @@ The same artifacts are also reachable via the MCP resources channel under URIs o
 
 ## Authentication
 
-The REST API is currently in an alpha stage and does not require authentication to the MCP server itself. This may be subject to change in future releases.
+The REST API is currently in an alpha stage and does not require a dedicated credential to access the MCP server itself. This may be subject to change in future releases.
 
-### Optional client-supplied Blockscout PRO API key
+Its data endpoints query Blockscout through its PRO API, so every request to those endpoints must include a Blockscout PRO API key in the `Blockscout-MCP-Pro-Api-Key` request header. To obtain a key, register on the [Blockscout Developer Portal](https://dev.blockscout.com) (the free tier does not require a credit card); keys are prefixed `proapi_`.
 
-Most data endpoints query Blockscout through its PRO API. A hosted server is normally already configured with its own key, but a REST client may optionally supply its own key for a request via the `Blockscout-MCP-Pro-Api-Key` request header (the header name is configurable on the server through `BLOCKSCOUT_PRO_API_KEY_HEADER`; an operator can disable the feature entirely by setting that name to an empty string).
-
-- A valid client-supplied key takes precedence over the server's configured key for that request, so each caller can consume its own PRO credit allowance.
-- If the header is absent, the server falls back to its own configured key.
-- If the header is present but malformed (it contains control characters or exceeds the maximum allowed length), any request that reaches a PRO-authenticated upstream call fails with HTTP `400`, and the server does not fall back to its own key. Endpoints that don't query the PRO API are unaffected.
+- The supplied key authenticates that request's upstream PRO API calls, so each caller consumes its own PRO credit allowance.
+- If the key is missing, or malformed (it contains control characters or exceeds the maximum allowed length), any request that reaches a PRO-authenticated upstream call fails with HTTP `400`. Endpoints that don't query the PRO API are unaffected.
 - The key is never written to logs, analytics, or cache keys. A raw `Authorization` header sent by the client is ignored and never forwarded to the PRO API; only the dedicated header above is honored.
 
 ## General Concepts
@@ -92,10 +89,10 @@ All error responses, regardless of the HTTP status code, return a JSON object wi
 
 #### Error Categories
 
-- **Client-Side Errors (`4xx` status codes)**: These errors usually indicate a problem with the request itself, though some (such as `402 Payment Required`) instead reflect an account/quota state of whichever PRO API key the request uses rather than anything wrong with the request. Common examples include:
+- **Client-Side Errors (`4xx` status codes)**: These errors usually indicate a problem with the request itself, though some (such as `402 Payment Required`) instead reflect an account/quota state of the PRO API key supplied with the request rather than anything wrong with the request. Common examples include:
   - **Validation Errors (`400 Bad Request`)**: Occur when a required parameter is missing or a parameter value is invalid.
   - **Deprecated Endpoints (`410 Gone`)**: Occur when a requested endpoint is no longer supported.
-  - **Credits Exhausted (`402 Payment Required`)**: Occurs when the Blockscout PRO API daily credit allowance for the effective API key used by the request has been exhausted — the client-supplied key when one is provided, otherwise the server's configured key. This is a distinct, clearly-labeled signal — separate from generic transient upstream failures — and reflects that key's quota state, not a problem with the request itself: the caller should stop and top up credits (or wait for the daily reset) rather than retry.
+  - **Credits Exhausted (`402 Payment Required`)**: Occurs when the Blockscout PRO API daily credit allowance for the API key supplied with the request has been exhausted. This is a distinct, clearly-labeled signal — separate from generic transient upstream failures — and reflects that key's quota state, not a problem with the request itself: the caller should stop and top up credits (or wait for the daily reset) rather than retry.
 
 - **Server-Side Errors (`5xx` status codes)**: These errors indicate a problem on the server or with a downstream service. Common examples include:
   - **Internal Errors (`500 Internal Server Error`)**: Occur when the server encounters an unexpected condition.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ For more powerful and efficient blockchain analysis, install the **Blockscout An
 
 ## Configuring MCP Clients
 
+### Blockscout PRO API Key
+
+Configuring the Blockscout MCP server with an AI agent requires a Blockscout PRO API key. Most of the data tools route their requests through the authenticated Blockscout PRO API gateway, so without a valid key those tools fail fast before making any upstream request.
+
+To obtain a key, register on the [Blockscout Developer Portal](https://dev.blockscout.com) (the free tier does not require a credit card) and generate an API key; keys are prefixed `proapi_`. Then supply it when configuring your client, as shown in the sections below.
+
 ### Using Claude Connectors Directory - Recommended
 
 The easiest way to use the Blockscout MCP server with Claude ( Claude Web, Claude Desktop and Claude Code) is through the official [Anthropic Connectors Directory](https://claude.com/connectors). This provides a native, managed installation experience with automatic updates.
@@ -52,10 +58,11 @@ Visit [claude.com/connectors/blockscout](https://claude.com/connectors/blockscou
 
 ### Claude Code Setup
 
-To quickly install the Blockscout MCP server for use with Claude Code, run the following command in your terminal:
+Pass your PRO API key via the `Blockscout-MCP-Pro-Api-Key` header when adding the server:
 
 ```sh
-claude mcp add --transport http blockscout https://mcp.blockscout.com/mcp
+claude mcp add --transport http blockscout https://mcp.blockscout.com/mcp \
+  --header "Blockscout-MCP-Pro-Api-Key: proapi_your_key_here"
 ```
 
 After running this command, Blockscout will be available as an MCP server in Claude Code, allowing you to access and analyze blockchain data directly from your coding environment.
@@ -71,36 +78,47 @@ Install the Blockscout app from the [ChatGPT Apps marketplace](https://chatgpt.c
 
 1. Open Codex and go to **Settings > MCP Servers > Add server**.
 2. Set **Name** to `Blockscout`, select the **Streamable HTTP** tab, and set **URL** to `https://mcp.blockscout.com/mcp`.
-3. Save and restart the Codex app.
+3. Under **Headers**, add a header with key `Blockscout-MCP-Pro-Api-Key` and value `proapi_your_key_here`.
+4. Save and restart the Codex app.
 
 ### Codex CLI Setup
 
-Run the following command in your terminal:
+Codex CLI cannot attach a custom header from the command line, so configure it in two steps:
 
-```sh
-codex mcp add Blockscout --url https://mcp.blockscout.com/mcp
-```
+1. Scaffold the server entry:
+
+   ```sh
+   codex mcp add Blockscout --url https://mcp.blockscout.com/mcp
+   ```
+
+2. Edit `~/.codex/config.toml` to add the PRO API key header and enable the streamable-HTTP MCP client (required for remote MCP servers to connect). The resulting configuration should look like this:
+
+   ```toml
+   [features]
+   experimental_use_rmcp_client = true
+
+   [mcp_servers.Blockscout]
+   url = "https://mcp.blockscout.com/mcp"
+   http_headers = { "Blockscout-MCP-Pro-Api-Key" = "proapi_your_key_here" }
+   ```
 
 ### Cursor Setup
 
-Use [this deeplink](https://cursor.com/en/install-mcp?name=blockscout&config=eyJ1cmwiOiJodHRwczovL21jcC5ibG9ja3Njb3V0LmNvbS9tY3AiLCJ0aW1lb3V0IjoxODAwMDB9) to install the Blockscout MCP server in Cursor.
+Add the server to your Cursor MCP configuration — either the project-level `.cursor/mcp.json` or the global `~/.cursor/mcp.json` — supplying your PRO API key via the `Blockscout-MCP-Pro-Api-Key` header:
 
-### Gemini CLI Setup
-
-1. Add the following configuration to your `~/.gemini/settings.json` file:
-
-    ```json
-    {
-      "mcpServers": {
-        "blockscout": {
-          "httpUrl": "https://mcp.blockscout.com/mcp",
-          "timeout": 180000
-        }
+```json
+{
+  "mcpServers": {
+    "blockscout": {
+      "url": "https://mcp.blockscout.com/mcp",
+      "timeout": 180000,
+      "headers": {
+        "Blockscout-MCP-Pro-Api-Key": "proapi_your_key_here"
       }
     }
-    ```
-
-2. For detailed Gemini CLI MCP server configuration instructions, see the [official documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md).
+  }
+}
+```
 
 ## Try Blockscout X-Ray GPT
 
@@ -217,13 +235,9 @@ To customize the leading part of the `User-Agent` header used for RPC requests,
 set the `BLOCKSCOUT_MCP_USER_AGENT` environment variable (defaults to
 "Blockscout MCP"). The server version is appended automatically.
 
-### Blockscout PRO API Key
+### Providing the PRO API Key to the Server
 
-The Blockscout PRO API key is required for Blockscout data access. Every data tool routes its requests through the authenticated Blockscout PRO API gateway, so without an effective key those tools fail fast before making any upstream request.
-
-Set the key to enable all data access, public-tag enrichment, and contract reads.
-
-To obtain one, create an account at https://dev.blockscout.com (the free tier does not require a credit card) and generate an API key in the portal; keys are prefixed `proapi_`. Provide it to the server via the `BLOCKSCOUT_PRO_API_KEY` environment variable — exported in your shell or placed in a gitignored `.env` file in the project root. Never commit the key or embed it in a client-shipped binary; when running via Docker, pass it at runtime (e.g. `-e BLOCKSCOUT_PRO_API_KEY=...`) rather than baking it into the image.
+When you run the server yourself, provide the [Blockscout PRO API key](#blockscout-pro-api-key) through the `BLOCKSCOUT_PRO_API_KEY` environment variable — exported in your shell or placed in a gitignored `.env` file in the project root. This enables all data access, public-tag enrichment, and contract reads. Never commit the key or embed it in a client-shipped binary; when running via Docker, pass it at runtime (e.g. `-e BLOCKSCOUT_PRO_API_KEY=...`) rather than baking it into the image.
 
 ```bash
 export BLOCKSCOUT_PRO_API_KEY=proapi_your_key_here
@@ -360,7 +374,7 @@ docker run --rm -p 8000:8000 ghcr.io/blockscout/mcp-server:latest python -m bloc
 
 **With a Blockscout PRO API Key:**
 
-Pass the key at runtime with `-e` rather than baking it into the image (see [Blockscout PRO API Key](#blockscout-pro-api-key)):
+Pass the key at runtime with `-e` rather than baking it into the image (see [Providing the PRO API Key to the Server](#providing-the-pro-api-key-to-the-server)):
 
 ```bash
 docker run --rm -p 8000:8000 -e BLOCKSCOUT_PRO_API_KEY=proapi_your_key_here \


### PR DESCRIPTION
## Summary

The `Claude Code`, `Codex CLI`, and `Cursor` setup sections of the README no longer reflected that a Blockscout PRO API key must be supplied when configuring the MCP server. This PR updates the client setup docs to treat the PRO API key as a required prerequisite and shows how each client passes it via the `Blockscout-MCP-Pro-Api-Key` header. It also removes the obsolete Gemini CLI section and aligns `API.md` with the "key is required for REST clients" model.

## README.md

- Add a **Blockscout PRO API Key** section at the top of *Configuring MCP Clients*, stating the requirement once and explaining how to obtain a key from the [Blockscout Developer Portal](https://dev.blockscout.com).
- **Claude Code** — add the `--header "Blockscout-MCP-Pro-Api-Key: …"` flag to `claude mcp add`.
- **Codex App** — add a step to set the header under the dialog's *Headers* section.
- **Codex CLI** — replace the one-liner with a two-step flow (scaffold via `codex mcp add`, then hand-edit `~/.codex/config.toml` to add `http_headers` and enable `experimental_use_rmcp_client`), because the CLI cannot attach a custom header.
- **Cursor** — switch from the install deeplink to a hand-edited `.cursor/mcp.json` carrying a `headers` object.
- **Gemini CLI** — section removed (product discontinued).
- Split the former *Blockscout PRO API Key* section: client-facing "how to obtain" moves to the top; the server-operator details (`BLOCKSCOUT_PRO_API_KEY` env var, Docker `-e`, client-supplied keys, low-credit warning) stay under the renamed **Providing the PRO API Key to the Server**.

## API.md

- Rewrite **Authentication**: the PRO API key is now required for REST clients via the `Blockscout-MCP-Pro-Api-Key` header; dropped the optional/server-fallback framing and the operator-only `BLOCKSCOUT_PRO_API_KEY_HEADER` detail (not meaningful to API consumers).
- Align the `402 Payment Required` wording with the per-request key model.

## Notes

- Docs-only change; no code touched.
- Header name and default verified against the server config (`Blockscout-MCP-Pro-Api-Key`, see `tests/test_config.py`).
- Per-agent header syntax verified against the official Claude Code, Codex CLI, and Cursor documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)