### PR TITLE
Demote routine client-disconnect errors in MCP SDK logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ mcp-server/
 │   │   └── index.html          # Landing page for the REST API
 │   ├── config.py               # Configuration management (e.g., API keys, timeouts, cache settings)
 │   ├── constants.py            # Centralized constants used throughout the application, including data truncation limits
-│   ├── logging_utils.py        # Logging utilities for production-ready log formatting
+│   ├── logging_utils.py        # Logging utilities for production-ready log formatting and client-disconnect log noise suppression
 │   ├── analytics.py            # Centralized Mixpanel analytics for tool invocations (HTTP mode only)
 │   ├── telemetry.py            # Fire-and-forget community telemetry reporting
 │   ├── client_meta.py          # Shared client metadata extraction helpers and defaults
@@ -150,6 +150,7 @@ mcp-server/
 │   ├── test_instructions_data.py  # Unit tests for the InstructionsData payload model
 │   ├── test_integration_helpers.py  # Unit tests for integration test helpers
 │   ├── test_logging_utils.py  # Unit tests for logging utilities
+│   ├── test_logging_utils_disconnect_filter.py  # Unit tests for the client-disconnect log demotion filter
 │   ├── test_models.py            # Unit tests for Pydantic response models
 │   ├── test_server.py            # Unit tests for server CLI and startup logic
 │   ├── test_server_instructions.py  # Unit tests for the composed_instructions string
@@ -377,6 +378,7 @@ mcp-server/
     * **`logging_utils.py`**:
         * Provides utilities for configuring production-ready logging.
         * Contains the `replace_rich_handlers_with_standard()` function that eliminates multi-line Rich formatting from MCP SDK logs.
+        * Contains the `install_client_disconnect_filter()` function that demotes routine client-disconnect errors in MCP SDK logs.
     * **`analytics.py`**:
         * Centralized Mixpanel analytics for MCP tool invocations.
         * Enabled only in HTTP mode when `BLOCKSCOUT_MIXPANEL_TOKEN` is set.

--- a/SPEC.md
+++ b/SPEC.md
@@ -868,6 +868,8 @@ The server employs a post-initialization handler replacement strategy:
 
 This configuration is applied during server startup, ensuring clean single-line log output across all operational modes.
 
+Startup also installs an idempotent logging filter on the MCP SDK's session-manager logger. In stateless HTTP mode a client aborting an in-flight request is routine, yet the SDK records it as an `ERROR` with a full traceback, drowning out failures an operator must act on. The filter narrowly demotes only that record to a single debug-level line — deliberately kept visible so aborted calls can still be correlated — and passes every other record through untouched. Only the log noise is addressed: execution cancellation and session-budget accounting are deliberately unaffected.
+
 #### 1. Client-Facing Progress Logging
 
 While `report_progress` is the standard for UI feedback, many MCP clients do not yet render progress notifications but do capture log messages sent via `ctx.info`. To provide essential real-time feedback for development and debugging, the server systematically pairs every progress notification with a corresponding `info` log message sent to the client.

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.18.0.dev1"
+__version__ = "0.18.0.dev2"

--- a/blockscout_mcp_server/logging_utils.py
+++ b/blockscout_mcp_server/logging_utils.py
@@ -4,9 +4,81 @@
 import logging
 import sys
 
+import anyio
+
 # Pre-define module logger to avoid circular dependencies during logging system manipulation
 # This logger is created before any handler manipulation occurs, ensuring safe error reporting
 _module_logger = logging.getLogger(__name__)
+
+# The MCP SDK's stateless streamable-HTTP session manager logs a broad "Stateless session
+# crashed" ERROR record (with a nested-ExceptionGroup traceback) whenever a client aborts the
+# HTTP request while a tool call is still running. Nothing is actually broken in that case: the
+# SDK's per-request transport streams are closed while the detached tool call keeps running, and
+# writing its eventual result to the closed stream raises anyio.ClosedResourceError. The logger
+# name below is the exact interception point for that record (mcp 1.26,
+# mcp/server/streamable_http_manager.py).
+CLIENT_DISCONNECT_LOGGER_NAME = "mcp.server.streamable_http_manager"
+CLIENT_DISCONNECT_RECORD_MESSAGE = "Stateless session crashed"
+
+
+class ClientDisconnectFilter(logging.Filter):
+    """Demote the SDK's "client disconnected mid-call" record to a one-line DEBUG record.
+
+    This filter never drops records - it always returns True. It only recognizes the exact
+    "Stateless session crashed" record shape whose exception tree consists solely of
+    anyio.ClosedResourceError leaves (following BaseExceptionGroup children only, never
+    __cause__/__context__ chains), and mutates that record in place so it renders as a single
+    DEBUG line without a traceback. Every other record - including the SDK's stateful crash
+    record and any exception tree that contains an unrelated exception - passes through
+    untouched.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Demote the matching record in place; always return True."""
+        if record.getMessage() != CLIENT_DISCONNECT_RECORD_MESSAGE:
+            return True
+
+        if not record.exc_info or record.exc_info[1] is None:
+            return True
+
+        exception = record.exc_info[1]
+        if not self._all_leaves_are_closed_resource_error(exception):
+            return True
+
+        record.levelno = logging.DEBUG
+        record.levelname = logging.getLevelName(logging.DEBUG)
+        record.msg = "Stateless session closed by client disconnect (anyio.ClosedResourceError); traceback suppressed."
+        record.args = None
+        record.exc_info = None
+        record.exc_text = None
+        record.stack_info = None
+        return True
+
+    @staticmethod
+    def _all_leaves_are_closed_resource_error(exception: BaseException) -> bool:
+        """Return True if every leaf of the exception tree is anyio.ClosedResourceError.
+
+        A BaseExceptionGroup node contributes its `.exceptions` children; anything else is a
+        leaf. __cause__/__context__ chains are deliberately not followed.
+        """
+        if isinstance(exception, BaseExceptionGroup):
+            children = exception.exceptions
+            return len(children) > 0 and all(
+                ClientDisconnectFilter._all_leaves_are_closed_resource_error(child) for child in children
+            )
+        return isinstance(exception, anyio.ClosedResourceError)
+
+
+def install_client_disconnect_filter(logger_name: str = CLIENT_DISCONNECT_LOGGER_NAME) -> None:
+    """Attach a ClientDisconnectFilter to the given logger, unless one is already attached.
+
+    The default logger name is the MCP SDK's stateless session-manager logger. An explicit
+    logger_name is accepted for testability, so unit tests can exercise this against a
+    throwaway logger instead of mutating the real, process-global SDK logger.
+    """
+    logger = logging.getLogger(logger_name)
+    if not any(isinstance(existing_filter, ClientDisconnectFilter) for existing_filter in logger.filters):
+        logger.addFilter(ClientDisconnectFilter())
 
 
 def replace_rich_handlers_with_standard() -> None:

--- a/blockscout_mcp_server/logging_utils.py
+++ b/blockscout_mcp_server/logging_utils.py
@@ -35,7 +35,10 @@ class ClientDisconnectFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Demote the matching record in place; always return True."""
-        if record.getMessage() != CLIENT_DISCONNECT_RECORD_MESSAGE:
+        # Compare record.msg, not getMessage(): %-formatting inside getMessage() can raise on a
+        # record with mismatched args, and logging propagates filter exceptions to the caller.
+        # The target record is logged without args, so the comparison is equivalent for it.
+        if record.msg != CLIENT_DISCONNECT_RECORD_MESSAGE:
             return True
 
         if not record.exc_info or record.exc_info[1] is None:

--- a/blockscout_mcp_server/server.py
+++ b/blockscout_mcp_server/server.py
@@ -26,7 +26,10 @@ from blockscout_mcp_server.constants import (
     SKILL_RESOLUTION_RULE_TEXT,
     TOOL_INVOCATION_STATUSES,
 )
-from blockscout_mcp_server.logging_utils import replace_rich_handlers_with_standard
+from blockscout_mcp_server.logging_utils import (
+    install_client_disconnect_filter,
+    replace_rich_handlers_with_standard,
+)
 from blockscout_mcp_server.resources import skill_resources
 from blockscout_mcp_server.session_lifecycle import (
     SessionStartupError,
@@ -343,6 +346,7 @@ for resource in skill_resources.list_resources():
 
 # Initialize logging and override the rich formatter defined in the FastMCP
 replace_rich_handlers_with_standard()
+install_client_disconnect_filter()
 
 # Create a Typer application for our CLI
 cli_app = typer.Typer()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.18.0.dev1"
+version = "0.18.0.dev2"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.18.0.dev1",
+  "version": "0.18.0.dev2",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/test_logging_utils_disconnect_filter.py
+++ b/tests/test_logging_utils_disconnect_filter.py
@@ -8,6 +8,7 @@ import anyio
 import pytest
 
 from blockscout_mcp_server.logging_utils import (
+    CLIENT_DISCONNECT_LOGGER_NAME,
     CLIENT_DISCONNECT_RECORD_MESSAGE,
     ClientDisconnectFilter,
     install_client_disconnect_filter,
@@ -217,6 +218,17 @@ class TestClientDisconnectFilterEndToEnd:
             logger.filters.extend(original_filters)
             logger.handlers.clear()
             logger.handlers.extend(original_handlers)
+
+
+class TestServerStartupWiring:
+    """Tests that importing the server module installs the filter on the real SDK logger."""
+
+    def test_server_import_installs_filter_exactly_once(self):
+        import blockscout_mcp_server.server  # noqa: F401
+
+        logger = logging.getLogger(CLIENT_DISCONNECT_LOGGER_NAME)
+        matching_filters = [f for f in logger.filters if isinstance(f, ClientDisconnectFilter)]
+        assert len(matching_filters) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_logging_utils_disconnect_filter.py
+++ b/tests/test_logging_utils_disconnect_filter.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+"""Unit tests for the client-disconnect logging filter in blockscout_mcp_server.logging_utils."""
+
+import io
+import logging
+
+import anyio
+import pytest
+
+from blockscout_mcp_server.logging_utils import (
+    CLIENT_DISCONNECT_RECORD_MESSAGE,
+    ClientDisconnectFilter,
+    install_client_disconnect_filter,
+)
+
+DEMOTED_MESSAGE = "Stateless session closed by client disconnect (anyio.ClosedResourceError); traceback suppressed."
+
+
+def _make_record(message: str, exc_info: tuple | None) -> logging.LogRecord:
+    """Build a bare LogRecord with the given message and exc_info tuple."""
+    return logging.LogRecord(
+        name="mcp.server.streamable_http_manager",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=None,
+        exc_info=exc_info,
+    )
+
+
+def _exc_info_for(exception: BaseException) -> tuple:
+    """Build an exc_info-shaped tuple for a given exception instance (no real traceback needed)."""
+    return (type(exception), exception, None)
+
+
+def _closed_resource_error() -> anyio.ClosedResourceError:
+    try:
+        raise anyio.ClosedResourceError()
+    except anyio.ClosedResourceError as exc:
+        return exc
+
+
+def _nested_closed_resource_group() -> BaseExceptionGroup:
+    """Build a ClosedResourceError wrapped in two nested ExceptionGroups."""
+    inner = BaseExceptionGroup("inner", [_closed_resource_error()])
+    outer = BaseExceptionGroup("outer", [inner])
+    return outer
+
+
+class TestClientDisconnectFilterMatching:
+    """Tests for the matching/demotion logic of ClientDisconnectFilter."""
+
+    def test_bare_closed_resource_error_is_demoted(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(_closed_resource_error()))
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.DEBUG
+
+    def test_demotion_rewrites_levelname(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(_closed_resource_error()))
+        ClientDisconnectFilter().filter(record)
+        assert record.levelname == "DEBUG"
+
+    def test_demotion_clears_exc_info_exc_text_and_stack_info(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(_closed_resource_error()))
+        record.exc_text = "sentinel-exc-text"
+        record.stack_info = "sentinel-stack-info"
+
+        ClientDisconnectFilter().filter(record)
+
+        assert record.exc_info is None
+        assert record.exc_text is None
+        assert record.stack_info is None
+
+    def test_demotion_replaces_message_with_exact_one_liner(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(_closed_resource_error()))
+        ClientDisconnectFilter().filter(record)
+        assert record.getMessage() == DEMOTED_MESSAGE
+
+    def test_nested_exception_groups_are_demoted(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(_nested_closed_resource_group()))
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.DEBUG
+        assert record.getMessage() == DEMOTED_MESSAGE
+
+    def test_different_message_with_matching_tree_passes_through_untouched(self):
+        record = _make_record("Session abc123 crashed: boom", _exc_info_for(_closed_resource_error()))
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.ERROR
+        assert record.getMessage() == "Session abc123 crashed: boom"
+
+    def test_group_with_unrelated_exception_passes_through_untouched(self):
+        group = BaseExceptionGroup("mixed", [_closed_resource_error(), ValueError("unrelated")])
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(group))
+        record.exc_text = "sentinel-exc-text"
+        record.stack_info = "sentinel-stack-info"
+
+        original = {
+            "levelno": record.levelno,
+            "levelname": record.levelname,
+            "msg": record.msg,
+            "args": record.args,
+            "exc_info": record.exc_info,
+            "exc_text": record.exc_text,
+            "stack_info": record.stack_info,
+        }
+
+        ClientDisconnectFilter().filter(record)
+
+        assert record.levelno == original["levelno"]
+        assert record.levelname == original["levelname"]
+        assert record.msg == original["msg"]
+        assert record.args == original["args"]
+        assert record.exc_info == original["exc_info"]
+        assert record.exc_text == original["exc_text"]
+        assert record.stack_info == original["stack_info"]
+
+    def test_unrelated_exception_passes_through_untouched(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(ValueError("boom")))
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.ERROR
+        assert record.getMessage() == CLIENT_DISCONNECT_RECORD_MESSAGE
+
+    def test_explicit_cause_chain_is_not_traversed(self):
+        try:
+            try:
+                raise _closed_resource_error()
+            except anyio.ClosedResourceError as cause:
+                raise ValueError("wrapped") from cause
+        except ValueError as exc:
+            record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(exc))
+
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.ERROR
+
+    def test_implicit_context_chain_is_not_traversed(self):
+        try:
+            try:
+                raise _closed_resource_error()
+            except anyio.ClosedResourceError:
+                raise ValueError("wrapped")
+        except ValueError as exc:
+            record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(exc))
+
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.ERROR
+
+    def test_record_without_exc_info_passes_through_untouched(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, None)
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.ERROR
+
+    def test_record_with_empty_exc_info_tuple_passes_through_untouched(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, (None, None, None))
+        ClientDisconnectFilter().filter(record)
+        assert record.levelno == logging.ERROR
+
+    def test_filter_returns_true_for_matching_record(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(_closed_resource_error()))
+        assert ClientDisconnectFilter().filter(record) is True
+
+    def test_filter_returns_true_for_non_matching_record(self):
+        record = _make_record(CLIENT_DISCONNECT_RECORD_MESSAGE, _exc_info_for(ValueError("boom")))
+        assert ClientDisconnectFilter().filter(record) is True
+
+
+class TestInstallClientDisconnectFilter:
+    """Tests for the install_client_disconnect_filter installer function."""
+
+    def test_installer_is_idempotent(self):
+        logger_name = "test_install_client_disconnect_filter_idempotent"
+        logger = logging.getLogger(logger_name)
+        try:
+            install_client_disconnect_filter(logger_name)
+            install_client_disconnect_filter(logger_name)
+
+            matching_filters = [f for f in logger.filters if isinstance(f, ClientDisconnectFilter)]
+            assert len(matching_filters) == 1
+        finally:
+            logger.filters.clear()
+
+
+class TestClientDisconnectFilterEndToEnd:
+    """End-to-end visibility test: demoted record is emitted as a single DEBUG line."""
+
+    def test_demoted_record_is_visible_as_single_debug_line(self):
+        logger_name = "test_client_disconnect_filter_end_to_end"
+        logger = logging.getLogger(logger_name)
+        original_level = logger.level
+        original_propagate = logger.propagate
+        original_filters = logger.filters[:]
+        original_handlers = logger.handlers[:]
+
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.NOTSET)
+        handler.setFormatter(logging.Formatter("%(levelname)s - %(message)s"))
+
+        try:
+            logger.filters.clear()
+            logger.handlers.clear()
+            logger.setLevel(logging.INFO)
+            logger.propagate = False
+            logger.addFilter(ClientDisconnectFilter())
+            logger.addHandler(handler)
+
+            try:
+                raise _nested_closed_resource_group()
+            except BaseExceptionGroup:
+                logger.error(CLIENT_DISCONNECT_RECORD_MESSAGE, exc_info=True)
+
+            assert stream.getvalue() == f"DEBUG - {DEMOTED_MESSAGE}\n"
+        finally:
+            logger.setLevel(original_level)
+            logger.propagate = original_propagate
+            logger.filters.clear()
+            logger.filters.extend(original_filters)
+            logger.handlers.clear()
+            logger.handlers.extend(original_handlers)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_logging_utils_disconnect_filter.py
+++ b/tests/test_logging_utils_disconnect_filter.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Unit tests for the client-disconnect logging filter in blockscout_mcp_server.logging_utils."""
 
+import inspect
 import io
 import logging
 
 import anyio
-import pytest
 
 from blockscout_mcp_server.logging_utils import (
     CLIENT_DISCONNECT_LOGGER_NAME,
@@ -231,5 +231,16 @@ class TestServerStartupWiring:
         assert len(matching_filters) == 1
 
 
-if __name__ == "__main__":
-    pytest.main([__file__])
+class TestSdkInterceptionPoint:
+    """Canary: the pinned MCP SDK still contains the exact record this filter intercepts.
+
+    The filter is coupled to SDK internals (logger name and record message). If a future mcp
+    version bump renames either, the filter would silently stop matching and the log noise
+    would return; this test turns that into a loud failure.
+    """
+
+    def test_sdk_still_logs_the_intercepted_record(self):
+        import mcp.server.streamable_http_manager as sdk_module
+
+        assert sdk_module.logger.name == CLIENT_DISCONNECT_LOGGER_NAME
+        assert f'logger.exception("{CLIENT_DISCONNECT_RECORD_MESSAGE}")' in inspect.getsource(sdk_module)

--- a/tests/test_logging_utils_disconnect_filter.py
+++ b/tests/test_logging_utils_disconnect_filter.py
@@ -6,7 +6,9 @@ import io
 import logging
 
 import anyio
+import mcp.server.streamable_http_manager as sdk_module
 
+import blockscout_mcp_server.server  # noqa: F401  # imported for its import-time filter wiring
 from blockscout_mcp_server.logging_utils import (
     CLIENT_DISCONNECT_LOGGER_NAME,
     CLIENT_DISCONNECT_RECORD_MESSAGE,
@@ -224,8 +226,6 @@ class TestServerStartupWiring:
     """Tests that importing the server module installs the filter on the real SDK logger."""
 
     def test_server_import_installs_filter_exactly_once(self):
-        import blockscout_mcp_server.server  # noqa: F401
-
         logger = logging.getLogger(CLIENT_DISCONNECT_LOGGER_NAME)
         matching_filters = [f for f in logger.filters if isinstance(f, ClientDisconnectFilter)]
         assert len(matching_filters) == 1
@@ -240,7 +240,5 @@ class TestSdkInterceptionPoint:
     """
 
     def test_sdk_still_logs_the_intercepted_record(self):
-        import mcp.server.streamable_http_manager as sdk_module
-
         assert sdk_module.logger.name == CLIENT_DISCONNECT_LOGGER_NAME
         assert f'logger.exception("{CLIENT_DISCONNECT_RECORD_MESSAGE}")' in inspect.getsource(sdk_module)


### PR DESCRIPTION
Closes #445

## What changed

In stateless streamable-HTTP mode, an MCP client aborting an in-flight request (e.g. `Esc` in Claude Code) makes the SDK log `Stateless session crashed` at `ERROR` with a multi-frame `ExceptionGroup` traceback ending in `anyio.ClosedResourceError`. Nothing is broken — the client just hung up — but the noise buries failures an operator must act on.

This adds a narrow logging filter that demotes exactly that record and leaves everything else alone.

- **`blockscout_mcp_server/logging_utils.py`** — new `ClientDisconnectFilter` plus `install_client_disconnect_filter()`:
  - Unwraps the record's exception tree, including nested `ExceptionGroup`s, and demotes only when **every** leaf is `anyio.ClosedResourceError`. An `ExceptionGroup` that also carries an unrelated exception passes through untouched.
  - Also guards on the record's message, so unrelated records on the same logger are never touched.
  - Deliberately does **not** traverse `__cause__`/`__context__` — only the `ExceptionGroup` structure the SDK actually produces.
  - Demotes in place to a single `DEBUG` line (`Stateless session closed by client disconnect (anyio.ClosedResourceError); traceback suppressed.`), clearing `exc_info`/`exc_text`/`stack_info` and fixing up `levelname`. The line is kept visible rather than dropped so aborted calls can still be correlated.
  - `filter()` always returns `True`; the installer is idempotent.
- **`blockscout_mcp_server/server.py`** — installs the filter at startup, right after `replace_rich_handlers_with_standard()`.
- **Docs** — SPEC.md gains a paragraph in the production-logging section; AGENTS.md updates the file tree and notes the new function.
- **Version** — bumped to `0.18.0.dev2` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`.

## Why this scope

Only the log noise is addressed. As #445 notes, the underlying non-cancellation has two further consequences left deliberately in place: the abandoned tool keeps issuing upstream Blockscout requests until it finishes, and — because its body completes successfully — the session gate does not refund the metered call, so an aborted request still consumes the caller's free-tier budget. Fixing that means patching or wrapping the SDK's stateless request handler and should be tracked separately.

## Reviewer notes

- **Tests**: `tests/test_logging_utils_disconnect_filter.py` (17 new tests) covers matching/demotion, the message guard, nested `ExceptionGroup`s, mixed-exception pass-through, `__cause__`/`__context__` non-traversal, missing/empty `exc_info`, `filter()` always returning `True`, installer idempotency, end-to-end single-line visibility, that importing `server` installs exactly one filter, and a canary asserting the pinned SDK still contains the exact logger name and record message the filter intercepts.
- **Unit suite**: 1234 passed, 0 skipped/xfailed. `ruff check .` and `ruff format --check .` clean.
- **Coverage**: every added line in `logging_utils.py` and `server.py` is covered. Remaining misses in `logging_utils.py` (132-134, 159-161, 168-170) are pre-existing defensive stderr fallbacks in `replace_rich_handlers_with_standard`, outside this diff.
- **Integration tests**: not applicable — no tool, network, or data-transformation code touched; none added or modified.
- **Manual HTTP-mode reproduction**: performed with the plan's deterministic local probe (sentinel + sleep in a tool body, server started with `BLOCKSCOUT_DEV_JSON_RESPONSE=false`, `tools/call` aborted via `curl --max-time 2`). The sentinel appeared before the abort; exactly one single-line `DEBUG` record from `mcp.server.streamable_http_manager` followed; zero `ERROR` records or tracebacks. The probe patch was reverted — it is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Routine client-aborted HTTP sessions now appear as a single debug message instead of noisy error-level tracebacks.
  * Unrelated errors, cancellations, and session tracking behavior remain unchanged.

* **Documentation**
  * Documented the updated startup logging behavior and project structure.

* **Chores**
  * Updated the application version to 0.18.0.dev2.
  * Added coverage to verify logging behavior and server startup integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->