### PR TITLE
Operator-configurable PRO API key requirement notice in tool responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,17 @@ BLOCKSCOUT_PRO_API_KEY_HEADER="Blockscout-MCP-Pro-Api-Key"
 #   Default rationale: per-call costs range 20–120 credits (see /api/json/config "endpoint_pricing");
 #   5000 ≈ 250 cheapest (20-credit) calls or ~41 most expensive (120-credit) calls.
 BLOCKSCOUT_PRO_API_LOW_CREDITS_THRESHOLD=5000
+
+# Operator-configured PRO API key requirement notice. When non-empty, it is appended as the
+# last entry of the `notes` field of tool responses whose requests did not include the
+# client's own PRO API key (see BLOCKSCOUT_PRO_API_KEY_HEADER above). Intended only for the
+# official public deployment, to announce the migration to mandatory client-supplied keys;
+# community, self-hosted, and stdio deployments should leave it empty (the feature is then
+# fully disabled).
+# Recommended wording template for the official deployment (substitute the confirmed
+# enforcement date):
+# BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE="⚠️ Starting <enforcement date>, all requests to the Blockscout MCP server will require a PRO API key for authorization. Visit https://dev.blockscout.com to get a PRO API key (the free tier does not require a credit card). Client-specific setup instructions: https://mcp.blockscout.com/."
+BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE=""
 BLOCKSCOUT_CHAINS_LIST_TTL_SECONDS=300
 BLOCKSCOUT_PROGRESS_INTERVAL_SECONDS="15.0"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ mcp-server/
 │   ├── telemetry.py            # Fire-and-forget community telemetry reporting
 │   ├── client_meta.py          # Shared client metadata extraction helpers and defaults
 │   ├── observability.py        # Resource-read observability helpers
-│   ├── pro_api_key_context.py  # Request-scoped client-supplied PRO API key state, resolver, and @pro_api_key_scope decorator; per-invocation credit sink and @pro_api_credit_scope decorator; auth-origin and key-fingerprint helpers for analytics/telemetry
+│   ├── pro_api_key_context.py  # Request-scoped client-supplied PRO API key state, resolver, and @pro_api_key_scope decorator; per-invocation credit sink and @pro_api_credit_scope decorator; auth-origin and key-fingerprint helpers for analytics/telemetry; client-key presence helper for response assembly
 │   ├── cache.py                # Simple in-memory cache for chain data
 │   ├── web3_pool.py            # Async Web3 connection pool manager
 │   ├── models.py               # Defines standardized Pydantic models for all tool responses
@@ -278,6 +278,7 @@ mcp-server/
             * `BLOCKSCOUT_BENS_TIMEOUT`: Timeout for BENS API requests.
             * `BLOCKSCOUT_METADATA_TIMEOUT`: Timeout for PRO API metadata requests.
             * `BLOCKSCOUT_PRO_API_KEY`: Server-configured Blockscout PRO API key used as the default/fallback credential for data requests.
+            * `BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE`: Operator-configured notice appended to tool responses when the request lacked a client-supplied PRO API key (empty disables the feature).
             * `BLOCKSCOUT_CHAINSCOUT_URL`: URL for the Chainscout API (for chain resolution).
             * `BLOCKSCOUT_CHAINSCOUT_TIMEOUT`: Timeout for Chainscout API requests.
             * `BLOCKSCOUT_CHAINS_LIST_TTL_SECONDS`: Time-to-live for the Chains List cache.

--- a/API.md
+++ b/API.md
@@ -71,7 +71,7 @@ Tool endpoints under `/v1/` return a consistent JSON object that wraps the tool'
 
 - `data`: The main data payload of the response. Its structure is specific to each endpoint.
 - `data_description`: (Optional) A list of strings explaining the structure or fields of the `data` payload.
-- `notes`: (Optional) A list of important warnings or contextual notes, such as data truncation alerts or a low-credits advisory emitted when the Blockscout PRO API credit balance drops below the configured threshold.
+- `notes`: (Optional) A list of important warnings or contextual notes, such as data truncation alerts, a low-credits advisory emitted when the Blockscout PRO API credit balance drops below the configured threshold, or an operator-configured notice that requests should be authorized with the client's own PRO API key.
 - `instructions`: (Optional) A list of suggested follow-up actions for an AI agent.
 - `pagination`: (Optional) An object containing information to retrieve the next page of results.
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ export BLOCKSCOUT_PRO_API_KEY=proapi_your_key_here
 
 **Low-credit warning.** Access to the PRO API is metered in credits. When the remaining balance reported by the API drops below a configurable threshold, every data tool appends an advisory note to its response, prompting operators to top up so PRO API access stays ready for continued high-volume usage. The threshold is set via `BLOCKSCOUT_PRO_API_LOW_CREDITS_THRESHOLD` (default `5000` credits; set to `0` to disable the note). The note fires for any balance below the threshold, including zero and negative balances.
 
+**PRO API key requirement notice.** `BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE` holds an operator-configured notice that the server appends as the last entry of the `notes` field of tool responses whose requests did not carry the client's own (well-formed) PRO API key. It exists to announce the official public server's migration to mandatory client-supplied keys, so only the official deployment is expected to set it. When the variable is unset or empty (the default), the feature is completely off. Community and self-hosted operators should leave it empty — in particular in stdio mode, where you configure `BLOCKSCOUT_PRO_API_KEY` yourself and no request header can carry a client key, the notice would only repeat a migration message that does not apply to your deployment.
+
 ### Running the Server
 
 The server runs in `stdio` mode by default:

--- a/SPEC.md
+++ b/SPEC.md
@@ -207,6 +207,10 @@ The key's purpose is to ensure every request the server makes to the Blockscout 
 - The credential is resolved per request and scoped to a single tool invocation (see `blockscout_mcp_server/pro_api_key_context.py`). The client key is read for any HTTP request that carries the configured header — both MCP-over-HTTP tool calls and the REST API — and is never written to logs, analytics, or cache keys.
 - Because the key authorizes upstream requests rather than gating MCP functionality, a response served entirely from cache (e.g. contract metadata/source) requires only that some effective key be present, not that the client-supplied key was validated upstream. A well-formed but invalid, expired, or out-of-credit client key may therefore receive cached PRO-gated data — no protected upstream request is made on its behalf. This is a deliberate consequence of the principle above, not a validation gap.
 
+**Operator-configurable key-requirement notice**
+
+- `BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE` (`config.pro_api_key_required_notice`, empty by default) lets a deployment announce the migration to mandatory client-supplied keys: when set, tool responses whose requests were not backed by a well-formed client-supplied key carry the configured text as the **last** entry of the existing `notes` advisory channel, so it never displaces data-specific notes or the low-credits advisory. An empty value disables the feature entirely. The official-vs-community distinction is purely deployment configuration — only the official public deployment sets the variable — which keeps official-server migration policy out of the shared, transport-neutral code; community, self-hosted, and stdio deployments leave it empty and stay silent.
+
 **Two transports, one scheme**
 
 The server reaches the PRO API over two transports, each with its own header builder, but both follow the same `Bearer` scheme:
@@ -276,7 +280,7 @@ Credit-exhaustion responses on the PRO API *data path* are special-cased: the sh
 
    - `data`: The main data payload of the tool's response. The schema of this field can be specific to each tool.
    - `data_description`: An optional list of strings that explain the structure, fields, or conventions of the `data` payload (e.g., "The `method_call` field is actually the event signature...").
-   - `notes`: An optional list of important contextual notes, such as warnings about data truncation or data quality issues, or a low-credits advisory when the Blockscout PRO API credit balance falls below the configured threshold. This field includes guidance on how to retrieve full data if it has been truncated.
+   - `notes`: An optional list of important contextual notes, such as warnings about data truncation or data quality issues, a low-credits advisory when the Blockscout PRO API credit balance falls below the configured threshold, or the operator-configured key-requirement notice when the request was not backed by a client-supplied PRO API key. This field includes guidance on how to retrieve full data if it has been truncated.
    - `instructions`: An optional list of suggested follow-up actions for the LLM to plan its next steps. When pagination is available, the server automatically appends pagination instructions to motivate LLMs to fetch additional pages.
    - `pagination`: An optional object that provides structured information for retrieving the next page of results.
 

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.17.0.dev4"
+__version__ = "0.17.0.dev5"

--- a/blockscout_mcp_server/config.py
+++ b/blockscout_mcp_server/config.py
@@ -23,6 +23,10 @@ class ServerConfig(BaseSettings):
     pro_api_config_refresh_retry_seconds: int = 30
     pro_api_key: str = ""
     pro_api_key_header: str = "Blockscout-MCP-Pro-Api-Key"
+    # Operator-configurable notice appended to tool responses when the request was not
+    # backed by a well-formed client-supplied PRO API key. There is no default text in
+    # code: an empty value (the default) disables the feature entirely.
+    pro_api_key_required_notice: str = ""
     # Advisory low-credits threshold expressed in PRO API credits (same unit as
     # `endpoint_pricing` in /api/json/config).  A value of 0 disables the note
     # entirely (Phase 4 gates on threshold > 0).  The default of 5000 provides
@@ -46,6 +50,11 @@ class ServerConfig(BaseSettings):
     @field_validator("pro_api_key_header")
     @classmethod
     def normalize_pro_api_key_header(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("pro_api_key_required_notice")
+    @classmethod
+    def normalize_pro_api_key_required_notice(cls, value: str) -> str:
         return value.strip()
 
     # Metadata configuration (PRO API metadata endpoint)

--- a/blockscout_mcp_server/pro_api_key_context.py
+++ b/blockscout_mcp_server/pro_api_key_context.py
@@ -424,6 +424,37 @@ def resolve_pro_api_key() -> str:
 
 
 # ---------------------------------------------------------------------------
+# 5b. Notice-eligibility helper — reports whether the client key won precedence
+# ---------------------------------------------------------------------------
+
+
+def client_supplied_valid_key() -> bool:
+    """Return whether the current request's effective credential is a client-supplied key.
+
+    Meaningful only inside :func:`pro_api_key_scope` — applied to every MCP tool
+    (see the "Blanket decorator application" section of this module's docstring)
+    — because that decorator is what populates ``_client_key_state`` for the
+    request. Outside any scope the ContextVar reads its ``_ABSENT`` default and
+    this returns ``False``.
+
+    Delegates to :func:`_apply_key_precedence` (see the section-1b comment) — the
+    same single-source-of-truth decision that :func:`resolve_pro_api_key` enforces
+    and :func:`compute_auth_signals` reports — so this helper can never disagree
+    with the credential that actually backed the request:
+
+    - :class:`_UseClientKey` → ``True``.
+    - :class:`_RejectMalformed` (a malformed client key, no fallback) → ``False``.
+    - :class:`_UseServerKey` (no client key; whether or not a server key is
+      configured) → ``False``.
+
+    "Valid" means *locally well-formed only* (see :func:`_normalize_key`'s
+    semantics) — never an upstream-verified key. Never raises.
+    """
+    decision = _apply_key_precedence(_client_key_state.get())
+    return isinstance(decision, _UseClientKey)
+
+
+# ---------------------------------------------------------------------------
 # 6. require_pro_api_key — single chokepoint for the "not configured" error
 # ---------------------------------------------------------------------------
 

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -747,12 +747,19 @@ def build_tool_response(
     Returns:
         A ToolResponse instance.
     """
-    # Check for a low-credits advisory note.  All three conditions must hold:
+    # Auto-appended notes (low-credits advisory, then the PRO-API-key migration
+    # notice) accumulate in a local list and are folded onto the caller's notes
+    # once at the end.  Keeping them here — rather than threading a running
+    # ``final_notes`` through each branch — means neither branch depends on whether
+    # the other fired (no aliasing to reason about), and the caller-supplied list is
+    # never mutated in place.
+    extra_notes: list[str] = []
+
+    # Low-credits advisory note.  All three conditions must hold:
     # 1. A CreditSink was established for this invocation (sink is not None).
     # 2. A PRO API call actually happened (sink.remaining is not None).
     # 3. The threshold gate is enabled (> 0) and the remaining balance is below it.
     # Silence is the default; emit nothing when any condition is unmet.
-    final_notes: list[str] | None = notes
     sink = _credit_sink.get()
     if (
         sink is not None
@@ -769,21 +776,24 @@ def build_tool_response(
             f"(warning threshold: {threshold}). Top up your account to keep Blockscout PRO API access ready "
             f"for continued high-volume usage — see https://dev.blockscout.com."
         )
-        # Build a new list — never mutate the caller-supplied list in place.
-        final_notes = list(notes) if notes is not None else []
-        final_notes.append(advisory)
+        extra_notes.append(advisory)
 
-    # Append the operator-configured PRO-API-key-required migration notice.  Both
-    # conditions must hold: the notice is configured (non-empty; Phase 1's validator
-    # already stripped it) and the request was not backed by a well-formed
-    # client-supplied PRO API key.  Appended last so it never displaces caller-supplied
-    # or low-credits notes above.
+    # Operator-configured PRO-API-key-required migration notice.  Both conditions
+    # must hold: the notice is configured (non-empty; Phase 1's validator already
+    # stripped it) and the request was not backed by a well-formed client-supplied
+    # PRO API key.  Appended last so it never displaces caller-supplied or
+    # low-credits notes above.
     if config.pro_api_key_required_notice and not client_supplied_valid_key():
-        if final_notes is notes:
-            # The low-credits branch above did not fire — build a new list here too,
-            # never mutating the caller-supplied list in place.
-            final_notes = list(notes) if notes is not None else []
-        final_notes.append(config.pro_api_key_required_notice)
+        extra_notes.append(config.pro_api_key_required_notice)
+
+    # Fold the auto-appended notes onto the caller's notes.  When nothing was added,
+    # pass the caller's ``notes`` through unchanged (preserving ``None``); otherwise
+    # build a fresh list so the caller-supplied list is never mutated in place.
+    final_notes: list[str] | None
+    if extra_notes:
+        final_notes = [*notes, *extra_notes] if notes is not None else extra_notes
+    else:
+        final_notes = notes
 
     # Automatically add pagination instructions when pagination is present
     final_instructions = list(instructions) if instructions is not None else []

--- a/blockscout_mcp_server/tools/common.py
+++ b/blockscout_mcp_server/tools/common.py
@@ -21,6 +21,7 @@ from blockscout_mcp_server.constants import (
 from blockscout_mcp_server.models import NextCallInfo, PaginationInfo, ToolResponse
 from blockscout_mcp_server.pro_api_key_context import (
     _credit_sink,
+    client_supplied_valid_key,
     require_pro_api_key,
     resolve_pro_api_key,
 )
@@ -771,6 +772,18 @@ def build_tool_response(
         # Build a new list — never mutate the caller-supplied list in place.
         final_notes = list(notes) if notes is not None else []
         final_notes.append(advisory)
+
+    # Append the operator-configured PRO-API-key-required migration notice.  Both
+    # conditions must hold: the notice is configured (non-empty; Phase 1's validator
+    # already stripped it) and the request was not backed by a well-formed
+    # client-supplied PRO API key.  Appended last so it never displaces caller-supplied
+    # or low-credits notes above.
+    if config.pro_api_key_required_notice and not client_supplied_valid_key():
+        if final_notes is notes:
+            # The low-credits branch above did not fire — build a new list here too,
+            # never mutating the caller-supplied list in place.
+            final_notes = list(notes) if notes is not None else []
+        final_notes.append(config.pro_api_key_required_notice)
 
     # Automatically add pagination instructions when pagination is present
     final_instructions = list(instructions) if instructions is not None else []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.17.0.dev4"
+version = "0.17.0.dev5"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.17.0.dev4",
+  "version": "0.17.0.dev5",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/api/test_routes_pro_api_key.py
+++ b/tests/api/test_routes_pro_api_key.py
@@ -226,3 +226,52 @@ async def test_rest_empty_header_name_config_ignores_client_header(monkeypatch, 
     assert response.status_code == 200
     # Feature disabled: should fall back to server key
     assert fake_client.get_headers.get("Authorization") == f"Bearer {_SERVER_KEY}"
+
+
+# ---------------------------------------------------------------------------
+# PRO-API-key-required notice (issue #425, Phase 3) — REST transport-level
+# ---------------------------------------------------------------------------
+
+_NOTICE_TEXT = "PRO API keys will soon be required for every request; see https://dev.blockscout.com."
+
+
+@pytest.mark.asyncio
+async def test_rest_notice_present_without_key_header(monkeypatch, rest_client):
+    """Notice configured, request without the key header → HTTP 200 and the
+    JSON payload's `notes` array has the notice as its last entry."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    fake_client = CapturingClient(_ok_response())
+    with (
+        patch("blockscout_mcp_server.tools.common._create_httpx_client", return_value=fake_client),
+        patch("blockscout_mcp_server.tools.common.ensure_chain_supported", AsyncMock()),
+    ):
+        response = await rest_client.get(_TEST_URL)
+
+    assert response.status_code == 200
+    payload = response.json()
+    notes = payload.get("notes")
+    assert notes is not None, f"Expected 'notes' in response payload but got None: {payload}"
+    assert notes[-1] == _NOTICE_TEXT
+
+
+@pytest.mark.asyncio
+async def test_rest_notice_absent_with_well_formed_key_header(monkeypatch, rest_client):
+    """Notice configured, request with a well-formed key header → the JSON
+    payload carries no notice."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    fake_client = CapturingClient(_ok_response())
+    with (
+        patch("blockscout_mcp_server.tools.common._create_httpx_client", return_value=fake_client),
+        patch("blockscout_mcp_server.tools.common.ensure_chain_supported", AsyncMock()),
+    ):
+        response = await rest_client.get(
+            _TEST_URL,
+            headers={"Blockscout-MCP-Pro-Api-Key": _CLIENT_KEY},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    notes = payload.get("notes")
+    assert notes is None or _NOTICE_TEXT not in notes

--- a/tests/integration/chains/test_get_chains_list_real.py
+++ b/tests/integration/chains/test_get_chains_list_real.py
@@ -122,6 +122,35 @@ async def test_get_chains_list_query_optimism(mock_ctx):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_get_chains_list_notice_composes_with_real_response(mock_ctx, monkeypatch):
+    """The PRO-API-key-required notice (issue #425) composes with a real tool's
+    real response without displacing its existing notes.
+
+    ``mock_ctx.request_context`` is set to ``None`` explicitly to model a
+    stdio-like/no-request context — the same absent-key state the
+    decorator-seam unit test uses. This must not rely on the unrestricted
+    ``MagicMock`` merely happening to fall through the extractor's defensive
+    non-string branch (it would, but for the wrong reason): setting it
+    explicitly pins down *why* the state is absent.
+    """
+    marker = "TEST-MARKER: PRO API key will soon be required for every request."
+    monkeypatch.setattr(config, "pro_api_key_required_notice", marker)
+    mock_ctx.request_context = None
+
+    result = await retry_on_network_error(
+        lambda: get_chains_list(ctx=mock_ctx),
+        action_description="get_chains_list request",
+    )
+
+    assert isinstance(result, ToolResponse)
+    assert isinstance(result.data, list)
+    assert len(result.data) > 0
+    assert result.notes is not None
+    assert result.notes[-1] == marker
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_get_chains_list_query_xdai(mock_ctx):
     full = await retry_on_network_error(
         lambda: get_chains_list(ctx=mock_ctx), action_description="get_chains_list request"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,6 +129,36 @@ def test_pro_api_key_header_empty_string_preserved(monkeypatch):
     assert cfg.pro_api_key_header == ""
 
 
+def test_pro_api_key_required_notice_default(monkeypatch):
+    monkeypatch.delenv("BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE", raising=False)
+    cfg = ServerConfig(_env_file=None)
+    assert cfg.pro_api_key_required_notice == ""
+
+
+def test_pro_api_key_required_notice_env_override(monkeypatch):
+    monkeypatch.setenv("BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE", "Please authenticate with your own PRO API key.")
+    cfg = ServerConfig(_env_file=None)
+    assert cfg.pro_api_key_required_notice == "Please authenticate with your own PRO API key."
+
+
+def test_pro_api_key_required_notice_strips_surrounding_whitespace(monkeypatch):
+    monkeypatch.setenv("BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE", "  Please authenticate.  \n")
+    cfg = ServerConfig(_env_file=None)
+    assert cfg.pro_api_key_required_notice == "Please authenticate."
+
+
+def test_pro_api_key_required_notice_whitespace_only_becomes_empty(monkeypatch):
+    monkeypatch.setenv("BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE", "   ")
+    cfg = ServerConfig(_env_file=None)
+    assert cfg.pro_api_key_required_notice == ""
+
+
+def test_pro_api_key_required_notice_empty_string_preserved(monkeypatch):
+    monkeypatch.setenv("BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE", "")
+    cfg = ServerConfig(_env_file=None)
+    assert cfg.pro_api_key_required_notice == ""
+
+
 def test_pro_api_low_credits_threshold_default(monkeypatch):
     monkeypatch.delenv("BLOCKSCOUT_PRO_API_LOW_CREDITS_THRESHOLD", raising=False)
     cfg = ServerConfig(_env_file=None)

--- a/tests/test_pro_api_key_context_auth_signals.py
+++ b/tests/test_pro_api_key_context_auth_signals.py
@@ -18,6 +18,7 @@ from blockscout_mcp_server import pro_api_key_context
 from blockscout_mcp_server.config import config
 from blockscout_mcp_server.constants import PRO_API_KEY_HASH_PREFIX
 from blockscout_mcp_server.pro_api_key_context import (
+    client_supplied_valid_key,
     compute_auth_signals,
     extract_client_pro_api_key_from_ctx,
     resolve_pro_api_key,
@@ -162,17 +163,22 @@ def test_client_fingerprint_is_never_memoized(monkeypatch):
 # *same* state extracted from that ctx, so both see one logical input.
 
 
-def _resolve_outcome(state: pro_api_key_context.ClientKeyState) -> tuple[str, str | None]:
-    """Run ``resolve_pro_api_key`` with the ContextVar set to *state*; report its outcome.
+def _resolve_outcome(state: pro_api_key_context.ClientKeyState) -> tuple[tuple[str, str | None], bool]:
+    """Run ``resolve_pro_api_key`` and ``client_supplied_valid_key`` with the ContextVar set to *state*.
 
-    Returns ``("key", <value>)`` for a returned key (possibly ``""``) or
-    ``("raised", None)`` when the malformed-key ``ValueError`` is raised.
+    Both calls run inside the *same* state scope so the notice-eligibility flag
+    is pinned to the same precedence decision ``resolve_pro_api_key`` enforces.
+    Returns a pair: the resolve outcome (``("key", <value>)`` for a returned key,
+    possibly ``""``, or ``("raised", None)`` when the malformed-key ``ValueError``
+    is raised) and the ``client_supplied_valid_key()`` result.
     """
     token = pro_api_key_context._client_key_state.set(state)
     try:
-        return "key", resolve_pro_api_key()
-    except ValueError:
-        return "raised", None
+        try:
+            resolution: tuple[str, str | None] = ("key", resolve_pro_api_key())
+        except ValueError:
+            resolution = ("raised", None)
+        return resolution, client_supplied_valid_key()
     finally:
         pro_api_key_context._client_key_state.reset(token)
 
@@ -223,7 +229,7 @@ def test_auth_origin_stays_consistent_with_resolve_pro_api_key(
 
     # resolve sees the SAME state the telemetry path derived from ctx.
     state = extract_client_pro_api_key_from_ctx(ctx)
-    resolution = _resolve_outcome(state)
+    resolution, client_eligible = _resolve_outcome(state)
     assert resolution == expected_resolution
 
     # The invariant tying the two together: a "usable key" origin iff resolve
@@ -232,3 +238,7 @@ def test_auth_origin_stays_consistent_with_resolve_pro_api_key(
         assert resolution[0] == "key" and resolution[1]
     else:
         assert resolution == ("raised", None) or resolution == ("key", "")
+
+    # Notice eligibility (Phase 2, issue #425) must agree with the same
+    # precedence decision: True exactly when the client key won precedence.
+    assert client_eligible == (expected_origin == "client")

--- a/tests/test_pro_api_key_http_transport.py
+++ b/tests/test_pro_api_key_http_transport.py
@@ -86,6 +86,88 @@ def test_missing_client_header_falls_back_to_server_key(mcp_app):
     assert _extract_text_result(response.text) == "server-key"
 
 
+@pytest.fixture(autouse=True)
+def disable_telemetry(monkeypatch):
+    """Disable community telemetry for all tests in this module.
+
+    The real @log_tool_invocation decorator schedules
+    telemetry.send_community_usage_report(...) via asyncio.create_task in its
+    finally block — even when the tool body raises. Setting
+    config.disable_community_telemetry = True triggers the real gate in the
+    production code and avoids flaky real network calls, following the
+    established fixture in tests/api/test_routes_pro_api_key.py:88-100.
+    """
+    monkeypatch.setattr(server_config, "disable_community_telemetry", True, raising=False)
+
+
+@pytest.fixture()
+def unlock_app(monkeypatch):
+    """A throwaway FastMCP instance carrying the real, fully local, keyless
+    ``__unlock_blockchain_analysis__`` tool, registered exactly the way
+    production registers it (blockscout_mcp_server/server.py:235-240):
+    ``mcp.tool(structured_output=True, ...)`` wrapping
+    ``_wrap_tool_for_structured_output``. Registering the raw function would
+    fall back to the SDK's auto-serialization instead of the wrapper that
+    actually builds ``structuredContent`` in production, silently bypassing
+    the very serialization boundary these notice tests exist to cover.
+    """
+    from blockscout_mcp_server.server import _wrap_tool_for_structured_output
+    from blockscout_mcp_server.tools.initialization.unlock_blockchain_analysis import (
+        __unlock_blockchain_analysis__,
+    )
+
+    monkeypatch.setattr(server_config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key", raising=False)
+
+    mcp = FastMCP(
+        name="test-notice-transport",
+        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    )
+    mcp.settings.stateless_http = True
+    mcp.settings.json_response = True
+
+    mcp.tool(structured_output=True)(_wrap_tool_for_structured_output(__unlock_blockchain_analysis__))
+
+    return mcp.streamable_http_app()
+
+
+_NOTICE_TEXT = "PRO API keys will soon be required for every request; see https://dev.blockscout.com."
+
+
+def test_notice_present_in_structured_content_without_key_header(unlock_app, monkeypatch):
+    """Notice configured, no key header → structuredContent.notes ends with the notice."""
+    monkeypatch.setattr(server_config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    with TestClient(unlock_app) as client:
+        response = client.post(
+            "/mcp",
+            json=_build_tools_call_body("__unlock_blockchain_analysis__"),
+            headers=_MCP_HEADERS,
+        )
+
+    assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
+    data = json.loads(response.text)
+    structured = data["result"]["structuredContent"]
+    assert structured["notes"][-1] == _NOTICE_TEXT
+
+
+def test_notice_absent_in_structured_content_with_well_formed_key_header(unlock_app, monkeypatch):
+    """Notice configured, well-formed key header → no notice in structuredContent.notes."""
+    monkeypatch.setattr(server_config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    with TestClient(unlock_app) as client:
+        response = client.post(
+            "/mcp",
+            json=_build_tools_call_body("__unlock_blockchain_analysis__"),
+            headers={**_MCP_HEADERS, "Blockscout-MCP-Pro-Api-Key": "client-key-456"},
+        )
+
+    assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
+    data = json.loads(response.text)
+    structured = data["result"]["structuredContent"]
+    notes = structured.get("notes")
+    assert notes is None or _NOTICE_TEXT not in notes
+
+
 def test_not_configured_error_terse_contract_over_http(monkeypatch):
     """The model-facing JSON-RPC error text carries the new terse not-configured contract.
 

--- a/tests/test_pro_api_key_http_transport.py
+++ b/tests/test_pro_api_key_http_transport.py
@@ -29,6 +29,27 @@ def _build_tools_call_body(tool_name: str, arguments: dict | None = None) -> dic
     }
 
 
+@pytest.fixture(autouse=True)
+def disable_telemetry(monkeypatch):
+    """Disable community telemetry for every test in this module.
+
+    Declared at the top and ``autouse=True``, so it deliberately covers *all*
+    tests in the module — the pre-existing key-resolution tests
+    (``test_client_key_header_reaches_tool_body`` and
+    ``test_missing_client_header_falls_back_to_server_key``) as well as the
+    notice tests below. Disabling telemetry is inert for the former and a
+    flakiness guard for the latter, so uniform coverage is intentional.
+
+    The real @log_tool_invocation decorator schedules
+    telemetry.send_community_usage_report(...) via asyncio.create_task in its
+    finally block — even when the tool body raises. Setting
+    config.disable_community_telemetry = True triggers the real gate in the
+    production code and avoids flaky real network calls, mirroring the
+    ``disable_telemetry`` fixture in tests/api/test_routes_pro_api_key.py.
+    """
+    monkeypatch.setattr(server_config, "disable_community_telemetry", True, raising=False)
+
+
 @pytest.fixture()
 def mcp_app(monkeypatch):
     """A throwaway FastMCP instance with a single key-echo tool and streamable-HTTP app."""
@@ -86,25 +107,12 @@ def test_missing_client_header_falls_back_to_server_key(mcp_app):
     assert _extract_text_result(response.text) == "server-key"
 
 
-@pytest.fixture(autouse=True)
-def disable_telemetry(monkeypatch):
-    """Disable community telemetry for all tests in this module.
-
-    The real @log_tool_invocation decorator schedules
-    telemetry.send_community_usage_report(...) via asyncio.create_task in its
-    finally block — even when the tool body raises. Setting
-    config.disable_community_telemetry = True triggers the real gate in the
-    production code and avoids flaky real network calls, following the
-    established fixture in tests/api/test_routes_pro_api_key.py:88-100.
-    """
-    monkeypatch.setattr(server_config, "disable_community_telemetry", True, raising=False)
-
-
 @pytest.fixture()
 def unlock_app(monkeypatch):
     """A throwaway FastMCP instance carrying the real, fully local, keyless
     ``__unlock_blockchain_analysis__`` tool, registered exactly the way
-    production registers it (blockscout_mcp_server/server.py:235-240):
+    production registers it (see the ``mcp.tool(...)`` registration block in
+    blockscout_mcp_server/server.py):
     ``mcp.tool(structured_output=True, ...)`` wrapping
     ``_wrap_tool_for_structured_output``. Registering the raw function would
     fall back to the SDK's auto-serialization instead of the wrapper that

--- a/tests/tools/test_pro_api_key_required_notice.py
+++ b/tests/tools/test_pro_api_key_required_notice.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Unit tests for the PRO-API-key-required notice (issue #425).
+
+Phase 2 covers only ``client_supplied_valid_key()`` — the helper that reports
+whether the current request's effective credential is a client-supplied PRO
+API key, so response assembly (Phase 3) never has to touch this module's
+private state classes directly. Phase 3 extends this file with the
+notice-assembly integration tests; keep the whole file under 500 LOC per
+rule 210.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from blockscout_mcp_server.pro_api_key_context import (
+    _Absent,
+    _client_key_state,
+    _Malformed,
+    _Valid,
+    client_supplied_valid_key,
+)
+
+
+@contextmanager
+def _set_client_key_state(state):
+    """Context manager that sets _client_key_state and resets it in finally."""
+    token = _client_key_state.set(state)
+    try:
+        yield
+    finally:
+        _client_key_state.reset(token)
+
+
+# ===========================================================================
+# client_supplied_valid_key() — mapping from every ContextVar state to bool
+# ===========================================================================
+
+
+def test_valid_client_key_state_returns_true():
+    with _set_client_key_state(_Valid(value="client-key-123")):
+        assert client_supplied_valid_key() is True
+
+
+def test_absent_state_returns_false():
+    with _set_client_key_state(_Absent()):
+        assert client_supplied_valid_key() is False
+
+
+def test_malformed_state_returns_false():
+    with _set_client_key_state(_Malformed()):
+        assert client_supplied_valid_key() is False
+
+
+def test_no_state_set_returns_false():
+    """Outside any @pro_api_key_scope, the ContextVar reads its _ABSENT default."""
+    assert client_supplied_valid_key() is False

--- a/tests/tools/test_pro_api_key_required_notice.py
+++ b/tests/tools/test_pro_api_key_required_notice.py
@@ -5,21 +5,33 @@ Phase 2 covers only ``client_supplied_valid_key()`` — the helper that reports
 whether the current request's effective credential is a client-supplied PRO
 API key, so response assembly (Phase 3) never has to touch this module's
 private state classes directly. Phase 3 extends this file with the
-notice-assembly integration tests; keep the whole file under 500 LOC per
+notice-assembly tests (gating, ordering, non-mutation in ``build_tool_response``)
+plus the decorator-seam tests proving the whole chain — decorator -> ContextVar
+-> helper -> response — integrates. Keep the whole file under 500 LOC per
 rule 210.
 """
 
 from __future__ import annotations
 
 from contextlib import contextmanager
+from types import SimpleNamespace
 
+import pytest
+from pro_api_key_helpers import ctx_with_header
+
+from blockscout_mcp_server.config import config
+from blockscout_mcp_server.models import NextCallInfo, PaginationInfo
 from blockscout_mcp_server.pro_api_key_context import (
+    CreditSink,
     _Absent,
     _client_key_state,
+    _credit_sink,
     _Malformed,
     _Valid,
     client_supplied_valid_key,
+    pro_api_key_scope,
 )
+from blockscout_mcp_server.tools.common import build_tool_response
 
 
 @contextmanager
@@ -55,3 +67,173 @@ def test_malformed_state_returns_false():
 def test_no_state_set_returns_false():
     """Outside any @pro_api_key_scope, the ContextVar reads its _ABSENT default."""
     assert client_supplied_valid_key() is False
+
+
+# ===========================================================================
+# build_tool_response notice assembly — gating, ordering, non-mutation
+# ===========================================================================
+
+_NOTICE_TEXT = "PRO API keys will soon be required for every request; see https://dev.blockscout.com."
+
+
+def test_notice_present_and_last_when_state_absent(monkeypatch):
+    """Notice configured, state _Absent -> notice present and last entry."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    with _set_client_key_state(_Absent()):
+        response = build_tool_response(data={"ok": True})
+
+    assert response.notes is not None
+    assert response.notes[-1] == _NOTICE_TEXT
+
+
+def test_notice_present_when_state_malformed(monkeypatch):
+    """Notice configured, state _Malformed -> notice present (malformed key is not usable)."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    with _set_client_key_state(_Malformed()):
+        response = build_tool_response(data={"ok": True})
+
+    assert response.notes is not None
+    assert response.notes[-1] == _NOTICE_TEXT
+
+
+def test_notice_present_when_no_state_set(monkeypatch):
+    """Notice configured, no state set (ContextVar default) -> notice present."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    response = build_tool_response(data={"ok": True})
+
+    assert response.notes is not None
+    assert response.notes[-1] == _NOTICE_TEXT
+
+
+def test_notice_absent_when_state_valid(monkeypatch):
+    """Notice configured, state _Valid -> notes unchanged (no notice)."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    with _set_client_key_state(_Valid(value="client-key-123")):
+        response = build_tool_response(data={"ok": True})
+
+    assert response.notes is None
+
+
+@pytest.mark.parametrize("state", [_Absent(), _Malformed(), _Valid(value="client-key-123")])
+def test_no_notice_for_any_state_when_notice_empty(state):
+    """Notice empty (default config) -> no notice for any state, notes stays None."""
+    assert config.pro_api_key_required_notice == ""
+
+    with _set_client_key_state(state):
+        response = build_tool_response(data={"ok": True})
+
+    assert response.notes is None
+
+
+def test_notice_ordering_with_low_credits_advisory(monkeypatch):
+    """Both the low-credits advisory and the key-requirement notice can fire together;
+    the advisory comes first and the key-requirement notice is appended last."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+    monkeypatch.setattr(config, "pro_api_low_credits_threshold", 5000)
+
+    sink = CreditSink()
+    sink.record(4999.0)
+    token = _credit_sink.set(sink)
+    try:
+        with _set_client_key_state(_Absent()):
+            response = build_tool_response(data={"ok": True})
+    finally:
+        _credit_sink.reset(token)
+
+    assert response.notes is not None
+    assert len(response.notes) == 2
+    assert "4999" in response.notes[0]
+    assert response.notes[1] == _NOTICE_TEXT
+
+
+def test_notice_preserves_caller_notes_without_mutation(monkeypatch):
+    """Caller-supplied notes are preserved in order before the notice, and the
+    caller's original list object is not mutated."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    original_notes = ["existing note"]
+
+    with _set_client_key_state(_Absent()):
+        response = build_tool_response(data={"ok": True}, notes=original_notes)
+
+    # Original list must not be mutated
+    assert original_notes == ["existing note"]
+
+    assert response.notes is not None
+    assert response.notes == ["existing note", _NOTICE_TEXT]
+
+
+def test_notice_coexists_with_pagination_instructions(monkeypatch):
+    """instructions/pagination output is identical to today's behavior; the
+    notice only affects notes."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+
+    pagination = PaginationInfo(
+        next_call=NextCallInfo(tool_name="get_block_info", params={"chain_id": "1", "cursor": "abc"})
+    )
+
+    with _set_client_key_state(_Absent()):
+        response = build_tool_response(data={"ok": True}, pagination=pagination)
+
+    assert response.notes is not None
+    assert response.notes[-1] == _NOTICE_TEXT
+
+    assert response.instructions is not None
+    assert any("MORE DATA AVAILABLE" in i for i in response.instructions)
+    assert response.pagination == pagination
+
+
+# ===========================================================================
+# Decorator-seam tests — decorator -> ContextVar -> helper -> response
+# ===========================================================================
+
+
+@pro_api_key_scope
+async def _probe_tool(ctx):
+    """Minimal tool-shaped function proving the full integration chain."""
+    return build_tool_response(data={"ok": True})
+
+
+@pytest.mark.asyncio
+async def test_decorator_seam_well_formed_client_key_suppresses_notice(monkeypatch):
+    """A context carrying a well-formed key under the configured header ->
+    the decorator resolves a _Valid state and the notice is suppressed."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+    monkeypatch.setattr(config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key", raising=False)
+
+    ctx = ctx_with_header(config.pro_api_key_header, "client-key-456")
+    response = await _probe_tool(ctx)
+
+    assert response.notes is None
+
+
+@pytest.mark.asyncio
+async def test_decorator_seam_http_context_without_key_header_shows_notice(monkeypatch):
+    """An HTTP-shaped context whose headers do not include the configured key
+    header -> the decorator resolves _Absent and the notice is present."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+    monkeypatch.setattr(config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key", raising=False)
+
+    ctx = ctx_with_header("X-Some-Unrelated-Header", "irrelevant-value")
+    response = await _probe_tool(ctx)
+
+    assert response.notes is not None
+    assert response.notes[-1] == _NOTICE_TEXT
+
+
+@pytest.mark.asyncio
+async def test_decorator_seam_stdio_context_shows_notice(monkeypatch):
+    """A stdio-shaped context (no request_context) -> the decorator resolves
+    _Absent and the notice is present."""
+    monkeypatch.setattr(config, "pro_api_key_required_notice", _NOTICE_TEXT)
+    monkeypatch.setattr(config, "pro_api_key_header", "Blockscout-MCP-Pro-Api-Key", raising=False)
+
+    ctx = SimpleNamespace(request_context=None)
+    response = await _probe_tool(ctx)
+
+    assert response.notes is not None
+    assert response.notes[-1] == _NOTICE_TEXT

--- a/tests/tools/test_pro_api_key_required_notice.py
+++ b/tests/tools/test_pro_api_key_required_notice.py
@@ -119,9 +119,14 @@ def test_notice_absent_when_state_valid(monkeypatch):
 
 
 @pytest.mark.parametrize("state", [_Absent(), _Malformed(), _Valid(value="client-key-123")])
-def test_no_notice_for_any_state_when_notice_empty(state):
-    """Notice empty (default config) -> no notice for any state, notes stays None."""
-    assert config.pro_api_key_required_notice == ""
+def test_no_notice_for_any_state_when_notice_empty(state, monkeypatch):
+    """Notice empty -> no notice for any state, notes stays None.
+
+    Set the empty notice explicitly rather than asserting the global default, so
+    the test stays hermetic even when a developer's environment/.env defines
+    ``BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE``.
+    """
+    monkeypatch.setattr(config, "pro_api_key_required_notice", "")
 
     with _set_client_key_state(state):
         response = build_tool_response(data={"ok": True})


### PR DESCRIPTION
## What & why

Implements [#425](https://github.com/blockscout/mcp-server/issues/425) — an **operator-configurable notice** that gets appended to tool responses when a request is **not** backed by a well-formed client-supplied PRO API key. This lets an operator warn users (e.g. ahead of an enforcement date) that they should authenticate with their own PRO API key, without any hard-coded text in the codebase. The feature is **off by default**: an empty notice string disables it entirely.

## How it works

- A new setting `pro_api_key_required_notice` (env `BLOCKSCOUT_PRO_API_KEY_REQUIRED_NOTICE`) holds the operator's text; whitespace is stripped, and whitespace-only normalizes to empty (disabled).
- A new helper `client_supplied_valid_key()` in `pro_api_key_context.py` reports whether the current request carried a locally well-formed client key, routing through the existing `_apply_key_precedence` decision (single source of truth — "valid" means well-formed, not remotely authenticated).
- `build_tool_response` appends the notice as the **last** entry of `notes` only when the notice is non-empty **and** `client_supplied_valid_key()` is `False`. It coexists with the low-credits note and preserves the existing no-mutation contract on the caller's `notes` list.

## Phases (one commit each)

1. **Configuration field for the notice** — setting + normalizing validator.
2. **Client-key presence helper** — `client_supplied_valid_key()` + coupling-matrix coverage.
3. **Notice assembly in `build_tool_response`** — gating/ordering/non-mutation, plus REST + MCP-over-HTTP transport tests and a live integration test.
4. **Documentation and version bump** — SPEC.md, README.md, API.md, AGENTS.md, .env.example; version → `0.17.0.dev5`.

## Testing

- Unit suite: **958 passed**.
- Integration suite (mandatory — `tools/common.py` changed), via the timeout-protected runner: **92 passed, 0 failed, 0 skipped, 0 timed out**, including the new feature-on notice test in `tests/integration/chains/test_get_chains_list_real.py`.
- `ruff check .` and `ruff format --check .` clean.

## Reviewer notes

- **`.env.example` ships the literal `<enforcement date>` placeholder** in the recommended-wording template — no enforcement date was invented. A deployment owner should replace the placeholder with a confirmed date before enabling the notice in production.
- Version bumped to `0.17.0.dev5` across `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional operator-configured notice for responses made without a valid client PRO API key.
  * Notices appear as the final response note and can be disabled by leaving the setting empty.
  * Existing advisories and caller-provided notes are preserved in order.

* **Documentation**
  * Documented the new configuration option and response-note behavior.

* **Tests**
  * Added coverage for configured notices, valid and missing keys, note ordering, and response integration.

* **Chores**
  * Updated the release version to 0.17.0.dev5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->