### PR TITLE
Bump agent-skills to latest dev and version to 0.16.0.dev21

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.16.0.dev20"
+__version__ = "0.16.0.dev21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.16.0.dev20"
+version = "0.16.0.dev21"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.16.0.dev20",
+  "version": "0.16.0.dev21",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",


### PR DESCRIPTION
## What changed

- **agent-skills submodule**: updated from `bdd3306` to `112b027` (head of the `dev` branch)
- **Version bump**: `0.16.0.dev20` → `0.16.0.dev21` across `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`

## Why

Pulls in the latest agent-skills changes (blockscout-analysis 0.6.0) and advances the dev version counter accordingly.

@coderabbitai ignore