### PR TITLE
chore: fix mcp-proxy --headers args

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ To use the official Blockscout MCP server with your own PRO API key in Claude De
             "--transport",
             "streamablehttp",
             "--headers",
-            "Blockscout-MCP-Pro-Api-Key: proapi_your_key_here",
+            "Blockscout-MCP-Pro-Api-Key",
+            "proapi_your_key_here",
+            "--headers",
+            "Blockscout-MCP-Intermediary",
+            "ClaudeDesktop",
             "https://mcp.blockscout.com/mcp"
           ]
         }

--- a/blockscout_mcp_server/templates/index.html
+++ b/blockscout_mcp_server/templates/index.html
@@ -113,7 +113,11 @@
         "--transport",
         "streamablehttp",
         "--headers",
-        "Blockscout-MCP-Pro-Api-Key: &lt;YOUR_BLOCKSCOUT_PRO_API_KEY&gt;",
+        "Blockscout-MCP-Pro-Api-Key",
+        "&lt;YOUR_BLOCKSCOUT_PRO_API_KEY&gt;",
+        "--headers",
+        "Blockscout-MCP-Intermediary",
+        "ClaudeDesktop",
         "https://mcp.blockscout.com/mcp"
       ]
     }


### PR DESCRIPTION
## Summary

- Split the combined `--headers "Key: value"` string into two separate array elements, as required by `sparfenyuk/mcp-proxy`
- Added `Blockscout-MCP-Intermediary: ClaudeDesktop` header to the Docker proxy config, matching the existing MCPB (`mcpb/manifest.json`) configuration

## Files changed

- `README.md` — Docker proxy snippet under "Claude Desktop" setup
- `blockscout_mcp_server/templates/index.html` — same snippet in the hosted landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore