### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blockscout MCP Server
 
-[![smithery badge](https://smithery.ai/badge/@blockscout/mcp-server)](https://smithery.ai/server/@blockscout/mcp-server)
+[![LightNow](https://lightnow.ai/badge/com.blockscout/mcp-server)](https://lightnow.ai/servers/com.blockscout/mcp-server)
 
 <a href="https://glama.ai/mcp/servers/@blockscout/mcp-server">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@blockscout/mcp-server/badge" alt="Blockscout Server MCP server" />


### PR DESCRIPTION
## Summary

Replaces the broken Smithery badge with the matching LightNow capability badge.

- Server: https://lightnow.ai/servers/com.blockscout/mcp-server
- Badge docs and variants: https://docs.lightnow.ai/how-to/add-capability-badge/

## Validation

- Verified the badge SVG and server page return successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README header badge from Smithery to LightNow.
  - Updated the badge image and destination link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->