### PR TITLE
Move skill guidance to envelope instructions and slim the unlock payload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,7 +431,7 @@ mcp-server/
             * Tool functions remain `async`, accept a `Context` argument for progress reporting, and use `typing.Annotated`/`pydantic.Field` for argument descriptions.
             * The function docstring provides the description surfaced to FastMCP clients.
             * Example modules:
-                * `initialization/unlock_blockchain_analysis.py`: Implements `__unlock_blockchain_analysis__`, returning `InstructionsData` (`models.py`) with the `blockscout-analysis` skill pointer and the URI resolution rule.
+                * `initialization/unlock_blockchain_analysis.py`: Implements `__unlock_blockchain_analysis__`, the mandatory session-initialization call, returning `InstructionsData` (`models.py`).
                 * `chains/get_chains_list.py`: Implements `get_chains_list`, returning a formatted list of blockchain chains with their IDs.
                 * `ens/get_address_by_ens_name.py`: Implements `get_address_by_ens_name` via the BENS API.
                 * `search/lookup_token_by_symbol.py`: Implements `lookup_token_by_symbol(chain_id, symbol)` with a strict result cap.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,7 +431,7 @@ mcp-server/
             * Tool functions remain `async`, accept a `Context` argument for progress reporting, and use `typing.Annotated`/`pydantic.Field` for argument descriptions.
             * The function docstring provides the description surfaced to FastMCP clients.
             * Example modules:
-                * `initialization/unlock_blockchain_analysis.py`: Implements `__unlock_blockchain_analysis__`. Returns server reference data (version, recommended chains) and the same two-paragraph skill pointer-plus-resolution-rule block that the server emits through its MCP `instructions` field.
+                * `initialization/unlock_blockchain_analysis.py`: Implements `__unlock_blockchain_analysis__`. Returns server/session reference data (model: `InstructionsData` in `models.py`) and the same two-paragraph skill pointer-plus-resolution-rule block that the server emits through its MCP `instructions` field.
                 * `chains/get_chains_list.py`: Implements `get_chains_list`, returning a formatted list of blockchain chains with their IDs.
                 * `ens/get_address_by_ens_name.py`: Implements `get_address_by_ens_name` via the BENS API.
                 * `search/lookup_token_by_symbol.py`: Implements `lookup_token_by_symbol(chain_id, symbol)` with a strict result cap.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,7 +431,7 @@ mcp-server/
             * Tool functions remain `async`, accept a `Context` argument for progress reporting, and use `typing.Annotated`/`pydantic.Field` for argument descriptions.
             * The function docstring provides the description surfaced to FastMCP clients.
             * Example modules:
-                * `initialization/unlock_blockchain_analysis.py`: Implements `__unlock_blockchain_analysis__`. Returns server/session reference data (model: `InstructionsData` in `models.py`) and the same two-paragraph skill pointer-plus-resolution-rule block that the server emits through its MCP `instructions` field.
+                * `initialization/unlock_blockchain_analysis.py`: Implements `__unlock_blockchain_analysis__`, returning `InstructionsData` (`models.py`) with the `blockscout-analysis` skill pointer and the URI resolution rule.
                 * `chains/get_chains_list.py`: Implements `get_chains_list`, returning a formatted list of blockchain chains with their IDs.
                 * `ens/get_address_by_ens_name.py`: Implements `get_address_by_ens_name` via the BENS API.
                 * `search/lookup_token_by_symbol.py`: Implements `lookup_token_by_symbol(chain_id, symbol)` with a strict result cap.

--- a/API.md
+++ b/API.md
@@ -184,7 +184,7 @@ Retrieves a list of all registered MCP resources and their metadata.
 
 #### Unlock Blockchain Analysis (`__unlock_blockchain_analysis__`)
 
-Initializes a Blockscout MCP session: returns server reference data, the `blockscout-analysis` skill pointer, and the URI resolution rule. Call it once per session, before any other tool.
+Initializes a Blockscout MCP session: returns server reference data (`server_version` and, on session-gated deployments, `session_id`) in `data`, with the `blockscout-analysis` skill pointer and the URI resolution rule delivered in the response's `instructions` list. Call it once per session, before any other tool.
 
 `GET /v1/unlock_blockchain_analysis`
 `GET /v1/get_instructions` (legacy)

--- a/SPEC.md
+++ b/SPEC.md
@@ -157,7 +157,7 @@ This architecture provides the flexibility of a multi-protocol server without th
 ### Workflow Description
 
 1. **Instructions Retrieval**:
-   - MCP Host calls `__unlock_blockchain_analysis__` to receive server reference data (version) and a pointer to the `blockscout-analysis` skill, which holds the operating rules and analysis framework.
+   - MCP Host calls `__unlock_blockchain_analysis__` to receive server reference data (server version and, on session-gated deployments, the session identifier) and a pointer to the `blockscout-analysis` skill, which holds the operating rules and analysis framework.
    - MCP Server provides context-specific guidance
 
 2. **ENS Resolution**:
@@ -743,10 +743,10 @@ Earlier iterations packaged the full operational and strategy ruleset inline: er
 
 The resolution is to move operational and strategy rules out of the server entirely and into the `blockscout-analysis` skill, which is the natural home for agent-side methodology: it is consumed equally by MCP- and REST-mode agents, evolves on its own cadence independent of server releases, and is reviewed alongside the rest of the skill content.
 
-What the server now sends through both `composed_instructions` (the MCP `instructions=` string) and the `__unlock_blockchain_analysis__` payload is intentionally minimal — operational guidance, including default-chain resolution (e.g. Ethereum Mainnet = `chain_id` `1`), now lives in the `blockscout-analysis` skill and in the relevant tool descriptions rather than here:
+What the server now sends through both `composed_instructions` (the MCP `instructions=` string) and the `__unlock_blockchain_analysis__` response is intentionally minimal — operational guidance, including default-chain resolution (e.g. Ethereum Mainnet = `chain_id` `1`), now lives in the `blockscout-analysis` skill and in the relevant tool descriptions rather than here:
 
-1. The server version.
-2. A two-paragraph block: a pointer at the `blockscout-analysis` skill (with the verifiable "use the copy already loaded; otherwise fetch from `blockscout-mcp://skill/SKILL.md` over MCP or `GET /skill/SKILL.md` over HTTP" condition) followed by the URI-resolution rule for navigating from the entry point into reference files. The pointer also advertises the bundled skill's version — sourced from `metadata.version` in the bundled `SKILL.md` frontmatter and carried inline within the pointer text rather than as a separate structured field — and this is the surface an agent uses to decide whether an already-loaded copy matches the server's bundled copy before reusing it (when the version cannot be determined the pointer is served without it, otherwise unchanged). The exact same text, including the version annotation, is emitted from both surfaces so clients that consume only one of them are not at a disadvantage. See the `### Bundled blockscout-analysis Skill - Resources and HTTP Mirror` section for the addressable space the pointer refers to.
+1. The server version and, on session-gated deployments, the freshly minted session identifier. The version field is named `server_version` (a bare `version` beside a session identifier is ambiguous — the server's, the session's, or the skill's?) and the identifier is declared first: issue #450 traced agents overlooking the identifier to its position behind multi-sentence prose. For the same reason, the gated human-readable summary states the issued identifier's literal value instead of only pointing at the payload.
+2. A two-paragraph block: a pointer at the `blockscout-analysis` skill (with the verifiable "use the copy already loaded; otherwise fetch from `blockscout-mcp://skill/SKILL.md` over MCP or `GET /skill/SKILL.md` over HTTP" condition) followed by the URI-resolution rule for navigating from the entry point into reference files. The pointer also advertises the bundled skill's version — sourced from `metadata.version` in the bundled `SKILL.md` frontmatter and carried inline within the pointer text rather than as a separate structured field — and this is the surface an agent uses to decide whether an already-loaded copy matches the server's bundled copy before reusing it (when the version cannot be determined the pointer is served without it, otherwise unchanged). The exact same text, including the version annotation, is emitted from both surfaces so clients that consume only one of them are not at a disadvantage. In the tool response this block rides the envelope's `instructions` list rather than the `data` payload — the paragraphs are directives addressed to the agent, which is exactly what that field models, and moving them out of `data` lets the identifier lead the payload; the verbatim-equivalence invariant concerns text identity and is independent of the carrying field. See the `### Bundled blockscout-analysis Skill - Resources and HTTP Mirror` section for the addressable space the pointer refers to.
 
 `__unlock_blockchain_analysis__` remains the mandatory first call: its role as the structural-guidance anchor for clients that do not reliably consume the MCP `instructions=` field is unchanged. On deployments with session gating enabled (see the `### Session-Gated Free Tier` section), this is no longer only a narrative: a `session_id` issued by this tool is a functional precondition for every other tool, so enforcement has replaced persuasion there. Ungated deployments continue to rely on the structural-guidance narrative alone.
 
@@ -783,7 +783,7 @@ Resource annotations are used purposefully:
 
 #### Resolution Rule
 
-`SKILL.md` mentions reference files in prose, such as `references/blockscout-api-index.md`. The corresponding resource URI is `blockscout-mcp://skill/` plus that path, and the HTTP equivalent is `GET /skill/` plus that path. Both the MCP `instructions` field and the `__unlock_blockchain_analysis__` payload carry this rule verbatim.
+`SKILL.md` mentions reference files in prose, such as `references/blockscout-api-index.md`. The corresponding resource URI is `blockscout-mcp://skill/` plus that path, and the HTTP equivalent is `GET /skill/` plus that path. Both the MCP `instructions` field and the `instructions` list of the `__unlock_blockchain_analysis__` response envelope carry this rule verbatim.
 
 #### Key Design Decisions
 

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.19.0.dev1"
+__version__ = "0.18.1"

--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0.dev1"

--- a/blockscout_mcp_server/models.py
+++ b/blockscout_mcp_server/models.py
@@ -148,23 +148,12 @@ class DirectApiData(BaseModel):
 class InstructionsData(BaseModel):
     """A structured representation of the server's session-initialization payload.
 
-    Carries server-side reference data (version), a pointer at the
-    `blockscout-analysis` skill, and the rule for resolving its reference paths.
+    Carries session-scoped reference scalars: the session identifier (on gated
+    deployments) and the server version. The skill pointer and its reference-path
+    resolution rule are delivered via the response envelope's `instructions` list
+    instead of this model.
     """
 
-    version: str = Field(description="The version of the Blockscout MCP server.")
-    skill_reference: str = Field(
-        description=(
-            "Canonical pointer text for the `blockscout-analysis` skill. Intentionally identical "
-            "to the matching paragraph inside the server's `composed_instructions`."
-        )
-    )
-    skill_resolution_rule: str = Field(
-        description=(
-            "Canonical rule for resolving reference paths mentioned by the skill. Intentionally "
-            "identical to the matching paragraph inside the server's `composed_instructions`."
-        )
-    )
     # Deliberately mirrors `SESSION_ID_PARAM_DESCRIPTION` verbatim: this description is
     # serialized into the unlock tool's `outputSchema` and therefore reaches every MCP
     # client on every deployment, so it must name no source and no condition. The
@@ -174,6 +163,7 @@ class InstructionsData(BaseModel):
         default=None,
         description="Opaque session identifier.",
     )
+    server_version: str = Field(description="The version of the Blockscout MCP server.")
 
     @model_serializer(mode="wrap")
     def _serialize_omitting_unset_session_id(self, handler: Any) -> dict[str, Any]:

--- a/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
+++ b/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
@@ -60,10 +60,10 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
         instructions_data.session_id = mint_token()
         content_text = (
             f"Session initialized (server v{SERVER_VERSION}). Consult the `blockscout-analysis` skill "
-            "referenced in the payload before invoking any other tool. Your `session_id` is in the "
-            "payload — pass it with every subsequent tool call. A session is this entire conversation, "
-            "including all tool loops and sub-agents; reconnections and context compaction do not start "
-            "a new one. Do not initialize this session again."
+            "referenced in the payload before invoking any other tool. Your `session_id` is "
+            f"`{instructions_data.session_id}` — pass it with every subsequent tool call. A session is "
+            "this entire conversation, including all tool loops and sub-agents; reconnections and "
+            "context compaction do not start a new one. Do not initialize this session again."
         )
 
     # Report completion

--- a/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
+++ b/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
@@ -51,7 +51,7 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
 
     content_text = (
         f"Session initialized (server v{SERVER_VERSION}). "
-        "Consult the `blockscout-analysis` skill referenced in the payload before invoking any other tool."
+        "Consult the `blockscout-analysis` skill referenced in the response before invoking any other tool."
     )
 
     if gate_enabled():
@@ -60,7 +60,7 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
         instructions_data.session_id = mint_token()
         content_text = (
             f"Session initialized (server v{SERVER_VERSION}). Consult the `blockscout-analysis` skill "
-            "referenced in the payload before invoking any other tool. Your `session_id` is "
+            "referenced in the response before invoking any other tool. Your `session_id` is "
             f"`{instructions_data.session_id}` — pass it with every subsequent tool call. A session is "
             "this entire conversation, including all tool loops and sub-agents; reconnections and "
             "context compaction do not start a new one. Do not initialize this session again."

--- a/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
+++ b/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
@@ -33,6 +33,12 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
     # receive a `session_id`. It therefore says nothing about the identifier; the
     # gated branch of `content_text` below carries that instruction to the only
     # callers it applies to.
+    #
+    # The skill pointer and the resolution rule are directives, so they ride the
+    # envelope's `instructions` slot below rather than the `data` payload. They remain
+    # byte-identical to the matching paragraphs of `composed_instructions`
+    # (`blockscout_mcp_server/server.py`) — that identity is a tested invariant, not a
+    # coincidence.
     # Report start of operation
     await report_and_log_progress(
         ctx,
@@ -74,5 +80,9 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
 
     return build_tool_response(
         data=instructions_data,
+        instructions=[
+            skill_resources.skill_pointer_text(),
+            SKILL_RESOLUTION_RULE_TEXT,
+        ],
         content_text=content_text,
     )

--- a/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
+++ b/blockscout_mcp_server/tools/initialization/unlock_blockchain_analysis.py
@@ -47,11 +47,7 @@ async def __unlock_blockchain_analysis__(ctx: Context) -> ToolResponse[Instructi
         message="Fetching server instructions...",
     )
 
-    instructions_data = InstructionsData(
-        version=SERVER_VERSION,
-        skill_reference=skill_resources.skill_pointer_text(),
-        skill_resolution_rule=SKILL_RESOLUTION_RULE_TEXT,
-    )
+    instructions_data = InstructionsData(server_version=SERVER_VERSION)
 
     content_text = (
         f"Session initialized (server v{SERVER_VERSION}). "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.19.0.dev1"
+version = "0.18.1"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.18.0"
+version = "0.19.0.dev1"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.18.0",
+  "version": "0.19.0.dev1",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.19.0.dev1",
+  "version": "0.18.1",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",

--- a/tests/api/test_routes_session_gate_e2e.py
+++ b/tests/api/test_routes_session_gate_e2e.py
@@ -25,7 +25,12 @@ from mcp.server.fastmcp import FastMCP
 
 from blockscout_mcp_server.api.routes import register_api_routes
 from blockscout_mcp_server.config import config
-from blockscout_mcp_server.constants import SESSION_ID_REQUIRED_MESSAGE, SESSION_OVER_MESSAGE
+from blockscout_mcp_server.constants import (
+    SESSION_ID_REQUIRED_MESSAGE,
+    SESSION_OVER_MESSAGE,
+    SKILL_RESOLUTION_RULE_TEXT,
+)
+from blockscout_mcp_server.resources import skill_resources
 from blockscout_mcp_server.session_gate import get_store, mint_token, verify_token
 from blockscout_mcp_server.tools.block.get_block_number import get_block_number
 from blockscout_mcp_server.tools.common import chains_list_cache
@@ -134,6 +139,7 @@ async def test_unlock_endpoint_gated_returns_session_id(rest_client):
     payload = response.json()
     assert "session_id" in payload["data"]
     assert payload["data"]["session_id"]
+    assert list(payload["data"].keys()) == ["session_id", "server_version"]
 
 
 @pytest.mark.asyncio
@@ -148,6 +154,11 @@ async def test_unlock_endpoint_ungated_omits_session_id(monkeypatch):
     assert response.status_code == 200
     payload = response.json()
     assert "session_id" not in payload["data"]
+    assert list(payload["data"].keys()) == ["server_version"]
+    assert payload["instructions"] == [
+        skill_resources.skill_pointer_text(),
+        SKILL_RESOLUTION_RULE_TEXT,
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_instructions_data.py
+++ b/tests/test_instructions_data.py
@@ -1,56 +1,30 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Tests for the slim `InstructionsData` model returned by `__unlock_blockchain_analysis__`."""
 
-from blockscout_mcp_server.constants import SKILL_RESOLUTION_RULE_TEXT
 from blockscout_mcp_server.models import InstructionsData
-from blockscout_mcp_server.resources import skill_resources
 
 
-def test_instructions_data_constructs_with_three_fields():
-    """InstructionsData accepts and exposes its three surviving fields."""
-    instructions = InstructionsData(
-        version="9.9.9",
-        skill_reference="See the blockscout-analysis skill.",
-        skill_resolution_rule="Resolve references through the server.",
-    )
+def test_instructions_data_constructs_with_server_version_only():
+    """Constructing with only `server_version` exposes that value and leaves `session_id` as `None`."""
+    instructions = InstructionsData(server_version="9.9.9")
 
-    assert instructions.version == "9.9.9"
-    assert instructions.skill_reference == "See the blockscout-analysis skill."
-    assert instructions.skill_resolution_rule == "Resolve references through the server."
+    assert instructions.server_version == "9.9.9"
+    assert instructions.session_id is None
 
 
-def test_instructions_data_field_set_is_exactly_four():
+def test_instructions_data_field_set_is_exactly_two():
     """Regression guard: any future field re-introduction must be deliberate.
 
-    Phase 6 (issue #442) adds `session_id` to the surviving three fields, moving the
-    exact-field-set contract from three to four.
+    The model carries exactly two reference scalars: `session_id` and `server_version`.
+    The skill pointer and its reference-path resolution rule are delivered via the
+    response envelope's `instructions` list instead (see issue #450).
     """
-    assert set(InstructionsData.model_fields.keys()) == {
-        "version",
-        "skill_reference",
-        "skill_resolution_rule",
-        "session_id",
-    }
-
-
-def test_instructions_data_session_id_defaults_to_none():
-    """Constructing without `session_id` leaves it `None`."""
-    instructions = InstructionsData(
-        version="1.0.0",
-        skill_reference="pointer",
-        skill_resolution_rule=SKILL_RESOLUTION_RULE_TEXT,
-    )
-
-    assert instructions.session_id is None
+    assert set(InstructionsData.model_fields.keys()) == {"session_id", "server_version"}
 
 
 def test_instructions_data_serialization_omits_session_id_when_none():
     """Serialization must omit the `session_id` key entirely when unset, not emit `null`."""
-    instructions = InstructionsData(
-        version="1.0.0",
-        skill_reference="pointer",
-        skill_resolution_rule=SKILL_RESOLUTION_RULE_TEXT,
-    )
+    instructions = InstructionsData(server_version="1.0.0")
 
     dumped = instructions.model_dump(mode="json", by_alias=True)
 
@@ -59,36 +33,21 @@ def test_instructions_data_serialization_omits_session_id_when_none():
 
 def test_instructions_data_serialization_includes_session_id_when_set():
     """Serialization must include the `session_id` key with its value when set."""
-    instructions = InstructionsData(
-        version="1.0.0",
-        skill_reference="pointer",
-        skill_resolution_rule=SKILL_RESOLUTION_RULE_TEXT,
-        session_id="abc.123.def",
-    )
+    instructions = InstructionsData(server_version="1.0.0", session_id="abc.123.def")
 
     dumped = instructions.model_dump(mode="json", by_alias=True)
 
     assert dumped["session_id"] == "abc.123.def"
 
 
-def test_skill_reference_matches_rendered_pointer_when_populated_from_it():
-    """When sourced from skill_pointer_text(), `skill_reference` equals the rendered pointer verbatim."""
-    rendered_pointer = skill_resources.skill_pointer_text()
-    instructions = InstructionsData(
-        version="1.0.0",
-        skill_reference=rendered_pointer,
-        skill_resolution_rule=SKILL_RESOLUTION_RULE_TEXT,
-    )
+def test_instructions_data_session_id_is_first_key_when_set():
+    """When `session_id` is set, it is the first key of the serialized dict.
 
-    assert instructions.skill_reference == rendered_pointer
-    assert instructions.skill_resolution_rule == SKILL_RESOLUTION_RULE_TEXT
+    The ordering is a stated goal of issue #450: agents reliably overlook a
+    trailing scalar, so `session_id` must lead the serialized payload.
+    """
+    instructions = InstructionsData(server_version="1.0.0", session_id="abc.123.def")
 
+    dumped = instructions.model_dump(mode="json", by_alias=True)
 
-def test_skill_resolution_rule_round_trips_in_serialization():
-    instructions = InstructionsData(
-        version="1.0.0",
-        skill_reference="pointer",
-        skill_resolution_rule=SKILL_RESOLUTION_RULE_TEXT,
-    )
-
-    assert instructions.model_dump()["skill_resolution_rule"] == SKILL_RESOLUTION_RULE_TEXT
+    assert list(dumped.keys())[0] == "session_id"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,14 +38,9 @@ def test_tool_response_simple_data():
 
 def test_tool_response_complex_data():
     """Test ToolResponse with a nested Pydantic model as data."""
-    instructions_data = InstructionsData(
-        version="1.0.0",
-        skill_reference="pointer",
-        skill_resolution_rule="rule",
-    )
+    instructions_data = InstructionsData(server_version="1.0.0")
     response = ToolResponse[InstructionsData](data=instructions_data)
-    assert response.data.version == "1.0.0"
-    assert response.data.skill_reference == "pointer"
+    assert response.data.server_version == "1.0.0"
 
 
 def test_tool_response_with_all_fields():

--- a/tests/test_session_gate_http_transport.py
+++ b/tests/test_session_gate_http_transport.py
@@ -279,6 +279,40 @@ def test_unlock_serialization_gated_includes_verifiable_session_id(tmp_path, mon
             client.portal.call(close_store)
 
 
+def test_unlock_serialization_gated_summary_client_states_literal_session_id(tmp_path, monkeypatch):
+    """Gated deployment, summary-content client (the real unlock tool, over the real
+    transport): the minted `structuredContent.data.session_id` appears literally in
+    `content[0].text` — the issue's headline scenario. The generic wrapper tests in
+    `tests/test_server_structured_output.py` prove the summary-routing mechanism with
+    dummy responses only; this proves the real tool's gated content_text composes with
+    it end-to-end."""
+    db_path = tmp_path / "unlock-summary-sessions.db"
+    monkeypatch.setattr(server_config, "session_secret", "test-session-secret")
+    monkeypatch.setattr(server_config, "session_db_path", str(db_path))
+
+    app = _build_unlock_app(gated=True)
+    with TestClient(app) as client:
+        client.portal.call(initialize_store, str(db_path))
+        try:
+            body = _build_tools_call_body("__unlock_blockchain_analysis__")
+            body["params"]["_meta"] = {"openai/userAgent": "ChatGPT/1.0"}
+            response = client.post(
+                "/mcp",
+                json=body,
+                headers=_MCP_HEADERS,
+            )
+
+            assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
+            result = _extract_result(response.text)
+            assert result.get("isError") is not True
+            session_id = result["structuredContent"]["data"]["session_id"]
+            assert session_id
+            assert session_id in result["content"][0]["text"]
+            verify_token(session_id)
+        finally:
+            client.portal.call(close_store)
+
+
 def test_unlock_serialization_ungated_has_no_session_id_key():
     """Ungated deployment: structuredContent.data has no session_id key at all."""
     app = _build_unlock_app(gated=False)

--- a/tests/test_session_gate_http_transport.py
+++ b/tests/test_session_gate_http_transport.py
@@ -29,9 +29,14 @@ from starlette.testclient import TestClient
 
 from blockscout_mcp_server import analytics
 from blockscout_mcp_server.config import config as server_config
-from blockscout_mcp_server.constants import SESSION_BUDGET_NOTE_TEMPLATE, SESSION_ID_REQUIRED_MESSAGE
+from blockscout_mcp_server.constants import (
+    SESSION_BUDGET_NOTE_TEMPLATE,
+    SESSION_ID_REQUIRED_MESSAGE,
+    SKILL_RESOLUTION_RULE_TEXT,
+)
 from blockscout_mcp_server.models import ToolResponse
 from blockscout_mcp_server.pro_api_key_context import pro_api_key_scope
+from blockscout_mcp_server.resources import skill_resources
 from blockscout_mcp_server.server import _wrap_tool_for_structured_output
 from blockscout_mcp_server.session_gate import mint_token, session_gate, verify_token
 from blockscout_mcp_server.session_store import close_store, initialize_store
@@ -259,8 +264,13 @@ def test_unlock_serialization_gated_includes_verifiable_session_id(tmp_path, mon
             assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
             result = _extract_result(response.text)
             assert result.get("isError") is not True
-            session_id = result["structuredContent"]["data"]["session_id"]
+            data = result["structuredContent"]["data"]
+            session_id = data["session_id"]
             assert session_id
+            # Key order is a stated goal of issue #450: session_id must lead the serialized
+            # payload, proving the model's declaration order survives model_dump and the
+            # transport's JSON round-trip.
+            assert list(data.keys()) == ["session_id", "server_version"]
             # verify_token is store-I/O-free (only reads the in-memory `generation` attribute set
             # by `initialize_store` above), so it is safe to call on the pytest thread — but it
             # must run before `close_store` tears down the module-level singleton it reads from.
@@ -282,7 +292,11 @@ def test_unlock_serialization_ungated_has_no_session_id_key():
     assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
     result = _extract_result(response.text)
     assert result.get("isError") is not True
-    assert "session_id" not in result["structuredContent"]["data"]
+    assert list(result["structuredContent"]["data"].keys()) == ["server_version"]
+    assert result["structuredContent"]["instructions"] == [
+        skill_resources.skill_pointer_text(),
+        SKILL_RESOLUTION_RULE_TEXT,
+    ]
 
 
 def test_exempt_call_carries_no_budget_note(gated_app):

--- a/tests/tools/initialization/test___unlock_blockchain_analysis__.py
+++ b/tests/tools/initialization/test___unlock_blockchain_analysis__.py
@@ -37,9 +37,7 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
         assert isinstance(result, ToolResponse)
         assert isinstance(result.data, InstructionsData)
 
-        assert result.data.version == mock_version
-        assert result.data.skill_reference == mock_pointer
-        assert result.data.skill_resolution_rule == mock_resolution_rule
+        assert result.data.server_version == mock_version
         assert result.instructions == [mock_pointer, mock_resolution_rule]
 
         assert mock_ctx.report_progress.call_count == 2
@@ -100,7 +98,7 @@ async def test_gated_session_id_is_minted_and_no_store_row_written(enabled_sessi
     assert row is None
 
     expected_content_text = (
-        f"Session initialized (server v{result.data.version}). Consult the `blockscout-analysis` skill "
+        f"Session initialized (server v{result.data.server_version}). Consult the `blockscout-analysis` skill "
         "referenced in the payload before invoking any other tool. Your `session_id` is in the "
         "payload — pass it with every subsequent tool call. A session is this entire conversation, "
         "including all tool loops and sub-agents; reconnections and context compaction do not start "

--- a/tests/tools/initialization/test___unlock_blockchain_analysis__.py
+++ b/tests/tools/initialization/test___unlock_blockchain_analysis__.py
@@ -65,7 +65,7 @@ async def test_unlock_payload_skill_text_matches_server_instructions(mock_ctx):
 
 
 _UNGATED_CONTENT_TEXT = (
-    "Consult the `blockscout-analysis` skill referenced in the payload before invoking any other tool."
+    "Consult the `blockscout-analysis` skill referenced in the response before invoking any other tool."
 )
 
 
@@ -99,7 +99,7 @@ async def test_gated_session_id_is_minted_and_no_store_row_written(enabled_sessi
 
     expected_content_text = (
         f"Session initialized (server v{result.data.server_version}). Consult the `blockscout-analysis` skill "
-        "referenced in the payload before invoking any other tool. Your `session_id` is "
+        "referenced in the response before invoking any other tool. Your `session_id` is "
         f"`{result.data.session_id}` — pass it with every subsequent tool call. A session is this entire "
         "conversation, including all tool loops and sub-agents; reconnections and context compaction do "
         "not start a new one. Do not initialize this session again."

--- a/tests/tools/initialization/test___unlock_blockchain_analysis__.py
+++ b/tests/tools/initialization/test___unlock_blockchain_analysis__.py
@@ -40,6 +40,7 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
         assert result.data.version == mock_version
         assert result.data.skill_reference == mock_pointer
         assert result.data.skill_resolution_rule == mock_resolution_rule
+        assert result.instructions == [mock_pointer, mock_resolution_rule]
 
         assert mock_ctx.report_progress.call_count == 2
         assert mock_ctx.info.call_count == 2
@@ -57,9 +58,12 @@ async def test_unlock_blockchain_analysis_success(mock_ctx):
 async def test_unlock_payload_skill_text_matches_server_instructions(mock_ctx):
     result = await __unlock_blockchain_analysis__(ctx=mock_ctx)
 
-    assert result.data.skill_reference == skill_resources.skill_pointer_text()
-    assert result.data.skill_resolution_rule == SKILL_RESOLUTION_RULE_TEXT
-    assert f"{result.data.skill_reference}\n\n{result.data.skill_resolution_rule}" in composed_instructions
+    assert result.instructions == [
+        skill_resources.skill_pointer_text(),
+        SKILL_RESOLUTION_RULE_TEXT,
+    ]
+    pointer_text, resolution_rule_text = result.instructions
+    assert f"{pointer_text}\n\n{resolution_rule_text}" in composed_instructions
 
 
 _UNGATED_CONTENT_TEXT = (

--- a/tests/tools/initialization/test___unlock_blockchain_analysis__.py
+++ b/tests/tools/initialization/test___unlock_blockchain_analysis__.py
@@ -99,12 +99,13 @@ async def test_gated_session_id_is_minted_and_no_store_row_written(enabled_sessi
 
     expected_content_text = (
         f"Session initialized (server v{result.data.server_version}). Consult the `blockscout-analysis` skill "
-        "referenced in the payload before invoking any other tool. Your `session_id` is in the "
-        "payload — pass it with every subsequent tool call. A session is this entire conversation, "
-        "including all tool loops and sub-agents; reconnections and context compaction do not start "
-        "a new one. Do not initialize this session again."
+        "referenced in the payload before invoking any other tool. Your `session_id` is "
+        f"`{result.data.session_id}` — pass it with every subsequent tool call. A session is this entire "
+        "conversation, including all tool loops and sub-agents; reconnections and context compaction do "
+        "not start a new one. Do not initialize this session again."
     )
     assert result.content_text == expected_content_text
+    assert result.data.session_id in result.content_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

Reworks the `__unlock_blockchain_analysis__` response envelope so the two skill-guidance paragraphs travel as **envelope instructions** rather than as `data` fields, and slims the `data` payload accordingly.

- **Skill texts via `instructions`** — the skill-pointer text and the skill-resolution rule are now passed to `build_tool_response(instructions=[...])`, byte-identical to their counterparts in the server's `composed_instructions`.
- **Slim `InstructionsData`** — the model is reduced to two fields: `session_id` (first, so it leads the serialized `data` keys) and `server_version` (renamed from `version`). The `skill_reference` and `skill_resolution_rule` fields are removed.
- **Literal `session_id` in the gated summary** — the gated `content_text` now interpolates the minted `session_id` into its wording, so summary-only clients (e.g. ChatGPT) see the id in the text rather than only in `structuredContent`.
- **Summary wording** — both `content_text` branches now say the skill is "referenced in the response" (previously "in the payload"), since the pointer no longer travels in the `data` payload.
- **Docs** — SPEC.md (3 spots), AGENTS.md, and API.md updated to describe the new envelope shape.
- **Version** — bumped to `0.18.1` in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json`. This fixes a bug present in the shipped `0.18.0` release, so it ships as a patch now rather than as a `0.19.0.dev1` prerelease deferred to the next minor.

## Why

Guidance prose belongs in the envelope's `instructions` channel, not in the structured `data` payload. Keeping it in `data` duplicated content that clients already receive through the envelope contract and made the payload larger than it needed to be. Putting the `session_id` literally in the gated summary text also fixes a real gap for clients that only render `content`, not `structuredContent`.

## Verification

- `pytest` — **1267 passed**, 92 integration deselected; **0 skipped, 0 xfailed**.
- Integration suite via the timeout-protected runner (`scripts/run_integration_tests.py tests/integration/`) — **92 passed, 0 failed, 0 skipped, 0 timed out** in 273s. Mandatory here because an MCP tool function changed; no unlock-specific integration tests exist, so this run guards against regressions elsewhere.
- `ruff check .` clean; `ruff format --check .` — 236 files already formatted.
- **Started-server HTTP validation** — ran with `--http --rest` and a session secret configured, then exercised both surfaces:
  - MCP `tools/call` on `/mcp`: `data` keys are `['session_id', 'server_version']`, `instructions` carries exactly the two skill paragraphs, `server_version = 0.18.1`, and the minted `session_id` appears literally in `content[0].text`.
  - REST `GET /v1/unlock_blockchain_analysis`: same key order and `instructions`, with `skill_reference` / `skill_resolution_rule` absent from `data`.

## Notes for reviewers

- The two paragraphs are asserted to be substrings of the server's `composed_instructions`, so the wording cannot drift between the two delivery paths without a test failure.
- `session_id` ordering is load-bearing (it must lead the `data` keys) and is now covered by explicit first-key assertions in both the HTTP-transport and REST e2e tests.
- `mcpb/manifest.json` is intentionally untouched — it carries its own independent version.

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unlock responses now include the server version and, where applicable, a session identifier.
  * Skill guidance is provided through response instructions, with clearer URI-resolution details.
  * Gated session responses display the session identifier directly for easier use.

* **Documentation**
  * Updated API and workflow documentation to reflect the revised unlock response format.

* **Chores**
  * Updated the application version to 0.18.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->