### PR TITLE
chore: enhancements in implementation plan review process 

### DIFF
--- a/.agents/skills/export-plan-review-comments/SKILL.md
+++ b/.agents/skills/export-plan-review-comments/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: export-plan-review-comments
+description: Export the survived comments from a completed implementation-plan review into a timestamped Markdown findings artifact. Use when the user asks to save, write, or export plan-review comments/findings under `.ai/impl_plans/PLAN_ID/findings/REVIEW_TIMESTAMP/finding.md` while preserving the original review wording and wrapping each finding in paired `comment` markers.
+disable-model-invocation: true
+---
+
+# Export Plan Review Comments
+
+Export the final review comments without re-reviewing the plan, changing verdicts, or implementing anything.
+
+## Resolve the source and target
+
+1. Identify exactly one plan file from the user request or the completed review:
+
+   ```text
+   .ai/impl_plans/<plan-id>.md
+   ```
+
+   If more than one plan is plausible, ask instead of guessing.
+
+2. Resolve the review timestamp from the exact scratchpad paths cited by the comments:
+
+   ```text
+   .ai/impl_plans/<plan-id>/scratchpads/<YYMMDD-HHMM>/...
+   ```
+
+   Reuse that timestamp verbatim. Do not generate the current time, glob scratchpad directories, or reuse a timestamp from another review. If no exact review timestamp is recoverable, ask the user.
+
+3. Write to:
+
+   ```text
+   .ai/impl_plans/<plan-id>/findings/<YYMMDD-HHMM>/finding.md
+   ```
+
+4. Treat every item actually present in the final review's actionable-comments section as one survived finding. Do not export summaries, coverage notes, closed candidates, intermediate commentary, or test-checklist repetitions.
+
+## Preserve each comment
+
+- Keep the original review wording almost verbatim.
+- Do not normalize findings into a new schema.
+- Do not rewrite links, severity labels, verdicts, recommendations, rationales, action text, or scratchpad paths.
+- Make only a tiny edit when required to make a finding understandable on its own.
+- Keep the original numbering text inside the block body.
+- Preserve Markdown lists and blank lines within a comment.
+
+Wrap each finding in a separate region:
+
+```markdown
+<!-- comment:begin slug="concise-kebab-case-slug" -->
+1. **Severity:** Major
+   **Location:** ...
+   **Problem:** ...
+   **Recommendation:** ...
+   **Rationale:** ...
+   **Scratchpad:** ...
+<!-- comment:end slug="concise-kebab-case-slug" -->
+```
+
+Use a unique lowercase kebab-case slug. The begin and end slugs must match. Keep only blank lines between regions and no document-level introduction or summary.
+
+## Write safely
+
+- Create only the timestamped findings directory and `finding.md`.
+- Use `apply_patch` for the file content.
+- Do not modify the implementation plan, scratchpads, application code, tests, or documentation.
+- If the target already exists with different content, do not overwrite it unless the user explicitly requested replacement or update.
+
+## Validate
+
+Run the bundled validator with the exact number of exported review comments:
+
+```bash
+python3 .agents/skills/export-plan-review-comments/scripts/validate_comments_export.py \
+  .ai/impl_plans/<plan-id>/findings/<YYMMDD-HHMM>/finding.md \
+  --expected-count <count>
+```
+
+Fix every validation error before finishing. Then read the file once to confirm that wording and links still match the source comments.
+
+## Respond
+
+Reply with only a clickable link to the created file:
+
+```markdown
+[.ai/impl_plans/<plan-id>/findings/<YYMMDD-HHMM>/finding.md](.ai/impl_plans/<plan-id>/findings/<YYMMDD-HHMM>/finding.md)
+```

--- a/.agents/skills/export-plan-review-comments/agents/openai.yaml
+++ b/.agents/skills/export-plan-review-comments/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Export Plan Review Comments"
+  short_description: "Export plan-review comments to Markdown"
+  default_prompt: "Use $export-plan-review-comments to export the survived implementation-plan review comments into the plan timestamped findings Markdown file."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/export-plan-review-comments/scripts/validate_comments_export.py
+++ b/.agents/skills/export-plan-review-comments/scripts/validate_comments_export.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate a timestamped implementation-plan review comments export."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+BEGIN_RE = re.compile(r'^<!-- comment:begin slug="([a-z0-9]+(?:-[a-z0-9]+)*)" -->$')
+END_RE = re.compile(r'^<!-- comment:end slug="([a-z0-9]+(?:-[a-z0-9]+)*)" -->$')
+NUMBER_RE = re.compile(r"^(\d+)\.\s+\S")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Markdown export to validate.")
+    parser.add_argument(
+        "--expected-count",
+        type=int,
+        help="Require exactly this many comment blocks.",
+    )
+    return parser.parse_args()
+
+
+def validate(path: Path, expected_count: int | None) -> list[str]:
+    errors: list[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return [f"cannot read {path}: {exc}"]
+
+    blocks: list[tuple[str, int, list[str]]] = []
+    seen_slugs: set[str] = set()
+    active_slug: str | None = None
+    active_start = 0
+    active_body: list[str] = []
+
+    for line_number, line in enumerate(lines, start=1):
+        begin_match = BEGIN_RE.fullmatch(line)
+        end_match = END_RE.fullmatch(line)
+
+        if begin_match:
+            slug = begin_match.group(1)
+            if active_slug is not None:
+                errors.append(f"line {line_number}: nested begin for {slug!r} inside {active_slug!r}")
+                continue
+            if slug in seen_slugs:
+                errors.append(f"line {line_number}: duplicate slug {slug!r}")
+            seen_slugs.add(slug)
+            active_slug = slug
+            active_start = line_number
+            active_body = []
+            continue
+
+        if end_match:
+            slug = end_match.group(1)
+            if active_slug is None:
+                errors.append(f"line {line_number}: end marker for {slug!r} has no begin")
+                continue
+            if slug != active_slug:
+                errors.append(f"line {line_number}: end slug {slug!r} does not match {active_slug!r}")
+            blocks.append((active_slug, active_start, active_body))
+            active_slug = None
+            active_start = 0
+            active_body = []
+            continue
+
+        if active_slug is None:
+            if line.strip():
+                errors.append(f"line {line_number}: nonblank content outside a comment block")
+        else:
+            active_body.append(line)
+
+    if active_slug is not None:
+        errors.append(f"line {active_start}: comment {active_slug!r} has no end marker")
+
+    if expected_count is not None and expected_count < 0:
+        errors.append("--expected-count must be non-negative")
+    elif expected_count is not None and len(blocks) != expected_count:
+        errors.append(f"expected {expected_count} comment blocks, found {len(blocks)}")
+
+    for index, (slug, start, body) in enumerate(blocks, start=1):
+        first_content = next((line for line in body if line.strip()), None)
+        if first_content is None:
+            errors.append(f"line {start}: comment {slug!r} is empty")
+            continue
+        number_match = NUMBER_RE.match(first_content)
+        if number_match is None:
+            errors.append(f"line {start}: first content in comment {slug!r} must retain list numbering")
+            continue
+        number = int(number_match.group(1))
+        if number != index:
+            errors.append(f"line {start}: comment {slug!r} is numbered {number}, expected {index}")
+
+    if not blocks and not errors:
+        errors.append("no comment blocks found")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    errors = validate(args.path, args.expected_count)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    block_count = sum(1 for line in args.path.read_text(encoding="utf-8").splitlines() if BEGIN_RE.fullmatch(line))
+    print(f"OK comments={block_count} path={args.path.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/implementation-plan-review/SKILL.md
+++ b/.agents/skills/implementation-plan-review/SKILL.md
@@ -13,7 +13,7 @@ Review an implementation plan for coverage, correctness, and fit with the curren
 - Implementation plan: a local file path.
 - Issue/requirements: either (a) a local file path, or (b) a GitHub issue number (run from the target repo so `gh` resolves it).
 
-If the user provides a GitHub issue number, prefer fetching it into a local file using the bundled script (requires `gh` auth and network access; otherwise ask for a local issue description file):
+If the user provides a GitHub issue number, prefer fetching it into a local file using the bundled script:
 
 ```bash
 bash scripts/fetch_github_issue.sh <issue-number> --out /tmp/issue.md
@@ -23,22 +23,23 @@ Run this command from the skill directory when that directory is inside the targ
 command agent-agnostic by resolving the script path relative to this skill directory while running `gh` from the target
 repo so the issue number resolves against the correct repository.
 
-If the script reports that `gh` is not authenticated (exit code `3`), ask the user to run:
-
-```bash
-gh auth login
-```
+Fetching is a network operation. When command execution is sandboxed, request
+network escalation (`require_escalated`) for this exact fetch command rather
+than granting a reusable broad `bash` permission. On failure, follow the
+script's self-contained `ACTION` line. It distinguishes unavailable network
+(exit `6`), credentials unavailable to the process (exit `3`), other GitHub
+fetch failures (exit `4`), and local output failures (exit `5`).
 
 ## Workflow
 
-1) Prepare clean scratchpads:
+1) Prepare a clean review run:
    - Before reading or listing any scratchpad files, run from this skill directory:
 
 ```bash
 bash scripts/new_scratchpads_dir.sh <plan-file>
 ```
 
-   - Use exactly the absolute path the script printed on stdout for this run's scratchpads; never glob or guess a path under `scratchpads/` yourself.
+   - Use exactly the absolute path the script printed on stdout as this review's run directory; never glob or guess a path under `scratchpads/` yourself.
    - Each run creates a fresh timestamped directory (`scratchpads/<YYMMDD-HHMM>/`); nothing is deleted. Directories from earlier reviews belong to a different run — never read or reuse them for this review. (If the printed path is ever lost from context, the lexicographically-last timestamp subdirectory is the most recent, since the format sorts chronologically — but prefer the printed path.)
    - If the script fails (non-zero exit; `error: <message>` on stderr), stop and report the failure.
 
@@ -73,26 +74,95 @@ rg -n "ServerConfig\\(|BaseSettings\\(|BLOCKSCOUT_" blockscout_mcp_server/config
 rg -n "pytest\\.mark\\.integration|tests/integration|tests/tools" tests -S
 ```
 
-6) Ground findings with scratchpads:
-   - Use only the clean scratchpad directory prepared in step 1.
-   - For each actionable candidate finding, create one deterministic scratchpad file in final report order:
-     - `finding-01-short-slug.md`
-     - `finding-02-short-slug.md`
-     - Continue numbering in the same order used in §4.
-   - Each scratchpad must include these sections:
-     - `Grounded context`: exact code, docs, tests, configs, or rules inspected, with paths/functions/classes where relevant.
-     - `Variants`: at least 2 meaningful solution options; use 3-4 for non-trivial findings.
-     - `Rubric`: criteria for choosing between variants.
-     - `Evaluation`: a score table or concise comparison of variants against the rubric.
-     - `Best recommendation`: the concrete change to make to the implementation plan.
-     - `Plain-language rationale`: why the chosen recommendation is best.
-   - Use the scratchpad result to rewrite the final §4 recommendation. If scratchpad investigation disproves or weakens a finding, remove it or downgrade it before final output.
-   - Findings that cannot be grounded in a scratchpad should normally be omitted. Keep them only when they are genuinely product/intent questions and mark them as `Question`.
+6) Independently adjudicate candidate findings:
 
-Scratchpad discipline:
-- Scratchpads are working artifacts created by this review skill to make final recommendations grounded.
-- Do not create scratchpads for pure summary text, obvious nits, or questions that require user/product input rather than code investigation.
-- Do not use scratchpads to pad the report; use them only to make actionable recommendations more accurate.
+   Read these two skill resources completely before creating candidate inputs or
+   launching adjudicators:
+
+   - `references/finding-adjudication-protocol.md`
+   - `assets/finding-adjudication-report.md`
+
+   Treat every initially suspected problem as a **candidate**, not a final
+   finding. Do not create candidates for pure summary text or obvious nits.
+
+   For each candidate, create a directory in the clean run:
+
+```text
+finding-01-short-slug/
+├── input.md
+├── full-report.md  # written by the adjudicator
+└── brief.md        # generated by the finalizer
+```
+
+   Create `input.md` with:
+
+   - candidate ID;
+   - absolute plan, issue snapshot, template, protocol, and output paths;
+   - one neutral, falsifiable candidate hypothesis;
+   - focused research questions;
+   - candidate-specific scope or edge cases;
+   - an explicit statement that `Confirmed`, `Downgraded`, `Question`, and
+     `Closed` are all successful outcomes.
+
+   Do not include prior scratchpad conclusions, a preferred solution, expected
+   disposition, or another adjudicator's work.
+
+   Launch one independent subagent per candidate, batching when concurrency is
+   limited. Use `fork_turns="none"` so the adjudicator receives only the
+   candidate input and stable protocol. Prefer a strong reasoning model
+   (`gpt-5.6-sol` with `xhigh` reasoning when available) unless the user
+   requests otherwise. The launcher prompt should contain only:
+
+   - the absolute protocol path and instruction to read it completely;
+   - the absolute `input.md` path;
+   - the exact writable candidate directory;
+   - the absolute template path;
+   - the requirement to run the protocol's finalization loop before returning.
+
+   Each adjudicator must write `full-report.md`, run
+   `scripts/finalize_adjudication.py`, fix every validation error, and return
+   only the protocol's short completion record. The script deterministically
+   generates `brief.md`; the adjudicator must not edit the brief.
+
+   After all adjudicators finish, independently verify the complete run:
+
+```bash
+python3 scripts/verify_adjudication_run.py \
+  --run <absolute-run-directory> \
+  --expected-count <candidate-count>
+```
+
+   If verification fails, send the exact errors back to the responsible
+   adjudicator and require it to correct and re-finalize its report. Do not use
+   an invalid or stale brief.
+
+   Read all valid `brief.md` files first. Open the full report or extract a
+   tagged section only when progressive disclosure is warranted, for example:
+
+   - unexpected `Closed` or `Downgraded` disposition;
+   - low confidence or a close variant result;
+   - a decision that depends on an unresolved product assumption;
+   - overlap or conflict between candidates;
+   - a recommendation that materially expands plan scope;
+   - a challenged finding.
+
+   Extract one validated section without loading the full report:
+
+```bash
+python3 scripts/finalize_adjudication.py \
+  --report <candidate-directory>/full-report.md \
+  --extract <section-slug>
+```
+
+   The main agent owns cross-finding work: deduplicate overlapping candidates,
+   resolve conflicts, apply one common severity scale, and assess cumulative
+   scope. Case-specific rubric totals are not comparable across candidates.
+
+   Only `Confirmed`, actionable `Downgraded`, and unresolved `Question`
+   candidates may reach final §4. Omit `Closed` candidates. Point the final
+   comment's `Scratchpad` field to the candidate's generated `brief.md`, never
+   directly to `full-report.md`. The brief's generated `Source` link is the
+   progressive-disclosure path to the full report.
 
 7) Produce the review in the required format (next section).
 
@@ -125,7 +195,7 @@ Provide comments as a list. Each comment must include:
 - Problem: what’s wrong / missing
 - Recommendation: concrete change to the plan
 - Rationale: why it matters (bug risk / security / perf / maintainability)
-- Scratchpad: path to the backing scratchpad file, when the comment is actionable and not a pure `Question`
+- Scratchpad: path to the candidate's generated `brief.md`, when the comment is actionable and not a pure `Question`; never link `full-report.md` directly from the final review
 
 **Testing gaps rule:**
 

--- a/.agents/skills/implementation-plan-review/assets/finding-adjudication-report.md
+++ b/.agents/skills/implementation-plan-review/assets/finding-adjudication-report.md
@@ -1,0 +1,87 @@
+<!-- finding_adjudication:begin disclosure="core" slug="candidate-hypothesis" -->
+# Candidate hypothesis
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="candidate-hypothesis" -->
+
+<!-- finding_adjudication:begin disclosure="reference" slug="requirement-interpretations" -->
+# Requirement interpretations
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="requirement-interpretations" -->
+
+<!-- finding_adjudication:begin disclosure="reference" slug="investigation" -->
+# Investigation
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="investigation" -->
+
+<!-- finding_adjudication:begin disclosure="reference" slug="evidence-for-and-against" -->
+# Evidence for and against
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="evidence-for-and-against" -->
+
+<!-- finding_adjudication:begin disclosure="core" slug="evidence-synthesis" -->
+# Evidence synthesis
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="evidence-synthesis" -->
+
+<!-- finding_adjudication:begin disclosure="core" slug="disposition" -->
+# Disposition
+
+<!-- adjudication-result: {"disposition":"REPLACE_ME","confidence":0.0,"severity":"REPLACE_ME"} -->
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="disposition" -->
+
+<!-- finding_adjudication:begin disclosure="reference" slug="feasible-response-variants" -->
+# Feasible response variants
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="feasible-response-variants" -->
+
+<!-- finding_adjudication:begin disclosure="reference" slug="decision-rubric" -->
+# Decision rubric
+
+<!-- rubric-weights: {"REPLACE_ME":100} -->
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="decision-rubric" -->
+
+<!-- finding_adjudication:begin disclosure="reference" slug="variant-evaluation" -->
+# Variant evaluation
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="variant-evaluation" -->
+
+<!-- finding_adjudication:begin disclosure="reference" slug="sensitivity-analysis" -->
+# Sensitivity analysis
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="sensitivity-analysis" -->
+
+<!-- finding_adjudication:begin disclosure="core" slug="decision-boundary" -->
+# Decision boundary
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="decision-boundary" -->
+
+<!-- finding_adjudication:begin disclosure="core" slug="recommendation" -->
+# Recommendation
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="recommendation" -->
+
+<!-- finding_adjudication:begin disclosure="core" slug="residual-uncertainty" -->
+# Residual uncertainty
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="residual-uncertainty" -->
+
+<!-- finding_adjudication:begin disclosure="core" slug="overlap" -->
+# Overlap with other candidates
+
+REPLACE_ME
+<!-- finding_adjudication:end slug="overlap" -->

--- a/.agents/skills/implementation-plan-review/references/finding-adjudication-protocol.md
+++ b/.agents/skills/implementation-plan-review/references/finding-adjudication-protocol.md
@@ -1,0 +1,130 @@
+# Finding adjudication protocol
+
+Use this protocol for one independently investigated candidate finding from an
+implementation-plan review.
+
+## Inputs and allowed output
+
+The launcher prompt supplies:
+
+- a candidate `input.md`;
+- the report template path;
+- the exact candidate output directory;
+- the implementation plan and issue snapshot paths through `input.md`.
+
+Read the plan and issue snapshot in full before reaching a disposition. Read
+repository code, tests, rules, and documentation as needed. Do not implement
+the plan.
+
+Write only `full-report.md` in the candidate output directory. The finalizer
+creates `brief.md`. Do not edit `input.md`, the plan, issue snapshot, code,
+tests, documentation, skill files, or another candidate's artifacts.
+
+## Isolation
+
+- Treat the candidate hypothesis as unproven. Confirm, narrow, question, or
+  close it according to evidence.
+- Do not read prior review scratchpads, prior adjudication runs, another
+  candidate directory, or another adjudicator's messages.
+- Do not ask another adjudicator for its conclusion or rubric.
+- If an applicable repository skill requires an isolated specialist such as a
+  SPEC-only consultant, it may be used. Keep the final adjudication independent.
+- Do not infer desired conclusions from candidate numbering, wording, or the
+  fact that the main agent selected the candidate.
+
+## Investigation and decision method
+
+1. State the strongest requirement interpretations both supporting and
+   defeating the candidate. Separate explicit requirements, repository facts,
+   and assumptions.
+2. Investigate the relevant production path, tests, rules, documentation, and
+   history. Seek counterevidence rather than merely accumulating support.
+3. Synthesize the decisive evidence and strongest counterargument.
+4. Choose exactly one disposition:
+   - `Confirmed`: actionable substantially as hypothesized.
+   - `Downgraded`: a narrower or lower-severity issue survives.
+   - `Question`: product or ownership information is required before deciding.
+   - `Closed`: no actionable issue remains.
+5. Consider 2–4 genuinely feasible response variants, including no change,
+   close, or narrower wording when plausible. Explicitly reject attractive but
+   invalid shortcuts.
+6. Build a case-specific rubric with 2–8 criteria. For every criterion give its
+   provenance, scoring direction, and weight. Weights must total 100.
+7. Score every feasible variant with evidence for each score and show the
+   weighted totals.
+8. Perform sensitivity analysis. Identify the assumptions or reasonable weight
+   changes that can alter the winner.
+9. State the decision boundary before the recommendation: what newly learned
+   fact or changed requirement would alter the disposition or preferred variant.
+10. Record residual uncertainty and likely overlap with other candidates
+    without reading their reports.
+
+Use the review severity vocabulary: `Blocker`, `Major`, `Minor`, `Question`,
+`Nit`, or `None`. A `Closed` candidate must use `None`; a `Question` candidate
+must use `Question`.
+
+## Full report contract
+
+Use the supplied `finding-adjudication-report.md` template exactly:
+
+- preserve every section, tag, slug, disclosure value, and section order;
+- preserve each required first-level heading;
+- replace every `REPLACE_ME`;
+- do not nest tagged sections;
+- put no nonblank content outside tagged sections;
+- keep recommendation after variants, rubric, evaluation, and sensitivity;
+- keep all core sections combined under 1,000 words.
+
+The `adjudication-result` comment must be valid one-line JSON:
+
+```html
+<!-- adjudication-result: {"disposition":"Closed","confidence":0.92,"severity":"None"} -->
+```
+
+The `rubric-weights` comment must be valid one-line JSON with 2–8
+kebab-case criterion slugs and positive weights totaling 100:
+
+```html
+<!-- rubric-weights: {"contract-fidelity":35,"regression-risk":25,"scope":40} -->
+```
+
+`disclosure="core"` means the section is copied verbatim into the default brief.
+It does not mean the section should be written first. `reference` sections are
+equally important to the adjudicator's reasoning and remain available in the
+full report.
+
+Core sections must be independently understandable. In particular:
+
+- `Evidence synthesis` includes 3–6 decisive facts and the strongest
+  counterargument with source pointers.
+- `Disposition` states the surviving problem and its practical severity.
+- `Decision boundary` states the assumption that can flip the conclusion.
+- `Recommendation` gives the concrete plan change, or explicitly says no plan
+  change.
+- `Residual uncertainty` distinguishes unresolved facts from speculation.
+- `Overlap` names conceptual areas of likely duplication, or says none found;
+  it must not cite unread candidate reports.
+
+## Mandatory finalization loop
+
+After writing `full-report.md`, run:
+
+```bash
+python3 <skill-dir>/scripts/finalize_adjudication.py \
+  --report <candidate-output-dir>/full-report.md
+```
+
+If validation fails, fix `full-report.md` and rerun the command. Do not return
+until it succeeds and creates the sibling `brief.md`. Do not edit `brief.md`
+manually.
+
+Return only:
+
+```text
+Completed.
+Disposition: <value>
+Confidence: <0..1>
+Validation: passed
+Brief: <absolute path>
+Full report: <absolute path>
+```

--- a/.agents/skills/implementation-plan-review/scripts/_adjudication_report.py
+++ b/.agents/skills/implementation-plan-review/scripts/_adjudication_report.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Shared parser, validator, and renderer for finding adjudication reports."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+NAMESPACE: Final = "finding_adjudication"
+REPORT_NAME: Final = "full-report.md"
+BRIEF_NAME: Final = "brief.md"
+INPUT_NAME: Final = "input.md"
+MAX_CORE_WORDS: Final = 1_000
+
+_MARKER_RE = re.compile(
+    rf'^<!-- {NAMESPACE}:(?P<kind>begin|end)'
+    r'(?P<attrs>(?:\s+[a-z][a-z0-9_-]*="[^"]*")*)\s*-->$'
+)
+_ATTRIBUTE_RE = re.compile(r'([a-z][a-z0-9_-]*)="([^"]*)"')
+_RESULT_RE = re.compile(r"<!-- adjudication-result: (?P<json>\{.*\}) -->")
+_WEIGHTS_RE = re.compile(r"<!-- rubric-weights: (?P<json>\{.*\}) -->")
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_WORD_RE = re.compile(r"\b[\w'-]+\b", re.UNICODE)
+
+DISPOSITIONS: Final = {"Confirmed", "Downgraded", "Question", "Closed"}
+SEVERITIES: Final = {"Blocker", "Major", "Minor", "Question", "Nit", "None"}
+
+
+@dataclass(frozen=True)
+class SectionSpec:
+    slug: str
+    disclosure: str
+    heading: str
+
+
+SECTION_SPECS: Final[tuple[SectionSpec, ...]] = (
+    SectionSpec("candidate-hypothesis", "core", "# Candidate hypothesis"),
+    SectionSpec(
+        "requirement-interpretations",
+        "reference",
+        "# Requirement interpretations",
+    ),
+    SectionSpec("investigation", "reference", "# Investigation"),
+    SectionSpec(
+        "evidence-for-and-against",
+        "reference",
+        "# Evidence for and against",
+    ),
+    SectionSpec("evidence-synthesis", "core", "# Evidence synthesis"),
+    SectionSpec("disposition", "core", "# Disposition"),
+    SectionSpec(
+        "feasible-response-variants",
+        "reference",
+        "# Feasible response variants",
+    ),
+    SectionSpec("decision-rubric", "reference", "# Decision rubric"),
+    SectionSpec("variant-evaluation", "reference", "# Variant evaluation"),
+    SectionSpec(
+        "sensitivity-analysis",
+        "reference",
+        "# Sensitivity analysis",
+    ),
+    SectionSpec("decision-boundary", "core", "# Decision boundary"),
+    SectionSpec("recommendation", "core", "# Recommendation"),
+    SectionSpec(
+        "residual-uncertainty",
+        "core",
+        "# Residual uncertainty",
+    ),
+    SectionSpec("overlap", "core", "# Overlap with other candidates"),
+)
+
+_SPEC_BY_SLUG: Final = {spec.slug: spec for spec in SECTION_SPECS}
+
+
+class ReportValidationError(ValueError):
+    """Raised when a report violates the adjudication artifact contract."""
+
+    def __init__(self, errors: list[str] | tuple[str, ...]):
+        self.errors = tuple(errors)
+        super().__init__("\n".join(f"- {error}" for error in self.errors))
+
+
+@dataclass(frozen=True)
+class ReportSection:
+    slug: str
+    disclosure: str
+    content: str
+    begin_line: int
+    end_line: int
+
+
+@dataclass(frozen=True)
+class AdjudicationReport:
+    path: Path
+    raw_bytes: bytes
+    sections: tuple[ReportSection, ...]
+    result: dict[str, object]
+    rubric_weights: dict[str, float]
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.raw_bytes).hexdigest()
+
+    def section(self, slug: str) -> ReportSection:
+        for section in self.sections:
+            if section.slug == slug:
+                return section
+        raise KeyError(slug)
+
+
+def _parse_attributes(raw: str, line_number: int) -> tuple[dict[str, str], list[str]]:
+    attributes: dict[str, str] = {}
+    errors: list[str] = []
+    cursor = 0
+    for match in _ATTRIBUTE_RE.finditer(raw):
+        gap = raw[cursor : match.start()]
+        if gap.strip():
+            errors.append(
+                f"line {line_number}: malformed tag attributes near {gap.strip()!r}"
+            )
+        cursor = match.end()
+        key, value = match.groups()
+        if key in attributes:
+            errors.append(f"line {line_number}: duplicate attribute {key!r}")
+        attributes[key] = value
+    if raw[cursor:].strip():
+        errors.append(
+            f"line {line_number}: malformed tag attributes near "
+            f"{raw[cursor:].strip()!r}"
+        )
+    return attributes, errors
+
+
+def _first_nonblank_line(content: str) -> str | None:
+    for line in content.splitlines():
+        if line.strip():
+            return line.strip()
+    return None
+
+
+def _load_json_comment(
+    *,
+    content: str,
+    regex: re.Pattern[str],
+    label: str,
+    slug: str,
+    errors: list[str],
+) -> dict[str, object] | None:
+    matches = list(regex.finditer(content))
+    if len(matches) != 1:
+        errors.append(
+            f"section {slug!r}: expected exactly one {label} JSON comment, "
+            f"found {len(matches)}"
+        )
+        return None
+    try:
+        value = json.loads(matches[0].group("json"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"section {slug!r}: invalid {label} JSON: {exc}")
+        return None
+    if not isinstance(value, dict):
+        errors.append(f"section {slug!r}: {label} JSON must be an object")
+        return None
+    return value
+
+
+def _validate_result(value: dict[str, object] | None, errors: list[str]) -> None:
+    if value is None:
+        return
+    expected_keys = {"disposition", "confidence", "severity"}
+    if set(value) != expected_keys:
+        errors.append(
+            "adjudication-result: keys must be exactly "
+            "'disposition', 'confidence', and 'severity'"
+        )
+    disposition = value.get("disposition")
+    if disposition not in DISPOSITIONS:
+        errors.append(
+            f"adjudication-result: disposition must be one of "
+            f"{sorted(DISPOSITIONS)}, got {disposition!r}"
+        )
+    severity = value.get("severity")
+    if severity not in SEVERITIES:
+        errors.append(
+            f"adjudication-result: severity must be one of "
+            f"{sorted(SEVERITIES)}, got {severity!r}"
+        )
+    confidence = value.get("confidence")
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, (int, float))
+        or not 0 <= confidence <= 1
+    ):
+        errors.append(
+            "adjudication-result: confidence must be a number from 0 through 1"
+        )
+    if disposition == "Closed" and severity != "None":
+        errors.append("adjudication-result: Closed disposition requires severity None")
+    if disposition == "Question" and severity != "Question":
+        errors.append(
+            "adjudication-result: Question disposition requires severity Question"
+        )
+
+
+def _validate_weights(
+    value: dict[str, object] | None, errors: list[str]
+) -> dict[str, float]:
+    if value is None:
+        return {}
+    if not 2 <= len(value) <= 8:
+        errors.append("rubric-weights: expected between 2 and 8 criteria")
+    normalized: dict[str, float] = {}
+    for key, weight in value.items():
+        if not isinstance(key, str) or not _SLUG_RE.fullmatch(key):
+            errors.append(
+                f"rubric-weights: criterion key must be a kebab-case slug, got {key!r}"
+            )
+            continue
+        if (
+            isinstance(weight, bool)
+            or not isinstance(weight, (int, float))
+            or weight <= 0
+        ):
+            errors.append(
+                f"rubric-weights: weight for {key!r} must be a positive number"
+            )
+            continue
+        normalized[key] = float(weight)
+    if normalized and abs(sum(normalized.values()) - 100) > 1e-9:
+        errors.append(
+            f"rubric-weights: weights must total 100, got "
+            f"{sum(normalized.values()):g}"
+        )
+    return normalized
+
+
+def parse_and_validate_report(path: Path | str) -> AdjudicationReport:
+    """Parse and validate one full adjudication report."""
+
+    report_path = Path(path).resolve()
+    errors: list[str] = []
+    if report_path.name != REPORT_NAME:
+        errors.append(f"report filename must be {REPORT_NAME!r}")
+    if not report_path.is_file():
+        raise ReportValidationError([f"report does not exist: {report_path}"])
+    if report_path.is_symlink():
+        errors.append("report must not be a symbolic link")
+
+    raw_bytes = report_path.read_bytes()
+    try:
+        text = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ReportValidationError([f"report is not valid UTF-8: {exc}"]) from exc
+
+    sections: list[ReportSection] = []
+    current_slug: str | None = None
+    current_disclosure: str | None = None
+    current_begin_line = 0
+    current_lines: list[str] = []
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        marker = _MARKER_RE.fullmatch(line.strip())
+        if marker is None:
+            if NAMESPACE in line:
+                errors.append(f"line {line_number}: malformed {NAMESPACE} marker")
+            if current_slug is None:
+                if line.strip():
+                    errors.append(
+                        f"line {line_number}: nonblank content outside tagged sections"
+                    )
+            else:
+                current_lines.append(line)
+            continue
+
+        attributes, attribute_errors = _parse_attributes(
+            marker.group("attrs"), line_number
+        )
+        errors.extend(attribute_errors)
+        kind = marker.group("kind")
+
+        if kind == "begin":
+            if set(attributes) != {"disclosure", "slug"}:
+                errors.append(
+                    f"line {line_number}: begin marker attributes must be exactly "
+                    "'disclosure' and 'slug'"
+                )
+            if current_slug is not None:
+                errors.append(
+                    f"line {line_number}: nested section inside {current_slug!r}"
+                )
+                continue
+            current_slug = attributes.get("slug", "")
+            current_disclosure = attributes.get("disclosure", "")
+            current_begin_line = line_number
+            current_lines = []
+            continue
+
+        if set(attributes) != {"slug"}:
+            errors.append(
+                f"line {line_number}: end marker attribute must be exactly 'slug'"
+            )
+        if current_slug is None:
+            errors.append(f"line {line_number}: end marker without an open section")
+            continue
+        end_slug = attributes.get("slug", "")
+        if end_slug != current_slug:
+            errors.append(
+                f"line {line_number}: end slug {end_slug!r} does not match "
+                f"open slug {current_slug!r}"
+            )
+        sections.append(
+            ReportSection(
+                slug=current_slug,
+                disclosure=current_disclosure or "",
+                content="\n".join(current_lines).strip() + "\n",
+                begin_line=current_begin_line,
+                end_line=line_number,
+            )
+        )
+        current_slug = None
+        current_disclosure = None
+        current_lines = []
+
+    if current_slug is not None:
+        errors.append(
+            f"section {current_slug!r} opened on line {current_begin_line} is not closed"
+        )
+
+    actual_slugs = [section.slug for section in sections]
+    expected_slugs = [spec.slug for spec in SECTION_SPECS]
+    if actual_slugs != expected_slugs:
+        errors.append(
+            "section slugs/order mismatch: expected "
+            f"{expected_slugs!r}, got {actual_slugs!r}"
+        )
+    if len(set(actual_slugs)) != len(actual_slugs):
+        errors.append("section slugs must be unique")
+
+    for section in sections:
+        spec = _SPEC_BY_SLUG.get(section.slug)
+        if spec is None:
+            continue
+        if section.disclosure != spec.disclosure:
+            errors.append(
+                f"section {section.slug!r}: disclosure must be "
+                f"{spec.disclosure!r}, got {section.disclosure!r}"
+            )
+        first_line = _first_nonblank_line(section.content)
+        if first_line != spec.heading:
+            errors.append(
+                f"section {section.slug!r}: first nonblank line must be "
+                f"{spec.heading!r}, got {first_line!r}"
+            )
+        if "REPLACE_ME" in section.content:
+            errors.append(f"section {section.slug!r}: unresolved REPLACE_ME placeholder")
+
+    section_map = {section.slug: section for section in sections}
+    disposition_section = section_map.get("disposition")
+    result_value = (
+        _load_json_comment(
+            content=disposition_section.content,
+            regex=_RESULT_RE,
+            label="adjudication-result",
+            slug="disposition",
+            errors=errors,
+        )
+        if disposition_section
+        else None
+    )
+    _validate_result(result_value, errors)
+
+    rubric_section = section_map.get("decision-rubric")
+    weights_value = (
+        _load_json_comment(
+            content=rubric_section.content,
+            regex=_WEIGHTS_RE,
+            label="rubric-weights",
+            slug="decision-rubric",
+            errors=errors,
+        )
+        if rubric_section
+        else None
+    )
+    normalized_weights = _validate_weights(weights_value, errors)
+
+    core_word_count = sum(
+        len(_WORD_RE.findall(section.content))
+        for section in sections
+        if section.disclosure == "core"
+    )
+    if core_word_count > MAX_CORE_WORDS:
+        errors.append(
+            f"core sections contain {core_word_count} words; maximum is "
+            f"{MAX_CORE_WORDS}"
+        )
+
+    if errors:
+        raise ReportValidationError(errors)
+
+    return AdjudicationReport(
+        path=report_path,
+        raw_bytes=raw_bytes,
+        sections=tuple(sections),
+        result=result_value or {},
+        rubric_weights=normalized_weights,
+    )
+
+
+def render_brief(report: AdjudicationReport) -> str:
+    """Render a deterministic brief from core sections in report order."""
+
+    source_link = f"./{report.path.name}"
+    blocks = [
+        "<!-- generated by implementation-plan-review; do not edit -->",
+        f"<!-- source-sha256: {report.sha256} -->",
+        f"Source: [{report.path.name}]({source_link})",
+    ]
+    blocks.extend(
+        section.content.rstrip()
+        for section in report.sections
+        if section.disclosure == "core"
+    )
+    return "\n\n".join(blocks) + "\n"
+
+
+def write_text_atomically(path: Path | str, content: str) -> None:
+    """Write UTF-8 text atomically in the destination directory."""
+
+    destination = Path(path).resolve()
+    destination.parent.mkdir(parents=False, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
+    try:
+        temporary.write_text(content, encoding="utf-8")
+        os.replace(temporary, destination)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def expected_candidate_files() -> set[str]:
+    """Return the exact allowed file set for a completed candidate directory."""
+
+    return {INPUT_NAME, REPORT_NAME, BRIEF_NAME}

--- a/.agents/skills/implementation-plan-review/scripts/_adjudication_report.py
+++ b/.agents/skills/implementation-plan-review/scripts/_adjudication_report.py
@@ -18,7 +18,7 @@ INPUT_NAME: Final = "input.md"
 MAX_CORE_WORDS: Final = 1_000
 
 _MARKER_RE = re.compile(
-    rf'^<!-- {NAMESPACE}:(?P<kind>begin|end)'
+    rf"^<!-- {NAMESPACE}:(?P<kind>begin|end)"
     r'(?P<attrs>(?:\s+[a-z][a-z0-9_-]*="[^"]*")*)\s*-->$'
 )
 _ATTRIBUTE_RE = re.compile(r'([a-z][a-z0-9_-]*)="([^"]*)"')
@@ -121,19 +121,14 @@ def _parse_attributes(raw: str, line_number: int) -> tuple[dict[str, str], list[
     for match in _ATTRIBUTE_RE.finditer(raw):
         gap = raw[cursor : match.start()]
         if gap.strip():
-            errors.append(
-                f"line {line_number}: malformed tag attributes near {gap.strip()!r}"
-            )
+            errors.append(f"line {line_number}: malformed tag attributes near {gap.strip()!r}")
         cursor = match.end()
         key, value = match.groups()
         if key in attributes:
             errors.append(f"line {line_number}: duplicate attribute {key!r}")
         attributes[key] = value
     if raw[cursor:].strip():
-        errors.append(
-            f"line {line_number}: malformed tag attributes near "
-            f"{raw[cursor:].strip()!r}"
-        )
+        errors.append(f"line {line_number}: malformed tag attributes near {raw[cursor:].strip()!r}")
     return attributes, errors
 
 
@@ -154,10 +149,7 @@ def _load_json_comment(
 ) -> dict[str, object] | None:
     matches = list(regex.finditer(content))
     if len(matches) != 1:
-        errors.append(
-            f"section {slug!r}: expected exactly one {label} JSON comment, "
-            f"found {len(matches)}"
-        )
+        errors.append(f"section {slug!r}: expected exactly one {label} JSON comment, found {len(matches)}")
         return None
     try:
         value = json.loads(matches[0].group("json"))
@@ -175,42 +167,23 @@ def _validate_result(value: dict[str, object] | None, errors: list[str]) -> None
         return
     expected_keys = {"disposition", "confidence", "severity"}
     if set(value) != expected_keys:
-        errors.append(
-            "adjudication-result: keys must be exactly "
-            "'disposition', 'confidence', and 'severity'"
-        )
+        errors.append("adjudication-result: keys must be exactly 'disposition', 'confidence', and 'severity'")
     disposition = value.get("disposition")
     if disposition not in DISPOSITIONS:
-        errors.append(
-            f"adjudication-result: disposition must be one of "
-            f"{sorted(DISPOSITIONS)}, got {disposition!r}"
-        )
+        errors.append(f"adjudication-result: disposition must be one of {sorted(DISPOSITIONS)}, got {disposition!r}")
     severity = value.get("severity")
     if severity not in SEVERITIES:
-        errors.append(
-            f"adjudication-result: severity must be one of "
-            f"{sorted(SEVERITIES)}, got {severity!r}"
-        )
+        errors.append(f"adjudication-result: severity must be one of {sorted(SEVERITIES)}, got {severity!r}")
     confidence = value.get("confidence")
-    if (
-        isinstance(confidence, bool)
-        or not isinstance(confidence, (int, float))
-        or not 0 <= confidence <= 1
-    ):
-        errors.append(
-            "adjudication-result: confidence must be a number from 0 through 1"
-        )
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1:
+        errors.append("adjudication-result: confidence must be a number from 0 through 1")
     if disposition == "Closed" and severity != "None":
         errors.append("adjudication-result: Closed disposition requires severity None")
     if disposition == "Question" and severity != "Question":
-        errors.append(
-            "adjudication-result: Question disposition requires severity Question"
-        )
+        errors.append("adjudication-result: Question disposition requires severity Question")
 
 
-def _validate_weights(
-    value: dict[str, object] | None, errors: list[str]
-) -> dict[str, float]:
+def _validate_weights(value: dict[str, object] | None, errors: list[str]) -> dict[str, float]:
     if value is None:
         return {}
     if not 2 <= len(value) <= 8:
@@ -218,25 +191,14 @@ def _validate_weights(
     normalized: dict[str, float] = {}
     for key, weight in value.items():
         if not isinstance(key, str) or not _SLUG_RE.fullmatch(key):
-            errors.append(
-                f"rubric-weights: criterion key must be a kebab-case slug, got {key!r}"
-            )
+            errors.append(f"rubric-weights: criterion key must be a kebab-case slug, got {key!r}")
             continue
-        if (
-            isinstance(weight, bool)
-            or not isinstance(weight, (int, float))
-            or weight <= 0
-        ):
-            errors.append(
-                f"rubric-weights: weight for {key!r} must be a positive number"
-            )
+        if isinstance(weight, bool) or not isinstance(weight, (int, float)) or weight <= 0:
+            errors.append(f"rubric-weights: weight for {key!r} must be a positive number")
             continue
         normalized[key] = float(weight)
     if normalized and abs(sum(normalized.values()) - 100) > 1e-9:
-        errors.append(
-            f"rubric-weights: weights must total 100, got "
-            f"{sum(normalized.values()):g}"
-        )
+        errors.append(f"rubric-weights: weights must total 100, got {sum(normalized.values()):g}")
     return normalized
 
 
@@ -271,29 +233,20 @@ def parse_and_validate_report(path: Path | str) -> AdjudicationReport:
                 errors.append(f"line {line_number}: malformed {NAMESPACE} marker")
             if current_slug is None:
                 if line.strip():
-                    errors.append(
-                        f"line {line_number}: nonblank content outside tagged sections"
-                    )
+                    errors.append(f"line {line_number}: nonblank content outside tagged sections")
             else:
                 current_lines.append(line)
             continue
 
-        attributes, attribute_errors = _parse_attributes(
-            marker.group("attrs"), line_number
-        )
+        attributes, attribute_errors = _parse_attributes(marker.group("attrs"), line_number)
         errors.extend(attribute_errors)
         kind = marker.group("kind")
 
         if kind == "begin":
             if set(attributes) != {"disclosure", "slug"}:
-                errors.append(
-                    f"line {line_number}: begin marker attributes must be exactly "
-                    "'disclosure' and 'slug'"
-                )
+                errors.append(f"line {line_number}: begin marker attributes must be exactly 'disclosure' and 'slug'")
             if current_slug is not None:
-                errors.append(
-                    f"line {line_number}: nested section inside {current_slug!r}"
-                )
+                errors.append(f"line {line_number}: nested section inside {current_slug!r}")
                 continue
             current_slug = attributes.get("slug", "")
             current_disclosure = attributes.get("disclosure", "")
@@ -302,18 +255,13 @@ def parse_and_validate_report(path: Path | str) -> AdjudicationReport:
             continue
 
         if set(attributes) != {"slug"}:
-            errors.append(
-                f"line {line_number}: end marker attribute must be exactly 'slug'"
-            )
+            errors.append(f"line {line_number}: end marker attribute must be exactly 'slug'")
         if current_slug is None:
             errors.append(f"line {line_number}: end marker without an open section")
             continue
         end_slug = attributes.get("slug", "")
         if end_slug != current_slug:
-            errors.append(
-                f"line {line_number}: end slug {end_slug!r} does not match "
-                f"open slug {current_slug!r}"
-            )
+            errors.append(f"line {line_number}: end slug {end_slug!r} does not match open slug {current_slug!r}")
         sections.append(
             ReportSection(
                 slug=current_slug,
@@ -328,17 +276,12 @@ def parse_and_validate_report(path: Path | str) -> AdjudicationReport:
         current_lines = []
 
     if current_slug is not None:
-        errors.append(
-            f"section {current_slug!r} opened on line {current_begin_line} is not closed"
-        )
+        errors.append(f"section {current_slug!r} opened on line {current_begin_line} is not closed")
 
     actual_slugs = [section.slug for section in sections]
     expected_slugs = [spec.slug for spec in SECTION_SPECS]
     if actual_slugs != expected_slugs:
-        errors.append(
-            "section slugs/order mismatch: expected "
-            f"{expected_slugs!r}, got {actual_slugs!r}"
-        )
+        errors.append(f"section slugs/order mismatch: expected {expected_slugs!r}, got {actual_slugs!r}")
     if len(set(actual_slugs)) != len(actual_slugs):
         errors.append("section slugs must be unique")
 
@@ -348,15 +291,11 @@ def parse_and_validate_report(path: Path | str) -> AdjudicationReport:
             continue
         if section.disclosure != spec.disclosure:
             errors.append(
-                f"section {section.slug!r}: disclosure must be "
-                f"{spec.disclosure!r}, got {section.disclosure!r}"
+                f"section {section.slug!r}: disclosure must be {spec.disclosure!r}, got {section.disclosure!r}"
             )
         first_line = _first_nonblank_line(section.content)
         if first_line != spec.heading:
-            errors.append(
-                f"section {section.slug!r}: first nonblank line must be "
-                f"{spec.heading!r}, got {first_line!r}"
-            )
+            errors.append(f"section {section.slug!r}: first nonblank line must be {spec.heading!r}, got {first_line!r}")
         if "REPLACE_ME" in section.content:
             errors.append(f"section {section.slug!r}: unresolved REPLACE_ME placeholder")
 
@@ -390,15 +329,10 @@ def parse_and_validate_report(path: Path | str) -> AdjudicationReport:
     normalized_weights = _validate_weights(weights_value, errors)
 
     core_word_count = sum(
-        len(_WORD_RE.findall(section.content))
-        for section in sections
-        if section.disclosure == "core"
+        len(_WORD_RE.findall(section.content)) for section in sections if section.disclosure == "core"
     )
     if core_word_count > MAX_CORE_WORDS:
-        errors.append(
-            f"core sections contain {core_word_count} words; maximum is "
-            f"{MAX_CORE_WORDS}"
-        )
+        errors.append(f"core sections contain {core_word_count} words; maximum is {MAX_CORE_WORDS}")
 
     if errors:
         raise ReportValidationError(errors)
@@ -421,11 +355,7 @@ def render_brief(report: AdjudicationReport) -> str:
         f"<!-- source-sha256: {report.sha256} -->",
         f"Source: [{report.path.name}]({source_link})",
     ]
-    blocks.extend(
-        section.content.rstrip()
-        for section in report.sections
-        if section.disclosure == "core"
-    )
+    blocks.extend(section.content.rstrip() for section in report.sections if section.disclosure == "core")
     return "\n\n".join(blocks) + "\n"
 
 

--- a/.agents/skills/implementation-plan-review/scripts/fetch_github_issue.sh
+++ b/.agents/skills/implementation-plan-review/scripts/fetch_github_issue.sh
@@ -9,14 +9,17 @@
 #   OK <path>
 #
 # Output on failure:
-#   ERROR <message>
+#   ERROR <classification>
+#   ACTION <what the caller should do next>
+#   DETAIL <first line from gh, when useful>
 #
 # Exit codes:
 #   0 - Success
 #   1 - Missing/invalid arguments
-#   3 - GitHub CLI not authenticated
-#   4 - Failed to fetch issue
+#   3 - GitHub credentials unavailable to this process
+#   4 - GitHub fetch failed for a non-network reason
 #   5 - Failed to write output file
+#   6 - GitHub API network access unavailable
 
 set -euo pipefail
 
@@ -53,11 +56,6 @@ if [[ ! "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-if ! gh auth status &>/dev/null; then
-    echo "ERROR GitHub CLI not authenticated. Run: gh auth login"
-    exit 3
-fi
-
 CMD=(gh issue view "$ISSUE_NUMBER")
 
 set +e
@@ -78,7 +76,50 @@ set -e
 
 if [[ $STATUS -ne 0 ]]; then
     FIRST_LINE="$(printf "%s" "$MD" | head -n 1)"
-    echo "ERROR Failed to fetch issue via gh: ${FIRST_LINE}"
+    LOWER_ERROR="$(printf "%s" "$MD" | tr '[:upper:]' '[:lower:]')"
+
+    case "$LOWER_ERROR" in
+        *"error connecting to"*|\
+        *"check your internet connection"*|\
+        *"could not resolve host"*|\
+        *"temporary failure in name resolution"*|\
+        *"network is unreachable"*|\
+        *"connection refused"*|\
+        *"connection timed out"*|\
+        *"failed to connect"*|\
+        *"tls handshake timeout"*|\
+        *"i/o timeout"*|\
+        *"context deadline exceeded"*)
+            echo "ERROR GitHub API network access is unavailable to this process."
+            echo "ACTION Agent: rerun this exact fetch command outside the network sandbox (require_escalated). Do not ask the user to re-authenticate for this error."
+            echo "DETAIL ${FIRST_LINE}"
+            exit 6
+            ;;
+    esac
+
+    case "$LOWER_ERROR" in
+        *"gh auth login"*|\
+        *"bad credentials"*|\
+        *"http 401"*|\
+        *"authentication required"*|\
+        *"not logged into any github hosts"*)
+            echo "ERROR GitHub credentials are unavailable to this process."
+            echo "ACTION Run 'gh auth status'. If it is not logged in, run 'gh auth login'. If an interactive terminal is already logged in, rerun this fetch outside the sandbox so it can access the keyring."
+            echo "DETAIL ${FIRST_LINE}"
+            exit 3
+            ;;
+    esac
+
+    if ! gh auth token -h github.com &>/dev/null; then
+        echo "ERROR GitHub credentials are unavailable to this process."
+        echo "ACTION Run 'gh auth status'. If it is not logged in, run 'gh auth login'. If an interactive terminal is already logged in, rerun this fetch outside the sandbox so it can access the keyring."
+        echo "DETAIL ${FIRST_LINE}"
+        exit 3
+    fi
+
+    echo "ERROR GitHub CLI could not fetch issue ${ISSUE_NUMBER} although credentials are available."
+    echo "ACTION Check the issue number and repository access, then inspect the gh error below."
+    echo "DETAIL ${FIRST_LINE}"
     exit 4
 fi
 

--- a/.agents/skills/implementation-plan-review/scripts/finalize_adjudication.py
+++ b/.agents/skills/implementation-plan-review/scripts/finalize_adjudication.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Validate a finding adjudication report and generate or inspect its brief."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from _adjudication_report import (
+    BRIEF_NAME,
+    ReportValidationError,
+    parse_and_validate_report,
+    render_brief,
+    write_text_atomically,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", required=True, type=Path)
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument(
+        "--brief",
+        type=Path,
+        help=f"output path (default: sibling {BRIEF_NAME})",
+    )
+    action.add_argument(
+        "--extract",
+        metavar="SLUG",
+        help="validate the report and print one section without its tags",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        report = parse_and_validate_report(args.report)
+        if args.extract:
+            try:
+                section = report.section(args.extract)
+            except KeyError:
+                available = ", ".join(section.slug for section in report.sections)
+                print(
+                    f"ERROR unknown section slug {args.extract!r}; "
+                    f"available: {available}",
+                    file=sys.stderr,
+                )
+                return 2
+            sys.stdout.write(section.content)
+            return 0
+
+        brief_path = (args.brief or report.path.with_name(BRIEF_NAME)).resolve()
+        if brief_path.parent != report.path.parent:
+            print(
+                "ERROR brief must be a sibling of the full report",
+                file=sys.stderr,
+            )
+            return 2
+        write_text_atomically(brief_path, render_brief(report))
+        print(f"OK brief={brief_path} source_sha256={report.sha256}")
+        return 0
+    except ReportValidationError as exc:
+        print("ERROR invalid adjudication report:", file=sys.stderr)
+        print(str(exc), file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"ERROR {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/implementation-plan-review/scripts/finalize_adjudication.py
+++ b/.agents/skills/implementation-plan-review/scripts/finalize_adjudication.py
@@ -43,8 +43,7 @@ def main() -> int:
             except KeyError:
                 available = ", ".join(section.slug for section in report.sections)
                 print(
-                    f"ERROR unknown section slug {args.extract!r}; "
-                    f"available: {available}",
+                    f"ERROR unknown section slug {args.extract!r}; available: {available}",
                     file=sys.stderr,
                 )
                 return 2

--- a/.agents/skills/implementation-plan-review/scripts/verify_adjudication_run.py
+++ b/.agents/skills/implementation-plan-review/scripts/verify_adjudication_run.py
@@ -31,22 +31,12 @@ def main() -> int:
         print(f"ERROR run directory does not exist: {run_dir}", file=sys.stderr)
         return 2
 
-    candidate_dirs = sorted(
-        path
-        for path in run_dir.iterdir()
-        if path.is_dir() and path.name.startswith("finding-")
-    )
+    candidate_dirs = sorted(path for path in run_dir.iterdir() if path.is_dir() and path.name.startswith("finding-"))
     errors: list[str] = []
     if not candidate_dirs:
         errors.append(f"no finding-* candidate directories found below {run_dir}")
-    if (
-        args.expected_count is not None
-        and len(candidate_dirs) != args.expected_count
-    ):
-        errors.append(
-            f"expected {args.expected_count} candidate directories, "
-            f"found {len(candidate_dirs)}"
-        )
+    if args.expected_count is not None and len(candidate_dirs) != args.expected_count:
+        errors.append(f"expected {args.expected_count} candidate directories, found {len(candidate_dirs)}")
 
     summaries: list[str] = []
     completed_reports = 0
@@ -87,10 +77,7 @@ def main() -> int:
                 errors.append(f"{relative}: cannot read {BRIEF_NAME}: {exc}")
             else:
                 if actual_brief != expected_brief:
-                    errors.append(
-                        f"{relative}: {BRIEF_NAME} is stale or was edited; "
-                        "rerun finalize_adjudication.py"
-                    )
+                    errors.append(f"{relative}: {BRIEF_NAME} is stale or was edited; rerun finalize_adjudication.py")
 
         summaries.append(
             f"{relative}: disposition={report.result['disposition']} "

--- a/.agents/skills/implementation-plan-review/scripts/verify_adjudication_run.py
+++ b/.agents/skills/implementation-plan-review/scripts/verify_adjudication_run.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Independently verify every completed finding adjudication in a run."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from _adjudication_report import (
+    BRIEF_NAME,
+    REPORT_NAME,
+    ReportValidationError,
+    expected_candidate_files,
+    parse_and_validate_report,
+    render_brief,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run", required=True, type=Path)
+    parser.add_argument("--expected-count", type=int)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    run_dir = args.run.resolve()
+    if not run_dir.is_dir():
+        print(f"ERROR run directory does not exist: {run_dir}", file=sys.stderr)
+        return 2
+
+    candidate_dirs = sorted(
+        path
+        for path in run_dir.iterdir()
+        if path.is_dir() and path.name.startswith("finding-")
+    )
+    errors: list[str] = []
+    if not candidate_dirs:
+        errors.append(f"no finding-* candidate directories found below {run_dir}")
+    if (
+        args.expected_count is not None
+        and len(candidate_dirs) != args.expected_count
+    ):
+        errors.append(
+            f"expected {args.expected_count} candidate directories, "
+            f"found {len(candidate_dirs)}"
+        )
+
+    summaries: list[str] = []
+    completed_reports = 0
+    for candidate_dir in candidate_dirs:
+        report_path = candidate_dir / REPORT_NAME
+        relative = candidate_dir.relative_to(run_dir)
+        if not report_path.is_file():
+            errors.append(f"{relative}: missing {REPORT_NAME}")
+            continue
+        completed_reports += 1
+        try:
+            report = parse_and_validate_report(report_path)
+        except ReportValidationError as exc:
+            errors.extend(f"{relative}: {message}" for message in exc.errors)
+            continue
+        except OSError as exc:
+            errors.append(f"{relative}: {exc}")
+            continue
+
+        actual_entries = {path.name for path in candidate_dir.iterdir()}
+        expected_files = expected_candidate_files()
+        if actual_entries != expected_files:
+            errors.append(
+                f"{relative}: candidate entries must be exactly "
+                f"{sorted(expected_files)!r}, got {sorted(actual_entries)!r}"
+            )
+
+        brief_path = candidate_dir / BRIEF_NAME
+        if not brief_path.is_file():
+            errors.append(f"{relative}: missing {BRIEF_NAME}")
+        elif brief_path.is_symlink():
+            errors.append(f"{relative}: {BRIEF_NAME} must not be a symbolic link")
+        else:
+            expected_brief = render_brief(report)
+            try:
+                actual_brief = brief_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                errors.append(f"{relative}: cannot read {BRIEF_NAME}: {exc}")
+            else:
+                if actual_brief != expected_brief:
+                    errors.append(
+                        f"{relative}: {BRIEF_NAME} is stale or was edited; "
+                        "rerun finalize_adjudication.py"
+                    )
+
+        summaries.append(
+            f"{relative}: disposition={report.result['disposition']} "
+            f"severity={report.result['severity']} "
+            f"confidence={report.result['confidence']} "
+            f"sha256={report.sha256}"
+        )
+
+    if errors:
+        print("ERROR adjudication run validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK reports={completed_reports} run={run_dir}")
+    for summary in summaries:
+        print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/review-plan-findings-feedback/SKILL.md
+++ b/.agents/skills/review-plan-findings-feedback/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: review-plan-findings-feedback
-description: Manually review a feedback file produced after implementation-plan review findings were addressed. Use when the user asks to read a findings-feedback file and verify that the plan changes correctly close, correctly reject, or fail to close the original implementation-plan-review findings, while checking for newly introduced or newly exposed plan problems. Writes only new findings to the plan-id findings directory and replies with the output file path or a concise no-new-findings status.
+description: Manually review a feedback file produced after implementation-plan review findings were addressed. Use when the user asks to verify that plan changes correctly close, correctly reject, or fail to close the original findings, while checking for newly introduced or newly exposed problems. Independently adjudicates only new candidate problems with the implementation-plan-review protocol, writes surviving unresolved or new findings to the plan-id findings directory, and replies with the output path or a concise no-new-findings status.
 disable-model-invocation: true
 ---
 
 # Review Plan Findings Feedback
 
-Review a follow-up feedback file after plan-review findings were addressed. Do not implement code and do not edit the plan. The only possible artifact is a new-findings file.
+Review a follow-up feedback file after plan-review findings were addressed. Do
+not implement code and do not edit the plan. The only user-facing artifact is a
+findings file. Adjudication work artifacts may be created only in this run's
+fresh scratchpad directory.
 
 ## Inputs And Assumptions
 
 - The user provides the feedback file path, usually `.ai/impl_plans/<plan-id>/findings-feedback/<timestamp>/feedback.md`.
-- The implementation plan path and the original review findings are expected to already be present in the conversation context because this skill is run in the same session as `implementation-plan-review`.
-- Do not require the user to pass the plan path or original findings again. Infer the plan id from the current session first, then from the feedback path if needed.
-- If the plan id or original findings cannot be recovered with confidence, stop and ask for the missing context rather than guessing.
+- The implementation plan path, issue snapshot, and original review findings are expected to already be present in the conversation context because this skill is run in the same session as `implementation-plan-review`.
+- Do not require the user to pass those inputs again. Infer the plan id from the current session first, then from the feedback path if needed.
+- Recover the exact issue snapshot used by the original review. Do not silently substitute a newer issue version.
+- If the plan id, issue snapshot, or original findings cannot be recovered with confidence, stop and ask for the missing context rather than guessing.
 
 ## Workflow
 
@@ -45,6 +49,7 @@ Read in full:
 
 - The feedback file supplied by the user.
 - The current implementation plan: `.ai/impl_plans/<plan-id>.md`.
+- The exact issue snapshot used by the original review.
 - The original review findings from the current conversation context.
 
 Read targeted evidence as needed:
@@ -61,9 +66,22 @@ For each original finding:
 - Check whether the feedback accurately understood the finding.
 - Check whether the current plan actually changed in a way that closes the valid part of the finding.
 - If the feedback rejects the finding, decide whether the rejection is acceptable. Treat an accepted rejection the same as a closed finding: do not report it as new/unresolved.
+- If the plan does not close the finding, or the rejection is not acceptable, retain the original finding as unresolved. Do not adjudicate it again.
 - Re-check the underlying code/rules when the finding depends on codebase reality.
 
-Then scan the edited plan sections for newly introduced or newly exposed issues. Apply the same review standard as `implementation-plan-review`, but only report findings that are new after the feedback round or still unresolved despite the feedback.
+Then scan the edited plan sections for newly introduced or newly exposed issues.
+Apply the same review standard as `implementation-plan-review`, but distinguish
+unresolved original findings from genuinely new candidate problems before
+launching any adjudicator.
+
+A problem is new only when it is not substantively covered by an original
+finding. Treat it as the unresolved original finding, without new adjudication,
+when it has the same violated requirement, affected behavior, and corrective
+obligation, even if the feedback review discovers new evidence, a clearer
+wording, another manifestation, or a different severity. Treat a distinct
+requirement violation, failure mode, edge case, affected surface, or materially
+different corrective obligation as a new candidate. When both are present,
+split the unresolved original part from the genuinely new candidate.
 
 Do not report:
 
@@ -72,15 +90,96 @@ Do not report:
 - Style nits that do not affect correctness, coverage, maintainability, safety, or junior-dev readiness.
 - Environment command-prefix mechanics, unless the verification scope itself is objectively wrong.
 
-### 5. Write Output Only If New Findings Exist
+### 5. Adjudicate Only New Candidate Problems
 
-If new findings exist, create exactly one Markdown file inside the directory printed in step 2:
+Skip this step when the closure review produces no genuinely new candidates.
+Never launch a new adjudicator for an original finding, regardless of its
+closure disposition.
+
+Before creating candidate inputs or launching adjudicators, read these
+`implementation-plan-review` resources completely:
+
+- `.agents/skills/implementation-plan-review/references/finding-adjudication-protocol.md`
+- `.agents/skills/implementation-plan-review/assets/finding-adjudication-report.md`
+
+Create a fresh adjudication run:
+
+```bash
+bash .agents/skills/implementation-plan-review/scripts/new_scratchpads_dir.sh \
+  .ai/impl_plans/<plan-id>.md
+```
+
+Use exactly the absolute path printed on stdout as this feedback review's
+adjudication run directory. Never reuse or write into an earlier scratchpad
+run. For each new candidate, create:
+
+```text
+finding-01-short-slug/
+├── input.md
+├── full-report.md  # written by the adjudicator
+└── brief.md        # generated by the finalizer
+```
+
+Create `input.md` with:
+
+- the candidate ID;
+- absolute current plan, original issue snapshot, template, protocol, and output paths;
+- one neutral, falsifiable candidate hypothesis;
+- focused research questions;
+- candidate-specific scope or edge cases;
+- an explicit statement that `Confirmed`, `Downgraded`, `Question`, and `Closed` are all successful outcomes.
+
+Do not include the feedback, original findings, prior scratchpads or
+adjudications, a preferred solution, or an expected disposition. The main
+reviewer owns novelty classification; the adjudicator decides only whether the
+candidate is an actionable problem in the current plan.
+
+Launch one independent subagent per candidate, batching when concurrency is
+limited. Use `fork_turns="none"` and prefer a strong reasoning model
+(`gpt-5.6-sol` with `xhigh` reasoning when available) unless the user requests
+otherwise. The launcher prompt must contain only:
+
+- the absolute protocol path and an instruction to read it completely;
+- the absolute `input.md` path;
+- the exact writable candidate directory;
+- the absolute template path;
+- the requirement to run the protocol's finalization loop before returning.
+
+Require each adjudicator to write `full-report.md`, run
+`finalize_adjudication.py`, fix every validation error, and return only the
+protocol's short completion record. The finalizer generates `brief.md`; never
+edit it manually.
+
+After all adjudicators finish, verify the complete run:
+
+```bash
+python3 .agents/skills/implementation-plan-review/scripts/verify_adjudication_run.py \
+  --run <absolute-run-directory> \
+  --expected-count <candidate-count>
+```
+
+If verification fails, send the exact errors to the responsible adjudicator
+and require correction and re-finalization. Read all valid `brief.md` files
+first; inspect a full report or extract a tagged section only when progressive
+disclosure is warranted.
+
+The main reviewer owns cross-finding deduplication, conflicts, cumulative scope,
+and one common severity scale. Only `Confirmed`, actionable `Downgraded`, and
+unresolved `Question` candidates survive. Omit `Closed` candidates. Deduplicate
+surviving new candidates against unresolved original findings before writing
+the output.
+
+### 6. Write Output Only If Findings Survive
+
+If one or more unresolved original findings or adjudicated new findings survive,
+create exactly one Markdown file inside the directory printed in step 2:
 
 ```text
 .ai/impl_plans/<plan-id>/findings/<timestamp>/findings.md
 ```
 
-The file must contain only a list of new findings. Do not add an introduction, summary, "no findings" line, or review sections.
+The file must contain only a list of reportable findings. Do not add an
+introduction, summary, "no findings" line, or review sections.
 
 Use this item shape:
 
@@ -90,11 +189,17 @@ Use this item shape:
   **Problem:** What remains wrong or what new problem was introduced.
   **Recommendation:** Concrete change to the plan.
   **Rationale:** Why it matters.
+  **Scratchpad:** Path to the generated brief.md.
 ```
 
-If there are no new findings, do not create any file in the findings directory.
+For an unresolved original actionable finding, preserve its original generated
+`brief.md` path. For a surviving new actionable finding, use the new
+adjudication's generated `brief.md`. Never link directly to `full-report.md`.
+Omit `Scratchpad` only for a pure `Question`.
 
-### 6. Chat Output
+If no findings survive, do not create any file in the findings directory.
+
+### 7. Chat Output
 
 If a findings file was created, reply with only a clickable link to it:
 

--- a/.agents/skills/review-plan-findings-feedback/agents/openai.yaml
+++ b/.agents/skills/review-plan-findings-feedback/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Review Plan Findings Feedback"
-  short_description: "Check plan-feedback fixes and write new findings"
-  default_prompt: "Use $review-plan-findings-feedback to review the feedback file for addressed implementation-plan findings."
+  short_description: "Check feedback fixes and adjudicate new findings"
+  default_prompt: "Use $review-plan-findings-feedback to review addressed implementation-plan findings and adjudicate only newly exposed problems."
 policy:
   allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

Enhances the implementation-plan review skills (`.agents/skills/`) so that candidate findings are adjudicated independently instead of being investigated inline by the same agent that raised them.

- **`implementation-plan-review`**: replaces the old single-agent "ground findings with scratchpads" step with an adjudication workflow — each candidate finding gets its own subagent, isolated `input.md`, and a `full-report.md` produced against a shared protocol (`references/finding-adjudication-protocol.md`) and template (`assets/finding-adjudication-report.md`). New scripts `finalize_adjudication.py` and `verify_adjudication_run.py` validate each report, generate a deterministic `brief.md`, and verify the full run (expected candidate count, structure, staleness) before the main reviewer reads results and folds them into the final review.
- **`review-plan-findings-feedback`**: reuses the same adjudication protocol for genuinely new candidates surfaced during a findings-feedback pass, while keeping already-known unresolved findings out of re-adjudication.
- **`export-plan-review-comments`** (new skill): exports the survived comments from a completed plan review into a timestamped `.ai/impl_plans/<plan-id>/findings/<timestamp>/finding.md` artifact, verbatim and without re-reviewing, with a validation script (`validate_comments_export.py`).
- `fetch_github_issue.sh` gains distinct exit codes/`ACTION` guidance for sandboxed network escalation vs. missing `gh` credentials vs. other fetch/output failures.

Also fixes CI: `.venv/bin/ruff format` reformats three of the new adjudication scripts to the project's 120-char line-length (no behavior change).

## Test plan

- [x] `ruff format --check .` and `ruff check .` pass
- [x] `pytest tests -m "not integration"` — no new failures (34 pre-existing failures, unrelated to this change, reproduce identically on `main`)
- [ ] Exercise the new adjudication workflow end-to-end on a real implementation-plan review

@coderabbitai ignore