### PR TITLE
Log and track resource-read requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ mcp-server/
 │   ├── analytics.py            # Centralized Mixpanel analytics for tool invocations (HTTP mode only)
 │   ├── telemetry.py            # Fire-and-forget community telemetry reporting
 │   ├── client_meta.py          # Shared client metadata extraction helpers and defaults
+│   ├── observability.py        # Resource-read observability helpers
 │   ├── pro_api_key_context.py  # Request-scoped client-supplied PRO API key state, resolver, and @pro_api_key_scope decorator; per-invocation credit sink and @pro_api_credit_scope decorator
 │   ├── cache.py                # Simple in-memory cache for chain data
 │   ├── web3_pool.py            # Async Web3 connection pool manager
@@ -132,6 +133,7 @@ mcp-server/
 │   ├── test_analytics_source.py  # Unit tests for analytics source detection
 │   ├── test_cache.py  # Unit tests for cache behavior
 │   ├── test_client_meta.py  # Unit tests for client metadata extraction
+│   ├── test_observability.py  # Unit tests for resource-read observability
 │   ├── test_pro_api_key_context.py  # Unit tests for client-supplied PRO API key resolution
 │   ├── test_hatch_build.py  # Unit tests for custom Hatch build hook helpers
 │   ├── test_instructions_data.py  # Unit tests for the InstructionsData payload model
@@ -385,11 +387,14 @@ mcp-server/
     * **`telemetry.py`**:
         * Sends anonymous usage reports from self-hosted servers when direct analytics are disabled.
         * Designed as fire-and-forget and never disrupts tool execution.
+    * **`observability.py`**:
+        * Provides `log_resource_read()`, the shared entry point for observing successful skill-resource reads (MCP resource channel and the REST `/skill` mirror).
     * **`client_meta.py`**:
         * Shared utilities for extracting client metadata (name, version, protocol, user_agent) from MCP Context.
         * Provides `ClientMeta` dataclass and `extract_client_meta_from_ctx()` function.
         * Falls back to User-Agent header when MCP client name is unavailable.
         * Ensures consistent sentinel defaults ("N/A", "Unknown") across logging and analytics modules.
+        * Also provides `format_client_meta_suffix()`, the shared client-metadata suffix formatter reused by tool-invocation and resource-read logging.
     * **`pro_api_key_context.py`**:
         * Owns request-scoped resolution of a client-supplied Blockscout PRO API key, kept separate from logging/observability.
         * Provides a `ContextVar` of the per-request client-key state, a normalization/validation helper, `extract_client_pro_api_key_from_ctx()`, `resolve_pro_api_key()` (precedence: valid client key → server key → not-configured error; malformed client key → terminal error, no fallback), and the `@pro_api_key_scope` decorator.

--- a/SPEC.md
+++ b/SPEC.md
@@ -937,6 +937,10 @@ Intent analytics should favor derived signals over raw text.
 - **Central Processing**: The central server receives this report, uses the sender's IP address for geolocation, and forwards the event to Mixpanel with the client metadata, protocol version, and a `source` property of `"community"`. This allows us to gather valuable aggregate statistics without requiring every user to have a Mixpanel account.
 - **Opt-Out**: This community reporting can be completely disabled by setting the `BLOCKSCOUT_DISABLE_COMMUNITY_TELEMETRY` environment variable to `true`.
 
+##### Resource-Read Observability
+
+Reads of the bundled `blockscout-analysis` skill — over both the MCP resource channel and the REST `/skill/{path}` mirror — are observed under the same analytics and telemetry model as tool invocations, so the two surfaces never drift apart in how usage is measured. Successful reads flow through the same dual-sink routing (direct analytics when a Mixpanel token is configured, community telemetry otherwise) and the same MCP-vs-REST source attribution as tools, but are recorded as a distinct event so resource reads stay separable from tool invocations. Only resolved reads are counted; an unknown or missing resource produces no signal, mirroring how an unknown tool is treated. Resource identifiers come from the fixed, public set of bundled-skill paths, so the existing privacy posture and the global telemetry opt-out apply unchanged.
+
 ### Smart Contract Interaction Tools
 
 This server exposes a tool for on-chain smart contract read-only state access. It uses the JSON-RPC `eth_call` semantics under the hood and aligns with the standardized `ToolResponse` model.

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.17.0"
+__version__ = "0.17.0.dev0"

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/blockscout_mcp_server/analytics.py
+++ b/blockscout_mcp_server/analytics.py
@@ -37,6 +37,7 @@ from blockscout_mcp_server.client_meta import (
     get_header_case_insensitive,
 )
 from blockscout_mcp_server.config import config
+from blockscout_mcp_server.constants import RESOURCE_READ_EVENT
 from blockscout_mcp_server.models import ToolUsageReport
 
 logger = logging.getLogger(__name__)
@@ -234,6 +235,21 @@ def track_tool_invocation(
             mp.track(distinct_id, tool_name, properties)
     except Exception as exc:  # pragma: no cover - do not break tool flow
         logger.debug("Mixpanel tracking failed for %s: %s", tool_name, exc)
+
+
+def track_resource_read(
+    ctx: Any,
+    uri: str,
+    client_meta: ClientMeta | None = None,
+) -> None:
+    """Track a resource read in Mixpanel, if enabled and in HTTP mode.
+
+    Delegates to :func:`track_tool_invocation` using the ``RESOURCE_READ`` event
+    sentinel so that all gating logic (HTTP-mode, token, IP extraction, etc.) is
+    reused verbatim.  The caller is responsible for providing a fully-normalised
+    URI string — this function does not stringify.
+    """
+    track_tool_invocation(ctx, RESOURCE_READ_EVENT, {"uri": uri}, client_meta=client_meta)
 
 
 def track_community_usage(report: ToolUsageReport, ip: str, user_agent: str) -> None:

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -85,6 +85,7 @@ async def serve_skill_resource(request: Request) -> Response:
     if body is None:
         return PlainTextResponse("Not Found", status_code=404)
 
+    # After the 404 guard → success-only, matching the MCP path; attributed to "rest".
     observability.log_resource_read(uri, get_mock_context(request))
     media_type = mimetypes.guess_type(path)[0] or "text/markdown"
     if path.endswith(".md"):

--- a/blockscout_mcp_server/api/routes.py
+++ b/blockscout_mcp_server/api/routes.py
@@ -11,7 +11,7 @@ from mcp.server.fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 
-from blockscout_mcp_server import analytics
+from blockscout_mcp_server import analytics, observability
 from blockscout_mcp_server.analytics import track_event
 from blockscout_mcp_server.api.dependencies import get_mock_context
 from blockscout_mcp_server.api.helpers import (
@@ -85,6 +85,7 @@ async def serve_skill_resource(request: Request) -> Response:
     if body is None:
         return PlainTextResponse("Not Found", status_code=404)
 
+    observability.log_resource_read(uri, get_mock_context(request))
     media_type = mimetypes.guess_type(path)[0] or "text/markdown"
     if path.endswith(".md"):
         media_type = "text/markdown"

--- a/blockscout_mcp_server/client_meta.py
+++ b/blockscout_mcp_server/client_meta.py
@@ -149,6 +149,21 @@ def extract_client_meta_from_ctx(ctx: Any) -> ClientMeta:
     )
 
 
+def format_client_meta_suffix(meta: ClientMeta) -> str:
+    """Return the parenthetical client-metadata suffix for a log line.
+
+    Produces ``(Client: {name}, Version: {version}, Protocol: {protocol})``
+    and, when ``meta.meta_dict`` is non-empty, appends ``, Meta: {meta_dict}``
+    before the closing parenthesis.  The returned string has **no leading
+    space**; the space before ``(`` belongs to the caller's prefix.
+    """
+    suffix = f"(Client: {meta.name}, Version: {meta.version}, Protocol: {meta.protocol}"
+    if meta.meta_dict:
+        suffix += f", Meta: {meta.meta_dict}"
+    suffix += ")"
+    return suffix
+
+
 def is_summary_content_client(meta: ClientMeta) -> bool:
     """Return True for clients that consume both content and structuredContent.
 

--- a/blockscout_mcp_server/constants.py
+++ b/blockscout_mcp_server/constants.py
@@ -21,6 +21,10 @@ SKILL_RESOLUTION_RULE_TEXT = (
 COMMUNITY_TELEMETRY_URL = "https://mcp.blockscout.com"
 COMMUNITY_TELEMETRY_ENDPOINT = "/v1/report_tool_usage"
 
+# Sentinel event name for MCP resource reads. UPPERCASE so it can never collide
+# with a tool function name (all tool names are snake_case/lowercase).
+RESOURCE_READ_EVENT = "RESOURCE_READ"
+
 ALLOW_LARGE_RESPONSE_HEADER = "X-Blockscout-Allow-Large-Response"
 
 TOOL_INVOCATION_STATUSES = {

--- a/blockscout_mcp_server/observability.py
+++ b/blockscout_mcp_server/observability.py
@@ -78,6 +78,16 @@ def log_resource_read(uri: Any, ctx: Any) -> None:
     # Step 3 — community-telemetry sink (fire-and-forget).  The separate guard
     # means an absent event loop or a scheduling failure can never raise into
     # the caller.
+    #
+    # The task reference is intentionally NOT retained. This is best-effort
+    # telemetry, and we deliberately mirror @log_tool_invocation's idiom
+    # (`asyncio.create_task(...)` inside try/except — tools/decorators.py) so the
+    # tool and resource observability paths never drift in implementation. Both
+    # production call sites — the async MCP `read_resource` override and the async
+    # REST `serve_skill_resource` handler — always run inside a live event loop,
+    # so the orphan-coroutine / no-loop path cannot occur there. Do NOT "fix" this
+    # to store the task or switch to get_running_loop() on this path alone (RUF006):
+    # that would re-introduce exactly the tool-vs-resource drift this feature prevents.
     try:
         asyncio.create_task(
             telemetry.send_community_resource_report(

--- a/blockscout_mcp_server/observability.py
+++ b/blockscout_mcp_server/observability.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Cross-cutting observability helper for MCP resource reads.
+
+Provides :func:`log_resource_read`, the single entry point called by both MCP
+resource-read and REST skill-mirror transports on a successful read.  It emits
+a structured INFO log line and fans out to the direct-analytics and
+community-telemetry sinks, mirroring the failure-isolation shape of
+:func:`~blockscout_mcp_server.tools.decorators.log_tool_invocation`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from blockscout_mcp_server import analytics, telemetry
+from blockscout_mcp_server.client_meta import (
+    UNDEFINED_CLIENT_NAME,
+    UNDEFINED_CLIENT_VERSION,
+    UNKNOWN_PROTOCOL_VERSION,
+    ClientMeta,
+    extract_client_meta_from_ctx,
+    format_client_meta_suffix,
+)
+from blockscout_mcp_server.resources import skill_resources
+
+logger = logging.getLogger(__name__)
+
+
+def log_resource_read(uri: Any, ctx: Any) -> None:
+    """Emit a log line and fan out to analytics/telemetry sinks on a successful resource read.
+
+    Parameters
+    ----------
+    uri:
+        The resource URI.  Accepts both ``str`` and pydantic ``AnyUrl`` — it is
+        normalised to ``str`` at the top of this helper so both sinks always
+        receive a JSON-serialisable value.
+    ctx:
+        The MCP context (or a REST mock context).  Passed through to the sinks
+        for client-metadata and IP extraction.
+    """
+    # Normalise to str once; AnyUrl is not JSON-serialisable.
+    full_uri = str(uri)
+
+    # Extract client metadata up-front.  extract_client_meta_from_ctx already
+    # self-guards, but wrap in a try/except so that a future regression never
+    # propagates into the request path; fall back to sentinel defaults so the
+    # read is still observed.
+    try:
+        meta: ClientMeta = extract_client_meta_from_ctx(ctx)
+    except Exception:
+        meta = ClientMeta(
+            UNDEFINED_CLIENT_NAME,
+            UNDEFINED_CLIENT_VERSION,
+            UNKNOWN_PROTOCOL_VERSION,
+            "",
+            {},
+        )
+
+    # Step 1 — human log line.  All label-derivation and formatting in its own
+    # guard so a failure here never skips the two sink steps below.
+    try:
+        rel = skill_resources.uri_to_relative_path(full_uri)
+        label = f"skill/{rel}" if rel is not None else full_uri
+        suffix = format_client_meta_suffix(meta)
+        logger.info("Resource read: %s %s", label, suffix)
+    except Exception:
+        pass
+
+    # Step 2 — direct analytics sink (self-gating, synchronous).
+    try:
+        analytics.track_resource_read(ctx, full_uri, client_meta=meta)
+    except Exception:
+        pass
+
+    # Step 3 — community-telemetry sink (fire-and-forget).  The separate guard
+    # means an absent event loop or a scheduling failure can never raise into
+    # the caller.
+    try:
+        asyncio.create_task(
+            telemetry.send_community_resource_report(
+                full_uri,
+                meta.name,
+                meta.version,
+                meta.protocol,
+            )
+        )
+    except Exception:
+        pass

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -202,6 +202,14 @@ class LoggingFastMCP(FastMCP):
     """FastMCP subclass that logs successful resource reads via the observability helper."""
 
     async def read_resource(self, uri):
+        # Log AFTER a successful super().read_resource(): on an unknown URI the SDK
+        # raises before this line, so misses are skipped automatically and we record
+        # success-only — the resource analog of how an unknown *tool* never logs
+        # (FastMCP rejects it before our code runs). This is why the timing differs
+        # from @log_tool_invocation, which logs the *attempt* before the body; for
+        # static in-memory skill resources the read cannot fail, so before-vs-after
+        # is immaterial. self.get_context() is still valid here — the low-level
+        # request contextvar is reset in _handle_request's finally, not on return.
         result = await super().read_resource(uri)
         observability.log_resource_read(uri, self.get_context())
         return result

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -12,7 +12,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
 from starlette.middleware.cors import CORSMiddleware
 
-from blockscout_mcp_server import analytics
+from blockscout_mcp_server import analytics, observability
 from blockscout_mcp_server.api.routes import register_api_routes
 from blockscout_mcp_server.client_meta import extract_client_meta_from_ctx, is_summary_content_client
 from blockscout_mcp_server.config import config
@@ -198,7 +198,16 @@ def _openai_tool_meta(tool_function) -> dict[str, str]:
     }
 
 
-mcp = FastMCP(
+class LoggingFastMCP(FastMCP):
+    """FastMCP subclass that logs successful resource reads via the observability helper."""
+
+    async def read_resource(self, uri):
+        result = await super().read_resource(uri)
+        observability.log_resource_read(uri, self.get_context())
+        return result
+
+
+mcp = LoggingFastMCP(
     name=SERVER_NAME,
     instructions=composed_instructions,
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 import json
 import logging
+from collections.abc import Iterable
 from functools import wraps
 from pathlib import Path
 from typing import Annotated
@@ -8,8 +9,10 @@ from typing import Annotated
 import typer
 import uvicorn
 from mcp.server.fastmcp import FastMCP
+from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
+from pydantic import AnyUrl
 from starlette.middleware.cors import CORSMiddleware
 
 from blockscout_mcp_server import analytics, observability
@@ -201,7 +204,10 @@ def _openai_tool_meta(tool_function) -> dict[str, str]:
 class LoggingFastMCP(FastMCP):
     """FastMCP subclass that logs successful resource reads via the observability helper."""
 
-    async def read_resource(self, uri):
+    async def read_resource(self, uri: AnyUrl | str) -> Iterable[ReadResourceContents]:
+        # NOTE: this hook fires for EVERY resource read, including any a tool might trigger
+        # internally via Context.read_resource — acknowledged, since there are no internal
+        # resource reads today and none are planned.
         # Log AFTER a successful super().read_resource(): on an unknown URI the SDK
         # raises before this line, so misses are skipped automatically and we record
         # success-only — the resource analog of how an unknown *tool* never logs

--- a/blockscout_mcp_server/telemetry.py
+++ b/blockscout_mcp_server/telemetry.py
@@ -8,6 +8,7 @@ from blockscout_mcp_server.config import config
 from blockscout_mcp_server.constants import (
     COMMUNITY_TELEMETRY_ENDPOINT,
     COMMUNITY_TELEMETRY_URL,
+    RESOURCE_READ_EVENT,
     SERVER_VERSION,
 )
 
@@ -44,3 +45,17 @@ async def send_community_usage_report(
         logger.debug("Community telemetry report sent for tool: %s", tool_name)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("Failed to send community telemetry report: %s", exc)
+
+
+async def send_community_resource_report(
+    uri: str,
+    client_name: str,
+    client_version: str,
+    protocol_version: str,
+) -> None:
+    """Send a fire-and-forget resource read report if in community telemetry mode.
+
+    Delegates to :func:`send_community_usage_report` using the ``RESOURCE_READ``
+    event sentinel so all gating and POST logic is reused verbatim.
+    """
+    await send_community_usage_report(RESOURCE_READ_EVENT, {"uri": uri}, client_name, client_version, protocol_version)

--- a/blockscout_mcp_server/tools/decorators.py
+++ b/blockscout_mcp_server/tools/decorators.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from blockscout_mcp_server import analytics, telemetry
-from blockscout_mcp_server.client_meta import extract_client_meta_from_ctx
+from blockscout_mcp_server.client_meta import extract_client_meta_from_ctx, format_client_meta_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -41,13 +41,7 @@ def log_tool_invocation(func: Callable[..., Awaitable[Any]]) -> Callable[..., Aw
             # Defensive: tracking must never break tool execution
             pass
 
-        log_message = (
-            f"Tool invoked: {func.__name__} with args: {arg_dict} "
-            f"(Client: {client_name}, Version: {client_version}, Protocol: {protocol_version}"
-        )
-        if meta.meta_dict:
-            log_message += f", Meta: {meta.meta_dict}"
-        log_message += ")"
+        log_message = f"Tool invoked: {func.__name__} with args: {arg_dict} " + format_client_meta_suffix(meta)
         logger.info(log_message)
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.17.0"
+version = "0.17.0.dev0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.16.0"
+version = "0.17.0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.17.0",
+  "version": "0.17.0.dev0",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/api/test_skill_resource_routes.py
+++ b/tests/api/test_skill_resource_routes.py
@@ -2,14 +2,40 @@
 """Tests for the bundled skill HTTP mirror."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from mcp.server.fastmcp import FastMCP
 
+from blockscout_mcp_server import analytics
+from blockscout_mcp_server.api import routes
 from blockscout_mcp_server.api.routes import register_api_routes
+from blockscout_mcp_server.config import config
 
 SKILL_ROOT = Path("agent-skills/blockscout-analysis")
+
+
+@pytest.fixture(autouse=True)
+def isolate_sinks(monkeypatch):
+    """Prevent live network calls to analytics and community-telemetry sinks.
+
+    The real log_resource_read fans out to two sinks that may make HTTP calls:
+    1. analytics.track_resource_read — fires when analytics HTTP mode is on and
+       mixpanel_token is set.
+    2. telemetry.send_community_resource_report — scheduled via asyncio.create_task;
+       makes an HTTP POST to the community endpoint unless
+       config.disable_community_telemetry is True.
+
+    This fixture closes both deterministically, independent of run order.
+    """
+    monkeypatch.setattr(config, "disable_community_telemetry", True, raising=False)
+    monkeypatch.setattr(config, "mixpanel_token", "", raising=False)
+    analytics.set_http_mode(False)
+    monkeypatch.setattr(analytics, "_mp_client", None, raising=False)
+    yield
+    analytics.set_http_mode(False)
+    monkeypatch.setattr(analytics, "_mp_client", None, raising=False)
 
 
 @pytest.fixture
@@ -98,3 +124,62 @@ async def test_v1_skill_returns_404(client: AsyncClient):
     response = await client.get("/v1/skill/SKILL.md")
 
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Observability tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_skill_md_success_emits_log(client: AsyncClient, caplog):
+    """A 200 response emits an INFO log line containing 'Resource read: skill/SKILL.md'."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
+        response = await client.get("/skill/SKILL.md")
+
+    assert response.status_code == 200
+    assert any("Resource read: skill/SKILL.md" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_skill_md_success_transport_attribution(client: AsyncClient):
+    """A 200 response calls log_resource_read with the canonical full URI and a REST context."""
+    with patch.object(routes.observability, "log_resource_read", new_callable=MagicMock) as mock_log:
+        response = await client.get("/skill/SKILL.md")
+
+    assert response.status_code == 200
+    mock_log.assert_called_once()
+    call_args = mock_log.call_args
+
+    # First arg: canonical full URI string
+    assert call_args[0][0] == "blockscout-mcp://skill/SKILL.md"
+
+    # Second arg: context with call_source="rest" and a live Starlette request
+    ctx = call_args[0][1]
+    assert ctx.call_source == "rest"
+    assert ctx.request_context is not None
+    assert ctx.request_context.request is not None
+
+
+@pytest.mark.asyncio
+async def test_404_path_emits_no_log(client: AsyncClient, caplog):
+    """A 404 response does not emit any 'Resource read:' log line."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
+        response = await client.get("/skill/README.md")
+
+    assert response.status_code == 404
+    assert not any("Resource read:" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_404_path_does_not_call_log_resource_read(client: AsyncClient):
+    """A 404 response does not call observability.log_resource_read at all."""
+    with patch.object(routes.observability, "log_resource_read", new_callable=MagicMock) as mock_log:
+        response = await client.get("/skill/does/not/exist.md")
+
+    assert response.status_code == 404
+    mock_log.assert_not_called()

--- a/tests/api/test_skill_resource_routes.py
+++ b/tests/api/test_skill_resource_routes.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Tests for the bundled skill HTTP mirror."""
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -134,8 +135,6 @@ async def test_v1_skill_returns_404(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_skill_md_success_emits_log(client: AsyncClient, caplog):
     """A 200 response emits an INFO log line containing 'Resource read: skill/SKILL.md'."""
-    import logging
-
     with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
         response = await client.get("/skill/SKILL.md")
 
@@ -166,8 +165,6 @@ async def test_skill_md_success_transport_attribution(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_404_path_emits_no_log(client: AsyncClient, caplog):
     """A 404 response does not emit any 'Resource read:' log line."""
-    import logging
-
     with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
         response = await client.get("/skill/README.md")
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -7,6 +7,7 @@ import pytest
 from blockscout_mcp_server import analytics
 from blockscout_mcp_server.analytics import ClientMeta
 from blockscout_mcp_server.config import config as server_config
+from blockscout_mcp_server.constants import RESOURCE_READ_EVENT
 from blockscout_mcp_server.models import ToolUsageReport
 
 
@@ -280,3 +281,53 @@ def test_track_community_usage(monkeypatch):
         assert properties["client_version"] == "1.0"
         assert properties["protocol_version"] == "1.1"
         assert kwargs.get("meta") == {"ip": "203.0.113.5"}
+
+
+# ---------------------------------------------------------------------------
+# track_resource_read tests
+# ---------------------------------------------------------------------------
+
+
+def test_track_resource_read_noop_when_not_http_mode(monkeypatch):
+    """No Mixpanel call when HTTP mode is disabled."""
+    monkeypatch.setattr(server_config, "mixpanel_token", "test-token", raising=False)
+    with patch("blockscout_mcp_server.analytics.Mixpanel") as mp_cls:
+        analytics.track_resource_read(DummyCtx(), "blockscout-mcp://skill/SKILL.md")
+        mp_cls.assert_not_called()
+
+
+def test_track_resource_read_noop_when_no_token(monkeypatch):
+    """No Mixpanel call when HTTP mode is on but no token is configured."""
+    monkeypatch.setattr(server_config, "mixpanel_token", "", raising=False)
+    analytics.set_http_mode(True)
+    with patch("blockscout_mcp_server.analytics.Mixpanel") as mp_cls:
+        analytics.track_resource_read(DummyCtx(), "blockscout-mcp://skill/SKILL.md")
+        mp_cls.assert_not_called()
+
+
+def test_track_resource_read_emits_correct_event(monkeypatch):
+    """When enabled, mp.track is called with RESOURCE_READ event and uri in tool_args."""
+    monkeypatch.setattr(server_config, "mixpanel_token", "test-token", raising=False)
+    uri = "blockscout-mcp://skill/SKILL.md"
+    headers = {"x-forwarded-for": "203.0.113.5", "user-agent": "pytest-UA"}
+    req = DummyRequest(headers=headers)
+    ctx = DummyCtx(request=req, client_name="clientA", client_version="1.0.0")
+    with patch("blockscout_mcp_server.analytics.Mixpanel") as mp_cls:
+        mp_instance = MagicMock()
+        mp_cls.return_value = mp_instance
+        analytics.set_http_mode(True)
+        analytics.track_resource_read(
+            ctx,
+            uri,
+            client_meta=ClientMeta(name="clientA", version="1.0.0", protocol="2024-11-05", user_agent="pytest-UA"),
+        )
+        mp_instance.track.assert_called_once()
+        args, kwargs = mp_instance.track.call_args
+        assert args[1] == RESOURCE_READ_EVENT
+        properties = args[2]
+        assert properties["tool_args"] == {"uri": uri}
+        assert properties["client_name"] == "clientA"
+        assert properties["client_version"] == "1.0.0"
+        assert properties["protocol_version"] == "2024-11-05"
+        assert properties["ip"] == "203.0.113.5"
+        assert "source" in properties

--- a/tests/test_client_meta.py
+++ b/tests/test_client_meta.py
@@ -10,6 +10,7 @@ from blockscout_mcp_server.client_meta import (
     ClientMeta,
     _parse_intermediary_header,
     extract_client_meta_from_ctx,
+    format_client_meta_suffix,
     get_header_case_insensitive,
     is_summary_content_client,
 )
@@ -253,3 +254,36 @@ def test_is_summary_content_client_false_for_partial_openai_match() -> None:
     meta = ClientMeta(name="n", version="v", protocol="p", user_agent="", meta_dict={"not-openai/foo": "bar"})
 
     assert is_summary_content_client(meta) is False
+
+
+# ---------------------------------------------------------------------------
+# format_client_meta_suffix tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_client_meta_suffix_no_meta_dict() -> None:
+    """Empty meta_dict produces suffix without Meta: clause."""
+    meta = ClientMeta(name="my-client", version="2.0.0", protocol="2024-11-05", user_agent="", meta_dict={})
+    result = format_client_meta_suffix(meta)
+    assert result == "(Client: my-client, Version: 2.0.0, Protocol: 2024-11-05)"
+
+
+def test_format_client_meta_suffix_with_meta_dict() -> None:
+    """Populated meta_dict appends ', Meta: {meta_dict}' before closing paren."""
+    meta_dict = {"openai/userAgent": "ChatGPT/1.0"}
+    meta = ClientMeta(name="my-client", version="2.0.0", protocol="2024-11-05", user_agent="", meta_dict=meta_dict)
+    result = format_client_meta_suffix(meta)
+    assert result == f"(Client: my-client, Version: 2.0.0, Protocol: 2024-11-05, Meta: {meta_dict})"
+
+
+def test_format_client_meta_suffix_sentinel_defaults() -> None:
+    """A ClientMeta at sentinel defaults renders the N/A / Unknown values."""
+    meta = ClientMeta(
+        name=UNDEFINED_CLIENT_NAME,
+        version=UNDEFINED_CLIENT_VERSION,
+        protocol=UNKNOWN_PROTOCOL_VERSION,
+        user_agent="",
+        meta_dict={},
+    )
+    result = format_client_meta_suffix(meta)
+    assert result == "(Client: N/A, Version: N/A, Protocol: Unknown)"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Unit tests for blockscout_mcp_server.observability.log_resource_read."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import AnyUrl
+
+from blockscout_mcp_server.client_meta import (
+    UNDEFINED_CLIENT_NAME,
+    UNDEFINED_CLIENT_VERSION,
+    UNKNOWN_PROTOCOL_VERSION,
+    ClientMeta,
+    format_client_meta_suffix,
+)
+from blockscout_mcp_server.observability import log_resource_read
+
+_SKILL_URI = "blockscout-mcp://skill/SKILL.md"
+_LOGGER_NAME = "blockscout_mcp_server.observability"
+
+
+def _make_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.session = None
+    ctx.request_context = None
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Log format
+# ---------------------------------------------------------------------------
+
+
+def test_log_format_emits_info_with_label_and_suffix(caplog):
+    """An INFO record contains 'Resource read: skill/SKILL.md' and the client suffix."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
+    ctx = _make_ctx()
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read"),
+        patch("blockscout_mcp_server.observability.telemetry.send_community_resource_report", new_callable=AsyncMock),
+        patch("blockscout_mcp_server.observability.asyncio.create_task"),
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME and r.levelno == logging.INFO]
+    assert records, "Expected at least one INFO record from the observability logger"
+    msg = records[0].getMessage()
+    assert "Resource read: skill/SKILL.md" in msg
+    # When ctx has no session/request, suffix is the N/A defaults.
+    expected_suffix = format_client_meta_suffix(
+        ClientMeta(UNDEFINED_CLIENT_NAME, UNDEFINED_CLIENT_VERSION, UNKNOWN_PROTOCOL_VERSION, "", {})
+    )
+    assert expected_suffix in msg
+
+
+# ---------------------------------------------------------------------------
+# URI normalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_uri_normalisation_anyurl_becomes_str():
+    """AnyUrl passed to log_resource_read is normalised to a plain str for the sinks."""
+    any_url = AnyUrl(_SKILL_URI)
+    ctx = _make_ctx()
+    captured: list[str] = []
+
+    def fake_track(ctx_, uri_, client_meta=None):
+        captured.append(uri_)
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read", side_effect=fake_track),
+        patch("blockscout_mcp_server.observability.asyncio.create_task"),
+    ):
+        log_resource_read(any_url, ctx)
+
+    assert captured, "track_resource_read was not called"
+    assert isinstance(captured[0], str), "URI forwarded to analytics must be a plain str"
+    assert captured[0] == _SKILL_URI
+
+
+# ---------------------------------------------------------------------------
+# Fan-out: both sinks are invoked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fan_out_both_sinks_called():
+    """Both analytics.track_resource_read and telemetry.send_community_resource_report are invoked."""
+    ctx = _make_ctx()
+
+    mock_community = AsyncMock()
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
+        patch(
+            "blockscout_mcp_server.observability.telemetry.send_community_resource_report",
+            return_value=mock_community(),
+        ),
+        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+        # Drain tasks
+        await asyncio.sleep(0)
+
+    mock_track.assert_called_once()
+    call_args = mock_track.call_args
+    forwarded_uri = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("uri")
+    assert forwarded_uri == _SKILL_URI
+    mock_create_task.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Error swallowing — no exception propagates
+# ---------------------------------------------------------------------------
+
+
+def test_no_exception_propagates_when_extract_meta_raises(monkeypatch):
+    """log_resource_read does not propagate when extract_client_meta_from_ctx raises."""
+    monkeypatch.setattr(
+        "blockscout_mcp_server.observability.extract_client_meta_from_ctx",
+        lambda ctx: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    ctx = _make_ctx()
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read"),
+        patch("blockscout_mcp_server.observability.asyncio.create_task"),
+    ):
+        log_resource_read(_SKILL_URI, ctx)  # must not raise
+
+
+def test_no_exception_propagates_when_analytics_raises(monkeypatch):
+    """log_resource_read does not propagate when track_resource_read raises."""
+    monkeypatch.setattr(
+        "blockscout_mcp_server.observability.analytics.track_resource_read",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("analytics boom")),
+    )
+    ctx = _make_ctx()
+    with patch("blockscout_mcp_server.observability.asyncio.create_task"):
+        log_resource_read(_SKILL_URI, ctx)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation across sinks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analytics_failure_does_not_suppress_community_report(caplog):
+    """When analytics.track_resource_read raises, the community-telemetry sink is still scheduled."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
+    ctx = _make_ctx()
+
+    def exploding_track(*args, **kwargs):
+        raise RuntimeError("analytics exploded")
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read", side_effect=exploding_track),
+        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+        await asyncio.sleep(0)
+
+    mock_create_task.assert_called_once()
+    # Log line must still have been emitted
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME and r.levelno == logging.INFO]
+    assert any("Resource read:" in r.getMessage() for r in records)
+
+
+@pytest.mark.asyncio
+async def test_community_failure_does_not_suppress_analytics(caplog):
+    """When create_task (community telemetry) raises, analytics and log line are still produced."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
+    ctx = _make_ctx()
+
+    def exploding_create_task(*args, **kwargs):
+        raise RuntimeError("create_task exploded")
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=exploding_create_task),
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+        await asyncio.sleep(0)
+
+    mock_track.assert_called_once()
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME and r.levelno == logging.INFO]
+    assert any("Resource read:" in r.getMessage() for r in records)
+
+
+# ---------------------------------------------------------------------------
+# Metadata-extraction fallback: sentinel metadata, both sinks still attempted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metadata_extraction_failure_still_observes_read(caplog, monkeypatch):
+    """When extract_client_meta_from_ctx raises, log line + both sinks are still attempted."""
+    caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
+
+    def raising_extractor(ctx):
+        raise RuntimeError("extractor failure")
+
+    monkeypatch.setattr("blockscout_mcp_server.observability.extract_client_meta_from_ctx", raising_extractor)
+    ctx = _make_ctx()
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
+        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+        await asyncio.sleep(0)
+
+    # Log line must be emitted
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME and r.levelno == logging.INFO]
+    assert any("Resource read:" in r.getMessage() for r in records), (
+        "Log line must be emitted even on extractor failure"
+    )
+
+    # Both sinks must be attempted
+    mock_track.assert_called_once()
+    mock_create_task.assert_called_once()
+
+    # Sinks should receive the sentinel metadata
+    call_args = mock_track.call_args
+    meta_arg = call_args.kwargs.get("client_meta") or (call_args.args[2] if len(call_args.args) > 2 else None)
+    assert meta_arg is not None
+    assert meta_arg.name == UNDEFINED_CLIENT_NAME
+    assert meta_arg.version == UNDEFINED_CLIENT_VERSION
+    assert meta_arg.protocol == UNKNOWN_PROTOCOL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Log-preparation/emission isolation: log block failure still leaves both sinks attempted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_block_failure_still_attempts_both_sinks(monkeypatch):
+    """When uri_to_relative_path raises (inside the log block), both sinks are still attempted."""
+    monkeypatch.setattr(
+        "blockscout_mcp_server.observability.skill_resources.uri_to_relative_path",
+        lambda uri: (_ for _ in ()).throw(RuntimeError("path resolution failure")),
+    )
+    ctx = _make_ctx()
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
+        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+        await asyncio.sleep(0)
+
+    mock_track.assert_called_once()
+    call_args = mock_track.call_args
+    # Full URI string must be forwarded, not a label-relative form
+    assert call_args.args[1] == _SKILL_URI or call_args.kwargs.get("uri") == _SKILL_URI
+    mock_create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_format_suffix_failure_still_attempts_both_sinks(monkeypatch):
+    """When format_client_meta_suffix raises, both sinks are still attempted."""
+    monkeypatch.setattr(
+        "blockscout_mcp_server.observability.format_client_meta_suffix",
+        lambda meta: (_ for _ in ()).throw(RuntimeError("format failure")),
+    )
+    ctx = _make_ctx()
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
+        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+        await asyncio.sleep(0)
+
+    mock_track.assert_called_once()
+    mock_create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_logger_info_failure_still_attempts_both_sinks(monkeypatch):
+    """When logger.info raises, both sinks are still attempted."""
+    monkeypatch.setattr(
+        "blockscout_mcp_server.observability.logger",
+        MagicMock(info=MagicMock(side_effect=RuntimeError("logger failure"))),
+    )
+    ctx = _make_ctx()
+
+    with (
+        patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
+        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+    ):
+        log_resource_read(_SKILL_URI, ctx)
+        await asyncio.sleep(0)
+
+    mock_track.assert_called_once()
+    call_args = mock_track.call_args
+    assert call_args.args[1] == _SKILL_URI
+    mock_create_task.assert_called_once()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -3,11 +3,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-import pytest
 from pydantic import AnyUrl
 
 from blockscout_mcp_server.client_meta import (
@@ -21,6 +19,23 @@ from blockscout_mcp_server.observability import log_resource_read
 
 _SKILL_URI = "blockscout-mcp://skill/SKILL.md"
 _LOGGER_NAME = "blockscout_mcp_server.observability"
+
+
+# Invariant for this module — avoiding "coroutine was never awaited" RuntimeWarnings.
+#
+# log_resource_read schedules the community-telemetry sink via
+# ``asyncio.create_task(telemetry.send_community_resource_report(...))``. The coroutine
+# argument is constructed *before* create_task runs, so handing a live coroutine to a
+# mocked create_task orphans it -> RuntimeWarning. The safe idiom used throughout this
+# module: patch create_task with ``side_effect=_close_coro`` so the constructed coroutine
+# is finalized instead of scheduled — deterministic, needs no event loop, and the sink
+# body never executes. The one exception is the test that makes create_task itself
+# *raise*: there the coroutine is built before create_task is reached, so that test
+# patches the sink as a plain MagicMock (a non-coroutine) so nothing is ever constructed.
+def _close_coro(coro):
+    """create_task side_effect: finalize the would-be-scheduled coroutine instead of
+    running it, so no 'coroutine was never awaited' warning is emitted."""
+    coro.close()
 
 
 def _make_ctx() -> MagicMock:
@@ -42,8 +57,7 @@ def test_log_format_emits_info_with_label_and_suffix(caplog):
 
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read"),
-        patch("blockscout_mcp_server.observability.telemetry.send_community_resource_report", new_callable=AsyncMock),
-        patch("blockscout_mcp_server.observability.asyncio.create_task"),
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro),
     ):
         log_resource_read(_SKILL_URI, ctx)
 
@@ -63,8 +77,7 @@ def test_log_format_emits_info_with_label_and_suffix(caplog):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_uri_normalisation_anyurl_becomes_str():
+def test_uri_normalisation_anyurl_becomes_str():
     """AnyUrl passed to log_resource_read is normalised to a plain str for the sinks."""
     any_url = AnyUrl(_SKILL_URI)
     ctx = _make_ctx()
@@ -75,7 +88,7 @@ async def test_uri_normalisation_anyurl_becomes_str():
 
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read", side_effect=fake_track),
-        patch("blockscout_mcp_server.observability.asyncio.create_task"),
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro),
     ):
         log_resource_read(any_url, ctx)
 
@@ -89,29 +102,21 @@ async def test_uri_normalisation_anyurl_becomes_str():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_fan_out_both_sinks_called():
+def test_fan_out_both_sinks_called():
     """Both analytics.track_resource_read and telemetry.send_community_resource_report are invoked."""
     ctx = _make_ctx()
 
-    mock_community = AsyncMock()
-
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
-        patch(
-            "blockscout_mcp_server.observability.telemetry.send_community_resource_report",
-            return_value=mock_community(),
-        ),
-        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro) as mock_create_task,
     ):
         log_resource_read(_SKILL_URI, ctx)
-        # Drain tasks
-        await asyncio.sleep(0)
 
     mock_track.assert_called_once()
     call_args = mock_track.call_args
     forwarded_uri = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("uri")
     assert forwarded_uri == _SKILL_URI
+    # The community-telemetry sink coroutine was constructed and handed to create_task.
     mock_create_task.assert_called_once()
 
 
@@ -129,7 +134,7 @@ def test_no_exception_propagates_when_extract_meta_raises(monkeypatch):
     ctx = _make_ctx()
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read"),
-        patch("blockscout_mcp_server.observability.asyncio.create_task"),
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro),
     ):
         log_resource_read(_SKILL_URI, ctx)  # must not raise
 
@@ -141,7 +146,7 @@ def test_no_exception_propagates_when_analytics_raises(monkeypatch):
         lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("analytics boom")),
     )
     ctx = _make_ctx()
-    with patch("blockscout_mcp_server.observability.asyncio.create_task"):
+    with patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro):
         log_resource_read(_SKILL_URI, ctx)  # must not raise
 
 
@@ -150,8 +155,7 @@ def test_no_exception_propagates_when_analytics_raises(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_analytics_failure_does_not_suppress_community_report(caplog):
+def test_analytics_failure_does_not_suppress_community_report(caplog):
     """When analytics.track_resource_read raises, the community-telemetry sink is still scheduled."""
     caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     ctx = _make_ctx()
@@ -161,10 +165,9 @@ async def test_analytics_failure_does_not_suppress_community_report(caplog):
 
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read", side_effect=exploding_track),
-        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro) as mock_create_task,
     ):
         log_resource_read(_SKILL_URI, ctx)
-        await asyncio.sleep(0)
 
     mock_create_task.assert_called_once()
     # Log line must still have been emitted
@@ -172,8 +175,7 @@ async def test_analytics_failure_does_not_suppress_community_report(caplog):
     assert any("Resource read:" in r.getMessage() for r in records)
 
 
-@pytest.mark.asyncio
-async def test_community_failure_does_not_suppress_analytics(caplog):
+def test_community_failure_does_not_suppress_analytics(caplog):
     """When create_task (community telemetry) raises, analytics and log line are still produced."""
     caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
     ctx = _make_ctx()
@@ -181,12 +183,19 @@ async def test_community_failure_does_not_suppress_analytics(caplog):
     def exploding_create_task(*args, **kwargs):
         raise RuntimeError("create_task exploded")
 
+    # Idiom (B): create_task itself raises -> patch the sink as a plain MagicMock so the
+    # coroutine is never constructed before create_task is invoked. new_callable=MagicMock
+    # is required: send_community_resource_report is an async def, so a bare patch() would
+    # auto-create an AsyncMock whose call yields an (orphaned) coroutine.
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
+        patch(
+            "blockscout_mcp_server.observability.telemetry.send_community_resource_report",
+            new_callable=MagicMock,
+        ),
         patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=exploding_create_task),
     ):
         log_resource_read(_SKILL_URI, ctx)
-        await asyncio.sleep(0)
 
     mock_track.assert_called_once()
     records = [r for r in caplog.records if r.name == _LOGGER_NAME and r.levelno == logging.INFO]
@@ -198,8 +207,7 @@ async def test_community_failure_does_not_suppress_analytics(caplog):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_metadata_extraction_failure_still_observes_read(caplog, monkeypatch):
+def test_metadata_extraction_failure_still_observes_read(caplog, monkeypatch):
     """When extract_client_meta_from_ctx raises, log line + both sinks are still attempted."""
     caplog.set_level(logging.INFO, logger=_LOGGER_NAME)
 
@@ -211,10 +219,9 @@ async def test_metadata_extraction_failure_still_observes_read(caplog, monkeypat
 
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
-        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro) as mock_create_task,
     ):
         log_resource_read(_SKILL_URI, ctx)
-        await asyncio.sleep(0)
 
     # Log line must be emitted
     records = [r for r in caplog.records if r.name == _LOGGER_NAME and r.levelno == logging.INFO]
@@ -240,8 +247,7 @@ async def test_metadata_extraction_failure_still_observes_read(caplog, monkeypat
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_log_block_failure_still_attempts_both_sinks(monkeypatch):
+def test_log_block_failure_still_attempts_both_sinks(monkeypatch):
     """When uri_to_relative_path raises (inside the log block), both sinks are still attempted."""
     monkeypatch.setattr(
         "blockscout_mcp_server.observability.skill_resources.uri_to_relative_path",
@@ -251,10 +257,9 @@ async def test_log_block_failure_still_attempts_both_sinks(monkeypatch):
 
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
-        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro) as mock_create_task,
     ):
         log_resource_read(_SKILL_URI, ctx)
-        await asyncio.sleep(0)
 
     mock_track.assert_called_once()
     call_args = mock_track.call_args
@@ -263,8 +268,7 @@ async def test_log_block_failure_still_attempts_both_sinks(monkeypatch):
     mock_create_task.assert_called_once()
 
 
-@pytest.mark.asyncio
-async def test_format_suffix_failure_still_attempts_both_sinks(monkeypatch):
+def test_format_suffix_failure_still_attempts_both_sinks(monkeypatch):
     """When format_client_meta_suffix raises, both sinks are still attempted."""
     monkeypatch.setattr(
         "blockscout_mcp_server.observability.format_client_meta_suffix",
@@ -274,17 +278,15 @@ async def test_format_suffix_failure_still_attempts_both_sinks(monkeypatch):
 
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
-        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro) as mock_create_task,
     ):
         log_resource_read(_SKILL_URI, ctx)
-        await asyncio.sleep(0)
 
     mock_track.assert_called_once()
     mock_create_task.assert_called_once()
 
 
-@pytest.mark.asyncio
-async def test_logger_info_failure_still_attempts_both_sinks(monkeypatch):
+def test_logger_info_failure_still_attempts_both_sinks(monkeypatch):
     """When logger.info raises, both sinks are still attempted."""
     monkeypatch.setattr(
         "blockscout_mcp_server.observability.logger",
@@ -294,10 +296,9 @@ async def test_logger_info_failure_still_attempts_both_sinks(monkeypatch):
 
     with (
         patch("blockscout_mcp_server.observability.analytics.track_resource_read") as mock_track,
-        patch("blockscout_mcp_server.observability.asyncio.create_task") as mock_create_task,
+        patch("blockscout_mcp_server.observability.asyncio.create_task", side_effect=_close_coro) as mock_create_task,
     ):
         log_resource_read(_SKILL_URI, ctx)
-        await asyncio.sleep(0)
 
     mock_track.assert_called_once()
     call_args = mock_track.call_args

--- a/tests/test_skill_resources_server.py
+++ b/tests/test_skill_resources_server.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Tests for server registration of bundled skill resources."""
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -63,8 +64,6 @@ async def test_server_read_unknown_resource_raises_not_found():
 @pytest.mark.asyncio
 async def test_successful_read_emits_resource_read_log(caplog):
     """Successful resource read emits an INFO line containing 'Resource read: skill/SKILL.md'."""
-    import logging
-
     with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
         await mcp.read_resource("blockscout-mcp://skill/SKILL.md")
 
@@ -74,8 +73,6 @@ async def test_successful_read_emits_resource_read_log(caplog):
 @pytest.mark.asyncio
 async def test_unknown_resource_emits_no_resource_read_log(caplog):
     """Unknown resource read raises and emits no 'Resource read:' log line."""
-    import logging
-
     with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
         with pytest.raises(ValueError, match="Unknown resource"):
             await mcp.read_resource("blockscout-mcp://skill/README.md")

--- a/tests/test_skill_resources_server.py
+++ b/tests/test_skill_resources_server.py
@@ -2,11 +2,30 @@
 """Tests for server registration of bundled skill resources."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from blockscout_mcp_server import analytics
+from blockscout_mcp_server.config import config
 from blockscout_mcp_server.resources import skill_resources
 from blockscout_mcp_server.server import mcp
+
+
+@pytest.fixture(autouse=True)
+def isolate_sinks(monkeypatch):
+    """Close both analytics/telemetry sinks for every test in this module.
+
+    Prevents live network calls to the community endpoint and Mixpanel,
+    independent of run order and environment.
+    """
+    monkeypatch.setattr(config, "disable_community_telemetry", True, raising=False)
+    monkeypatch.setattr(config, "mixpanel_token", "", raising=False)
+    analytics.set_http_mode(False)
+    monkeypatch.setattr(analytics, "_mp_client", None, raising=False)
+    yield
+    analytics.set_http_mode(False)
+    monkeypatch.setattr(analytics, "_mp_client", None, raising=False)
 
 
 @pytest.mark.asyncio
@@ -39,3 +58,41 @@ async def test_server_reads_reference_content_from_disk():
 async def test_server_read_unknown_resource_raises_not_found():
     with pytest.raises(ValueError, match="Unknown resource"):
         await mcp.read_resource("blockscout-mcp://skill/README.md")
+
+
+@pytest.mark.asyncio
+async def test_successful_read_emits_resource_read_log(caplog):
+    """Successful resource read emits an INFO line containing 'Resource read: skill/SKILL.md'."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
+        await mcp.read_resource("blockscout-mcp://skill/SKILL.md")
+
+    assert any("Resource read: skill/SKILL.md" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_unknown_resource_emits_no_resource_read_log(caplog):
+    """Unknown resource read raises and emits no 'Resource read:' log line."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="blockscout_mcp_server.observability"):
+        with pytest.raises(ValueError, match="Unknown resource"):
+            await mcp.read_resource("blockscout-mcp://skill/README.md")
+
+    assert not any("Resource read:" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_read_resource_override_calls_helper_with_correct_args(monkeypatch):
+    """Override forwards the correct URI and context into the shared observability helper."""
+    sentinel_ctx = object()
+    monkeypatch.setattr(mcp, "get_context", lambda: sentinel_ctx)
+
+    with patch("blockscout_mcp_server.server.observability.log_resource_read") as mock_helper:
+        await mcp.read_resource("blockscout-mcp://skill/SKILL.md")
+
+    mock_helper.assert_called_once()
+    call_args = mock_helper.call_args
+    assert str(call_args[0][0]) == "blockscout-mcp://skill/SKILL.md"
+    assert call_args[0][1] is sentinel_ctx

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -8,6 +8,7 @@ from blockscout_mcp_server.config import config
 from blockscout_mcp_server.constants import (
     COMMUNITY_TELEMETRY_ENDPOINT,
     COMMUNITY_TELEMETRY_URL,
+    RESOURCE_READ_EVENT,
 )
 
 
@@ -66,4 +67,73 @@ async def test_send_community_usage_report_network_error(monkeypatch):
     mock_ctx_mgr.__aenter__.return_value = mock_client
     with patch("httpx.AsyncClient", return_value=mock_ctx_mgr):
         await telemetry.send_community_usage_report("tool", {}, "client", "1.0", "1.1")
+        mock_client.post.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# send_community_resource_report tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_community_resource_report_sent(monkeypatch):
+    """Payload is sent with tool_name == RESOURCE_READ and uri in tool_args."""
+    monkeypatch.setattr(config, "disable_community_telemetry", False, raising=False)
+    monkeypatch.setattr(config, "mixpanel_token", "", raising=False)
+    uri = "blockscout-mcp://skill/SKILL.md"
+    mock_client = AsyncMock()
+    mock_ctx_mgr = AsyncMock()
+    mock_ctx_mgr.__aenter__.return_value = mock_client
+    with patch("httpx.AsyncClient", return_value=mock_ctx_mgr):
+        await telemetry.send_community_resource_report(uri, "client", "1.0", "1.1")
+        url = f"{COMMUNITY_TELEMETRY_URL}{COMMUNITY_TELEMETRY_ENDPOINT}"
+        mock_client.post.assert_awaited_once_with(
+            url,
+            json={
+                "tool_name": RESOURCE_READ_EVENT,
+                "tool_args": {"uri": uri},
+                "client_name": "client",
+                "client_version": "1.0",
+                "protocol_version": "1.1",
+            },
+            headers=ANY,
+            timeout=2.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_community_resource_report_suppressed_when_disabled(monkeypatch):
+    """No HTTP call when community telemetry is disabled."""
+    monkeypatch.setattr(config, "disable_community_telemetry", True, raising=False)
+    with patch("httpx.AsyncClient", AsyncMock()) as mock_ac:
+        await telemetry.send_community_resource_report("blockscout-mcp://skill/SKILL.md", "c", "1.0", "1.1")
+        mock_ac.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_community_resource_report_suppressed_in_direct_mode(monkeypatch):
+    """No HTTP call when HTTP mode is on and Mixpanel token is set (direct mode)."""
+    monkeypatch.setattr(config, "disable_community_telemetry", False, raising=False)
+    monkeypatch.setattr(config, "mixpanel_token", "token", raising=False)
+    analytics.set_http_mode(True)
+    try:
+        with patch("httpx.AsyncClient", AsyncMock()) as mock_ac:
+            await telemetry.send_community_resource_report("blockscout-mcp://skill/SKILL.md", "c", "1.0", "1.1")
+            mock_ac.assert_not_called()
+    finally:
+        analytics.set_http_mode(False)
+
+
+@pytest.mark.asyncio
+async def test_send_community_resource_report_network_error_swallowed(monkeypatch):
+    """Network errors during POST do not propagate."""
+    monkeypatch.setattr(config, "disable_community_telemetry", False, raising=False)
+    monkeypatch.setattr(config, "mixpanel_token", "", raising=False)
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = Exception("network failure")
+    mock_ctx_mgr = AsyncMock()
+    mock_ctx_mgr.__aenter__.return_value = mock_client
+    with patch("httpx.AsyncClient", return_value=mock_ctx_mgr):
+        # Must not raise
+        await telemetry.send_community_resource_report("blockscout-mcp://skill/SKILL.md", "c", "1.0", "1.1")
         mock_client.post.assert_awaited_once()

--- a/tests/tools/test_decorators.py
+++ b/tests/tools/test_decorators.py
@@ -90,6 +90,11 @@ async def test_log_tool_invocation_mcp_context(caplog: pytest.LogCaptureFixture,
     assert "Tool invoked: dummy_tool" in log_text
     assert "with args: {'a': 1}" in log_text
     assert "(Client: test-client, Version: 1.2.3, Protocol: 2024-11-05)" in log_text
+    # Exact full-message assertion: ensures byte-identical output (catches double spaces, stray text, etc.)
+    assert (
+        caplog.records[-1].getMessage()
+        == "Tool invoked: dummy_tool with args: {'a': 1} (Client: test-client, Version: 1.2.3, Protocol: 2024-11-05)"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds observability for **resource-read requests** (skill resources), mirroring the existing tool-invocation tracking across both the MCP and REST surfaces. When a resource is successfully read, the server now emits a `Resource read: <label>` log line and fans the event out to both analytics sinks.

Closes #418.

## What changed

Implemented phase-by-phase (one commit per phase):

1. **Shared client-metadata suffix formatter** — extracted `format_client_meta_suffix()` into `client_meta.py` and refactored the tool-invocation decorator to use it. The existing tool-invocation log line is **byte-identical** (regression test added).
2. **Resource-read event + reporting-sink wrappers** — new `RESOURCE_READ` constant plus `track_resource_read()` (Mixpanel/direct) and `send_community_resource_report()` (community telemetry) wrappers. No call sites wired in this phase.
3. **Cross-cutting observability helper** — new `blockscout_mcp_server/observability.py` with `log_resource_read(uri, ctx)`: normalizes the URI, logs the read line, and fires both sinks with **per-step error isolation** (a failing sink never breaks the read or the other sink; telemetry is fire-and-forget).
4. **MCP resource-read path wiring** — a `LoggingFastMCP(FastMCP)` subclass overrides `read_resource` to log on the **success path only** (unknown URIs raise before the log line).
5. **REST skill-mirror path wiring** — `serve_skill_resource` in `api/routes.py` calls the helper after the 404 guard, attributing the read to the `rest` call source.
6. **Documentation and version bump** — `AGENTS.md` (tree + module descriptions) and `SPEC.md` (new *Resource-Read Observability* subsection); version bumped to `0.17.0.dev0` in `pyproject.toml`, `__init__.py`, and `server.json` (`mcpb/manifest.json` intentionally unchanged).

## Why

The server already tracks tool invocations; resource reads (skill resources served over both MCP and the REST mirror) had no equivalent visibility. This closes that gap with a single cross-cutting helper reused by both entry points.

## Reviewer notes

- **Backward compatible:** the tool-invocation log line is unchanged byte-for-byte; only a new resource-read line is added.
- **Sink gating unchanged:** the direct (Mixpanel) sink remains gated on HTTP mode + token; the community sink on its opt-out/token rules. The log line itself is emitted regardless of either sink's gating.
- **Failure isolation:** logging/telemetry failures are swallowed and isolated per step so they can never break a resource read.
- **No integration tests added** (logging/telemetry only, no new live network paths). The full existing integration suite still passes: **88 passed, 0 failed, 0 skipped, 0 timed out** via the timeout-protected runner.
- **Manual HTTP smoke check** (both sinks disabled): `GET /skill/SKILL.md` → `200` with `Content-Type: text/markdown` and exactly one `Resource read: skill/SKILL.md` log line.
- **Unit suite:** 832 passed; `ruff check .` and `ruff format --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resource-read observability for bundled skill content, emitting distinct “Resource read” logs and forwarding events to analytics and community telemetry with existing privacy/opt-out behavior.
* **Documentation**
  * Documented resource-read observability in the spec and updated component structure notes.
* **Chores**
  * Bumped project version to `0.17.0.dev0`.
* **Tests**
  * Added and expanded coverage for resource-read logging across REST and MCP, including analytics/telemetry behavior, URI/context forwarding, and 404 suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->