### PR TITLE
Bump server version to 0.19.0

### DIFF
--- a/blockscout_mcp_server/__init__.py
+++ b/blockscout_mcp_server/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 """Blockscout MCP Server package."""
 
-__version__ = "0.19.0.dev0"
+__version__ = "0.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockscout-mcp-server"
-version = "0.19.0.dev0"
+version = "0.19.0"
 description = "MCP server for Blockscout"
 requires-python = ">=3.11"
 dependencies = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.blockscout/mcp-server",
   "description": "MCP server for Blockscout",
-  "version": "0.19.0.dev0",
+  "version": "0.19.0",
   "websiteUrl": "https://blockscout.com",
   "repository": {
     "url": "https://github.com/blockscout/mcp-server",


### PR DESCRIPTION
## Summary
- Bump server version to 0.19.0 in `pyproject.toml`, `blockscout_mcp_server/__init__.py`, and `server.json` per `.cursor/rules/130-version-management.mdc`.

## Test plan
- [x] Verified all three version locations match

@coderabbitai ignore